### PR TITLE
Compare environmentID values when checking if an environment update is required

### DIFF
--- a/internal/provider/common/client.go
+++ b/internal/provider/common/client.go
@@ -732,7 +732,7 @@ func UpdateEnvironmentID(ctx context.Context, apiClient *client.ClientWithRespon
 
 	state := envIDStateAndPlan.State
 	plan := envIDStateAndPlan.Plan
-	if state == plan {
+	if ValueOrDefault(state, "") == ValueOrDefault(plan, "") {
 		// doesn't matter which one we return
 		return state, nil
 	}

--- a/internal/provider/common/pointers.go
+++ b/internal/provider/common/pointers.go
@@ -18,3 +18,10 @@ func EmptyStringIfNil(s *string) *string {
 	}
 	return s
 }
+
+func ValueOrDefault[T any](v *T, def T) T {
+	if v == nil {
+		return def
+	}
+	return *v
+}


### PR DESCRIPTION
We are currently comparing pointers, so this condition always returns false and we attempt to perform a no-op environment update. This updates the check to compare the values instead.

Fixes https://github.com/render-oss/terraform-provider-render/issues/10