### PR TITLE
Update maintenance mode to be a computed attribute

### DIFF
--- a/internal/provider/types/resource/services.go
+++ b/internal/provider/types/resource/services.go
@@ -2,6 +2,7 @@ package resource
 
 import (
 	"regexp"
+
 	"terraform-provider-render/internal/provider/common/validators"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
@@ -160,9 +161,9 @@ var StartCommand = schema.StringAttribute{
 }
 
 var MaintenanceMode = schema.SingleNestedAttribute{
-	Optional:            true,
-	Description:         "Maintenance mode settings for the service.",
-	MarkdownDescription: "Maintenance mode settings for the service.",
+	Optional:    true,
+	Computed:    true,
+	Description: "Maintenance mode settings for the service.",
 	Attributes: map[string]schema.Attribute{
 		"enabled": schema.BoolAttribute{
 			Optional:    true,

--- a/internal/provider/webservice/models.go
+++ b/internal/provider/webservice/models.go
@@ -9,26 +9,26 @@ import (
 )
 
 type WebServiceModel struct {
-	Id                         types.String                 `tfsdk:"id"`
-	Autoscaling                *common.AutoscalingModel     `tfsdk:"autoscaling"`
-	CustomDomains              []common.CustomDomainModel   `tfsdk:"custom_domains"`
-	RuntimeSource              *common.RuntimeSourceModel   `tfsdk:"runtime_source"`
-	Disk                       *common.DiskModel            `tfsdk:"disk"`
-	EnvironmentID              types.String                 `tfsdk:"environment_id"`
-	HealthCheckPath            types.String                 `tfsdk:"health_check_path"`
-	Name                       types.String                 `tfsdk:"name"`
-	Slug                       types.String                 `tfsdk:"slug"`
-	NumInstances               types.Int64                  `tfsdk:"num_instances"`
-	Plan                       types.String                 `tfsdk:"plan"`
-	PreDeployCommand           types.String                 `tfsdk:"pre_deploy_command"`
-	Previews                   types.Object                 `tfsdk:"previews"`
-	PullRequestPreviewsEnabled types.Bool                   `tfsdk:"pull_request_previews_enabled"`
-	Region                     types.String                 `tfsdk:"region"`
-	RootDirectory              types.String                 `tfsdk:"root_directory"`
-	StartCommand               types.String                 `tfsdk:"start_command"`
-	Url                        types.String                 `tfsdk:"url"`
-	MaxShutdownDelaySeconds    types.Int64                  `tfsdk:"max_shutdown_delay_seconds"`
-	MaintenanceMode            *common.MaintenanceModeModel `tfsdk:"maintenance_mode"`
+	Id                         types.String               `tfsdk:"id"`
+	Autoscaling                *common.AutoscalingModel   `tfsdk:"autoscaling"`
+	CustomDomains              []common.CustomDomainModel `tfsdk:"custom_domains"`
+	RuntimeSource              *common.RuntimeSourceModel `tfsdk:"runtime_source"`
+	Disk                       *common.DiskModel          `tfsdk:"disk"`
+	EnvironmentID              types.String               `tfsdk:"environment_id"`
+	HealthCheckPath            types.String               `tfsdk:"health_check_path"`
+	Name                       types.String               `tfsdk:"name"`
+	Slug                       types.String               `tfsdk:"slug"`
+	NumInstances               types.Int64                `tfsdk:"num_instances"`
+	Plan                       types.String               `tfsdk:"plan"`
+	PreDeployCommand           types.String               `tfsdk:"pre_deploy_command"`
+	Previews                   types.Object               `tfsdk:"previews"`
+	PullRequestPreviewsEnabled types.Bool                 `tfsdk:"pull_request_previews_enabled"`
+	Region                     types.String               `tfsdk:"region"`
+	RootDirectory              types.String               `tfsdk:"root_directory"`
+	StartCommand               types.String               `tfsdk:"start_command"`
+	Url                        types.String               `tfsdk:"url"`
+	MaxShutdownDelaySeconds    types.Int64                `tfsdk:"max_shutdown_delay_seconds"`
+	MaintenanceMode            types.Object               `tfsdk:"maintenance_mode"`
 
 	EnvVars     map[string]common.EnvVarModel     `tfsdk:"env_vars"`
 	SecretFiles map[string]common.SecretFileModel `tfsdk:"secret_files"`
@@ -70,7 +70,7 @@ func ModelForServiceResult(service *common.WrappedService, plan WebServiceModel,
 		Url:                        types.StringValue(details.Url),
 		MaxShutdownDelaySeconds:    common.IntPointerAsValue(details.MaxShutdownDelaySeconds),
 
-		MaintenanceMode:      common.MaintenanceModeFromClient(details.MaintenanceMode),
+		MaintenanceMode:      common.MaintenanceModeFromClient(details.MaintenanceMode, diags),
 		Autoscaling:          common.AutoscalingFromClient(details.Autoscaling, diags),
 		Disk:                 common.DiskToDiskModel(details.Disk),
 		EnvVars:              common.EnvVarsFromClientCursors(service.EnvVars, plan.EnvVars),


### PR DESCRIPTION
Updates maintenance mode to be a computed attribute, since the API will return a value for this field if it's not defined.  Since it is both computed and optional, we need to handle it as a `types.Object` instead of using the struct directly.

Fixes #32 