### PR TITLE
Use dedicated fields for image tags and digests instead of including them in the image URL

### DIFF
--- a/docs/data-sources/background_worker.md
+++ b/docs/data-sources/background_worker.md
@@ -144,6 +144,11 @@ Read-Only:
 <a id="nestedatt--runtime_source--image"></a>
 ### Nested Schema for `runtime_source.image`
 
+Optional:
+
+- `digest` (String) Digest of the Docker image to deploy. Mutually exclusive with tag.
+- `tag` (String) Tag of the Docker image to deploy. Mutually exclusive with digest.
+
 Read-Only:
 
 - `image_url` (String) URL of the Docker image to deploy.

--- a/docs/data-sources/cron_job.md
+++ b/docs/data-sources/cron_job.md
@@ -87,6 +87,11 @@ Read-Only:
 <a id="nestedatt--runtime_source--image"></a>
 ### Nested Schema for `runtime_source.image`
 
+Optional:
+
+- `digest` (String) Digest of the Docker image to deploy. Mutually exclusive with tag.
+- `tag` (String) Tag of the Docker image to deploy. Mutually exclusive with digest.
+
 Read-Only:
 
 - `image_url` (String) URL of the Docker image to deploy.

--- a/docs/data-sources/private_service.md
+++ b/docs/data-sources/private_service.md
@@ -145,6 +145,11 @@ Read-Only:
 <a id="nestedatt--runtime_source--image"></a>
 ### Nested Schema for `runtime_source.image`
 
+Optional:
+
+- `digest` (String) Digest of the Docker image to deploy. Mutually exclusive with tag.
+- `tag` (String) Tag of the Docker image to deploy. Mutually exclusive with digest.
+
 Read-Only:
 
 - `image_url` (String) URL of the Docker image to deploy.

--- a/docs/data-sources/web_service.md
+++ b/docs/data-sources/web_service.md
@@ -165,6 +165,11 @@ Read-Only:
 <a id="nestedatt--runtime_source--image"></a>
 ### Nested Schema for `runtime_source.image`
 
+Optional:
+
+- `digest` (String) Digest of the Docker image to deploy. Mutually exclusive with tag.
+- `tag` (String) Tag of the Docker image to deploy. Mutually exclusive with digest.
+
 Read-Only:
 
 - `image_url` (String) URL of the Docker image to deploy.

--- a/docs/resources/background_worker.md
+++ b/docs/resources/background_worker.md
@@ -150,7 +150,9 @@ Required:
 
 Optional:
 
+- `digest` (String) Digest of the Docker image to deploy. Mutually exclusive with tag.
 - `registry_credential_id` (String) ID of the registry credential to use when pulling the image.
+- `tag` (String) Tag of the Docker image to deploy. Mutually exclusive with digest.
 
 
 <a id="nestedatt--runtime_source--native_runtime"></a>

--- a/docs/resources/cron_job.md
+++ b/docs/resources/cron_job.md
@@ -112,7 +112,9 @@ Required:
 
 Optional:
 
+- `digest` (String) Digest of the Docker image to deploy. Mutually exclusive with tag.
 - `registry_credential_id` (String) ID of the registry credential to use when pulling the image.
+- `tag` (String) Tag of the Docker image to deploy. Mutually exclusive with digest.
 
 
 <a id="nestedatt--runtime_source--native_runtime"></a>

--- a/docs/resources/env_group_link.md
+++ b/docs/resources/env_group_link.md
@@ -19,7 +19,10 @@ resource "render_web_service" "web" {
   region  = "ohio"
   runtime = "image"
   deploy_configuration = {
-    image = { image_url = "docker.io/library/nginx:latest" }
+    image = {
+      image_url = "docker.io/library/nginx",
+      tag       = "latest",
+    }
   }
 }
 

--- a/docs/resources/private_service.md
+++ b/docs/resources/private_service.md
@@ -147,7 +147,9 @@ Required:
 
 Optional:
 
+- `digest` (String) Digest of the Docker image to deploy. Mutually exclusive with tag.
 - `registry_credential_id` (String) ID of the registry credential to use when pulling the image.
+- `tag` (String) Tag of the Docker image to deploy. Mutually exclusive with digest.
 
 
 <a id="nestedatt--runtime_source--native_runtime"></a>

--- a/docs/resources/web_service.md
+++ b/docs/resources/web_service.md
@@ -137,7 +137,9 @@ Required:
 
 Optional:
 
+- `digest` (String) Digest of the Docker image to deploy. Mutually exclusive with tag.
 - `registry_credential_id` (String) ID of the registry credential to use when pulling the image.
+- `tag` (String) Tag of the Docker image to deploy. Mutually exclusive with digest.
 
 
 <a id="nestedatt--runtime_source--native_runtime"></a>

--- a/examples/resources/render_env_group_link/resource.tf
+++ b/examples/resources/render_env_group_link/resource.tf
@@ -4,7 +4,10 @@ resource "render_web_service" "web" {
   region  = "ohio"
   runtime = "image"
   deploy_configuration = {
-    image = { image_url = "docker.io/library/nginx:latest" }
+    image = {
+      image_url = "docker.io/library/nginx",
+      tag       = "latest",
+    }
   }
 }
 

--- a/internal/provider/backgroundworker/resource/internal/update.go
+++ b/internal/provider/backgroundworker/resource/internal/update.go
@@ -39,9 +39,15 @@ func UpdateServiceRequestFromModel(plan backgroundWorker.BackgroundWorkerModel, 
 
 	var image *client.Image
 	if plan.RuntimeSource.Runtime() == string(client.ServiceEnvImage) {
+		imagePath := common.ImageURLForURLAndReference(
+			plan.RuntimeSource.Image.ImageURL.ValueString(),
+			plan.RuntimeSource.Image.Tag.ValueString(),
+			plan.RuntimeSource.Image.Digest.ValueString(),
+		)
+
 		image = &client.Image{
 			OwnerId:              ownerID,
-			ImagePath:            plan.RuntimeSource.Image.ImageURL.ValueString(),
+			ImagePath:            imagePath,
 			RegistryCredentialId: plan.RuntimeSource.Image.RegistryCredentialID.ValueStringPointer(),
 		}
 	}

--- a/internal/provider/backgroundworker/resource/resource.go
+++ b/internal/provider/backgroundworker/resource/resource.go
@@ -272,5 +272,6 @@ func (r *backgroundWorkerResource) ImportState(ctx context.Context, req resource
 func (r *backgroundWorkerResource) ConfigValidators(ctx context.Context) []resource.ConfigValidator {
 	return []resource.ConfigValidator{
 		resourcecommon.RuntimeSourceValidator,
+		resourcecommon.ImageTagOrDigestValidator,
 	}
 }

--- a/internal/provider/common/models.go
+++ b/internal/provider/common/models.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -185,8 +186,26 @@ func DockerRuntimeSource(service *client.Service, envDetails client.EnvSpecificD
 }
 
 func ImageRuntimeSource(service *client.Service, envDetails client.EnvSpecificDetails) (*ImageRuntimeSourceModel, error) {
+	var imageURL *string
+	var imageTag *string
+	var imageDigest *string
+
+	if service.ImagePath != nil && strings.Contains(*service.ImagePath, "@") {
+		imageParts := strings.Split(*service.ImagePath, "@")
+		imageURL = &imageParts[0]
+		imageDigest = &imageParts[1]
+	}
+
+	if service.ImagePath != nil && strings.Contains(*service.ImagePath, ":") {
+		imageParts := strings.Split(*service.ImagePath, ":")
+		imageURL = &imageParts[0]
+		imageTag = &imageParts[1]
+	}
+
 	image := &ImageRuntimeSourceModel{
-		ImageURL: commontypes.ImageURLStringValue{StringValue: types.StringPointerValue(service.ImagePath)},
+		ImageURL: commontypes.ImageURLStringValue{StringValue: types.StringPointerValue(imageURL)},
+		Tag:      types.StringPointerValue(imageTag),
+		Digest:   types.StringPointerValue(imageDigest),
 	}
 
 	if service.RegistryCredential != nil {

--- a/internal/provider/cronjob/resource/resource.go
+++ b/internal/provider/cronjob/resource/resource.go
@@ -232,5 +232,6 @@ func (r *cronJobResource) ImportState(ctx context.Context, req resource.ImportSt
 func (r *cronJobResource) ConfigValidators(ctx context.Context) []resource.ConfigValidator {
 	return []resource.ConfigValidator{
 		resourcecommon.RuntimeSourceValidator,
+		resourcecommon.ImageTagOrDigestValidator,
 	}
 }

--- a/internal/provider/privateservice/resource/resource.go
+++ b/internal/provider/privateservice/resource/resource.go
@@ -276,5 +276,6 @@ func (r *privateServiceResource) ImportState(ctx context.Context, req resource.I
 func (r *privateServiceResource) ConfigValidators(ctx context.Context) []resource.ConfigValidator {
 	return []resource.ConfigValidator{
 		resourcecommon.RuntimeSourceValidator,
+		resourcecommon.ImageTagOrDigestValidator,
 	}
 }

--- a/internal/provider/types/datasource/runtimesource.go
+++ b/internal/provider/types/datasource/runtimesource.go
@@ -94,10 +94,24 @@ var PreDeployCommand = schema.StringAttribute{
 	Computed:    true,
 }
 
+var ImageTag = schema.StringAttribute{
+	Description: "Tag of the Docker image to deploy. Mutually exclusive with digest.",
+	Optional:    true,
+	Computed:    true,
+}
+
+var ImageDigest = schema.StringAttribute{
+	Description: "Digest of the Docker image to deploy. Mutually exclusive with tag.",
+	Optional:    true,
+	Computed:    true,
+}
+
 var RuntimeSourceImage = schema.SingleNestedAttribute{
 	Computed: true,
 	Attributes: map[string]schema.Attribute{
 		"image_url":              ImageURL,
+		"tag":                    ImageTag,
+		"digest":                 ImageDigest,
 		"registry_credential_id": RegistryCredentialID,
 	},
 }

--- a/internal/provider/types/resource/runtimesource.go
+++ b/internal/provider/types/resource/runtimesource.go
@@ -118,3 +118,8 @@ var RuntimeSourceValidator = resourcevalidator.ExactlyOneOf(
 	path.MatchRoot("runtime_source").AtName("image"),
 	path.MatchRoot("runtime_source").AtName("docker"),
 )
+
+var ImageTagOrDigestValidator = resourcevalidator.Conflicting(
+	path.MatchRoot("runtime_source").AtName("image").AtName("tag"),
+	path.MatchRoot("runtime_source").AtName("image").AtName("digest"),
+)

--- a/internal/provider/types/resource/runtimesource.go
+++ b/internal/provider/types/resource/runtimesource.go
@@ -68,6 +68,18 @@ var ImageURL = schema.StringAttribute{
 	Validators:  []validator.String{validators.StringNotEmpty},
 }
 
+var ImageTag = schema.StringAttribute{
+	Description: "Tag of the Docker image to deploy. Mutually exclusive with digest.",
+	Optional:    true,
+	Computed:    true,
+}
+
+var ImageDigest = schema.StringAttribute{
+	Description: "Digest of the Docker image to deploy. Mutually exclusive with tag.",
+	Optional:    true,
+	Computed:    true,
+}
+
 var RegistryCredentialID = schema.StringAttribute{
 	Description: "ID of the registry credential to use when pulling the image.",
 	Optional:    true,
@@ -95,6 +107,8 @@ var RuntimeSourceImage = schema.SingleNestedAttribute{
 	Optional:            true,
 	Attributes: map[string]schema.Attribute{
 		"image_url":              ImageURL,
+		"tag":                    ImageTag,
+		"digest":                 ImageDigest,
 		"registry_credential_id": RegistryCredentialID,
 	},
 }

--- a/internal/provider/types/resource/runtimesource.go
+++ b/internal/provider/types/resource/runtimesource.go
@@ -1,8 +1,11 @@
 package resource
 
 import (
+	"regexp"
+
 	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
@@ -65,7 +68,13 @@ var ImageURL = schema.StringAttribute{
 	CustomType:  commontypes.ImageURLStringType{},
 	Required:    true,
 	Description: "URL of the Docker image to deploy.",
-	Validators:  []validator.String{validators.StringNotEmpty},
+	Validators: []validator.String{
+		validators.StringNotEmpty,
+		stringvalidator.RegexMatches(
+			regexp.MustCompile(`^(([^/:@]+)|(.+\/[^/:@]+))$`),
+			"must not contain the tag or digest. Use the tag or digest fields instead",
+		),
+	},
 }
 
 var ImageTag = schema.StringAttribute{

--- a/internal/provider/webservice/resource/resource.go
+++ b/internal/provider/webservice/resource/resource.go
@@ -281,5 +281,6 @@ func (r *webServiceResource) ImportState(ctx context.Context, req resource.Impor
 func (r *webServiceResource) ConfigValidators(ctx context.Context) []resource.ConfigValidator {
 	return []resource.ConfigValidator{
 		resourcecommon.RuntimeSourceValidator,
+		resourcecommon.ImageTagOrDigestValidator,
 	}
 }

--- a/internal/provider/webservice/resource/resource_test.go
+++ b/internal/provider/webservice/resource/resource_test.go
@@ -164,7 +164,8 @@ func TestWebServiceResource_RuntimeUpdate(t *testing.T) {
 					},
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "runtime_source.image.image_url", "docker.io/library/nginx:latest"),
+					resource.TestCheckResourceAttr(resourceName, "runtime_source.image.image_url", "docker.io/library/nginx"),
+					resource.TestCheckResourceAttr(resourceName, "runtime_source.image.tag", "latest"),
 				),
 			},
 		},
@@ -211,10 +212,12 @@ func TestWebServiceResource_Image(t *testing.T) {
 				ResourceName: resourceName,
 				ConfigFile:   config.StaticFile("./testdata/image.tf"),
 				ConfigVariables: config.Variables{
-					"image_url": config.StringVariable("docker.io/library/nginx:latest"),
+					"image_url": config.StringVariable("docker.io/library/nginx"),
+					"tag":       config.StringVariable("latest"),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "runtime_source.image.image_url", "docker.io/library/nginx:latest"),
+					resource.TestCheckResourceAttr(resourceName, "runtime_source.image.image_url", "docker.io/library/nginx"),
+					resource.TestCheckResourceAttr(resourceName, "runtime_source.image.tag", "latest"),
 				),
 			},
 			{

--- a/internal/provider/webservice/resource/resource_test.go
+++ b/internal/provider/webservice/resource/resource_test.go
@@ -224,11 +224,13 @@ func TestWebServiceResource_Image(t *testing.T) {
 				ResourceName: resourceName,
 				ConfigFile:   config.StaticFile("./testdata/image.tf"),
 				ConfigVariables: config.Variables{
-					"image_url":     config.StringVariable("docker.io/library/nginx:stable-perl"),
+					"image_url":     config.StringVariable("docker.io/library/nginx"),
+					"tag":           config.StringVariable("stable-perl"),
 					"start_command": config.StringVariable("echo hello"),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "runtime_source.image.image_url", "docker.io/library/nginx:stable-perl"), // updated
+					resource.TestCheckResourceAttr(resourceName, "runtime_source.image.image_url", "docker.io/library/nginx"),
+					resource.TestCheckResourceAttr(resourceName, "runtime_source.image.tag", "stable-perl"), // updated
 					resource.TestCheckResourceAttr(resourceName, "start_command", "echo hello"),
 				),
 			},
@@ -236,11 +238,13 @@ func TestWebServiceResource_Image(t *testing.T) {
 				ResourceName: resourceName,
 				ConfigFile:   config.StaticFile("./testdata/image.tf"),
 				ConfigVariables: config.Variables{
-					"image_url": config.StringVariable("docker.io/library/nginx:stable-perl"),
+					"image_url": config.StringVariable("docker.io/library/nginx"),
+					"tag":       config.StringVariable("stable-perl"),
 					// removed start_command
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "runtime_source.image.image_url", "docker.io/library/nginx:stable-perl"),
+					resource.TestCheckResourceAttr(resourceName, "runtime_source.image.image_url", "docker.io/library/nginx"),
+					resource.TestCheckResourceAttr(resourceName, "runtime_source.image.tag", "stable-perl"),
 					resource.TestCheckNoResourceAttr(resourceName, "start_command"),
 				),
 			},

--- a/internal/provider/webservice/resource/testdata/enable-autoscaling.tf
+++ b/internal/provider/webservice/resource/testdata/enable-autoscaling.tf
@@ -3,7 +3,10 @@ resource "render_web_service" "web_autoscaling_test" {
   plan    = "starter"
   region  = "oregon"
   runtime_source = {
-    image = { image_url = "docker.io/library/redis:latest" }
+    image = {
+      image_url = "docker.io/library/redis"
+      tag       = "latest"
+    }
   }
   autoscaling = {
     enabled = true

--- a/internal/provider/webservice/resource/testdata/image.tf
+++ b/internal/provider/webservice/resource/testdata/image.tf
@@ -7,6 +7,10 @@ variable "image_url" {
   type = string
 }
 
+variable "tag" {
+  type = string
+}
+
 resource "render_web_service" "image" {
   name    = "web-service-image-tf"
   plan    = "starter"
@@ -16,6 +20,7 @@ resource "render_web_service" "image" {
   runtime_source = {
     image = {
       image_url = var.image_url
+      tag       = var.tag
     }
   }
 }

--- a/internal/provider/webservice/resource/testdata/image_runtime.tf
+++ b/internal/provider/webservice/resource/testdata/image_runtime.tf
@@ -5,7 +5,8 @@ resource "render_web_service" "web" {
 
   runtime_source = {
     image = {
-      image_url        = "docker.io/library/nginx:latest",
+      image_url        = "docker.io/library/nginx",
+      tag              = "latest",
     }
   }
 }

--- a/internal/provider/webservice/resource/testdata/remove-autoscaling.tf
+++ b/internal/provider/webservice/resource/testdata/remove-autoscaling.tf
@@ -3,6 +3,9 @@ resource "render_web_service" "web_autoscaling_test" {
   plan    = "starter"
   region  = "oregon"
   runtime_source = {
-    image = { image_url = "docker.io/library/redis:latest" }
+    image = {
+      image_url = "docker.io/library/redis"
+      tag       = "latest"
+    }
   }
 }

--- a/internal/provider/webservice/resource/testdata/remove-disk.tf
+++ b/internal/provider/webservice/resource/testdata/remove-disk.tf
@@ -3,7 +3,10 @@ resource "render_web_service" "web" {
   plan    = "starter"
   region  = "oregon"
   runtime_source = {
-    image = { image_url = "docker.io/library/redis:latest" }
+    image = {
+      image_url = "docker.io/library/redis"
+      tag       = "latest"
+    }
   }
   autoscaling = {
     enabled = false


### PR DESCRIPTION
This adds dedicated `tag` and `digest` fields to specify the version of the image that should be used. This allows us to mark the references as computed and optional. With this change, users can specify the reference in their Terraform config or manage it outside of Terraform and we won't try to revert the change. Including the tag or digest in the imageURL field will continue to work as it does today.