### PR TITLE
upgrade go to 1.22.5

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22.2'
+          go-version: '1.22.5'
       - name: Run tests
         run: TF_ACC=1 go test ./...
 

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -49,7 +49,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.21.8'
+        go-version: '1.22.5'
     - name: Update and Install file
       run: |
         sudo apt-get update

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module terraform-provider-render
 
-go 1.21
+go 1.22.5
 
 require (
 	github.com/bradleyjkemp/cupaloy v2.3.0+incompatible


### PR DESCRIPTION
- CodeQL requires the go version in go mod to match `x.y.z` rather than `x.y` this fixes that and upgrades our go version in the process