### PR TITLE
Update log stream types

### DIFF
--- a/internal/client/logs/logs_gen.go
+++ b/internal/client/logs/logs_gen.go
@@ -84,7 +84,7 @@ type LogStreamOwnerUpdate struct {
 	Endpoint *LogStreamEndpoint `json:"endpoint,omitempty"`
 
 	// Preview Whether to send logs or drop them.
-	Preview *LogStreamPreviewSetting `json:"preview,omitempty"`
+	Preview LogStreamPreviewSetting `json:"preview"`
 
 	// Token The optional token to authenticate the log stream.
 	Token *LogStreamToken `json:"token,omitempty"`
@@ -99,7 +99,7 @@ type LogStreamResourceUpdate struct {
 	Endpoint *LogStreamEndpoint `json:"endpoint,omitempty"`
 
 	// Setting Whether to send logs or drop them.
-	Setting *LogStreamSetting `json:"setting,omitempty"`
+	Setting LogStreamSetting `json:"setting"`
 
 	// Token The optional token to authenticate the log stream.
 	Token *LogStreamToken `json:"token,omitempty"`

--- a/internal/provider/common/logstreamoverride.go
+++ b/internal/provider/common/logstreamoverride.go
@@ -90,7 +90,7 @@ func LogStreamOverrideToClient(model types.Object) (*logs.LogStreamResourceUpdat
 	}
 
 	return &logs.LogStreamResourceUpdate{
-		Setting:  &logStreamSetting,
+		Setting:  logStreamSetting,
 		Endpoint: endpoint,
 		Token:    token,
 	}, nil

--- a/internal/provider/logstreams/resource/resource.go
+++ b/internal/provider/logstreams/resource/resource.go
@@ -139,7 +139,7 @@ func (r *logStreamSettingResource) logStreamPut(plan logstreams.LogStreamSetting
 	}
 
 	return client.UpdateOwnerLogStreamJSONRequestBody{
-		Preview:  &preview,
+		Preview:  preview,
 		Endpoint: common.From(plan.Endpoint.ValueString()),
 		Token:    common.From(plan.Token.ValueString()),
 	}


### PR DESCRIPTION
A recent change to our openAPI schema made the preview and setting attributes require. This change regenerates those types and updates their usage.