### PR TITLE
Increase the lint timeout

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -42,6 +42,6 @@ jobs:
       - name: vet
         run: go vet ./...
       - name: lint
-        run: golangci-lint run
+        run: golangci-lint run --timeout 10m
         env:
           GIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}


### PR DESCRIPTION
Lint checks are flaking due to timeouts. This increases the timeout to 10 minutes.