### PR TITLE
Add codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @jakemalachowski @mdbenjam


### PR DESCRIPTION
Starting with the folks on the Capabilities team who have been working on the provider and will own changes going forward. We will likely expand the set of owners to more of the team over time, but I just want to get this file in place for now.  I can't add Max until he accepts the invite to the repo.