### PR TITLE
Update docs URL to `render.com/docs`

### DIFF
--- a/docs/data-sources/background_worker.md
+++ b/docs/data-sources/background_worker.md
@@ -21,7 +21,7 @@ Provides information about a Render Background Worker.
 
 ### Optional
 
-- `log_stream_override` (Attributes) Configure the [log stream override settings](https://docs.render.com/log-streams#overriding-defaults) for this service. These will override the global log stream settings of the user or team. (see [below for nested schema](#nestedatt--log_stream_override))
+- `log_stream_override` (Attributes) Configure the [log stream override settings](https://render.com/docs/log-streams#overriding-defaults) for this service. These will override the global log stream settings of the user or team. (see [below for nested schema](#nestedatt--log_stream_override))
 
 ### Read-Only
 
@@ -35,7 +35,7 @@ Provides information about a Render Background Worker.
 - `num_instances` (Number)
 - `plan` (String) Plan to use for the service
 - `pre_deploy_command` (String) This command runs before starting your service. It is typically used for tasks like running a database migration or uploading assets to a CDN.
-- `previews` (Attributes) [Pull request previews](https://docs.render.com/pull-request-previews#pull-request-previews-git-backed) settings (see [below for nested schema](#nestedatt--previews))
+- `previews` (Attributes) [Pull request previews](https://render.com/docs/pull-request-previews#pull-request-previews-git-backed) settings (see [below for nested schema](#nestedatt--previews))
 - `pull_request_previews_enabled` (Boolean, Deprecated)
 - `region` (String) Region to deploy the service
 - `root_directory` (String) Defaults to repository root. When you specify a root directory that is different from your repository root, Render runs all your commands in the specified directory and ignores changes outside the directory.
@@ -132,7 +132,7 @@ Read-Only:
 
 Read-Only:
 
-- `generation` (String) Generation mode for [pull request previews](https://docs.render.com/pull-request-previews#pull-request-previews-git-backed). One of `off`, `manual`, or `automatic`. Defaults to `off`.
+- `generation` (String) Generation mode for [pull request previews](https://render.com/docs/pull-request-previews#pull-request-previews-git-backed). One of `off`, `manual`, or `automatic`. Defaults to `off`.
 
 
 <a id="nestedatt--runtime_source"></a>
@@ -149,7 +149,7 @@ Read-Only:
 
 Read-Only:
 
-- `auto_deploy` (Boolean) [Automatic deploy](https://docs.render.com/deploys#automatic-git-deploys) on every push to your repository, or changes to your service settings or environment.
+- `auto_deploy` (Boolean) [Automatic deploy](https://render.com/docs/deploys#automatic-git-deploys) on every push to your repository, or changes to your service settings or environment.
 - `branch` (String) Branch to build
 - `build_filter` (Attributes) Filter for files and paths to monitor for automatic deploys. Filter paths are absolute. If you've defined a root directory, you can still define paths outside of the root directory. (see [below for nested schema](#nestedatt--runtime_source--docker--build_filter))
 - `context` (String) [Docker build context directory.](https://docs.docker.com/reference/dockerfile/#usage) This is relative to your repository root. Defaults to the root.
@@ -186,7 +186,7 @@ Read-Only:
 
 Read-Only:
 
-- `auto_deploy` (Boolean) [Automatic deploy](https://docs.render.com/deploys#automatic-git-deploys) on every push to your repository, or changes to your service settings or environment.
+- `auto_deploy` (Boolean) [Automatic deploy](https://render.com/docs/deploys#automatic-git-deploys) on every push to your repository, or changes to your service settings or environment.
 - `branch` (String) Branch to build
 - `build_command` (String) Command to build the service
 - `build_filter` (Attributes) Filter for files and paths to monitor for automatic deploys. Filter paths are absolute. If you've defined a root directory, you can still define paths outside of the root directory. (see [below for nested schema](#nestedatt--runtime_source--native_runtime--build_filter))

--- a/docs/data-sources/cron_job.md
+++ b/docs/data-sources/cron_job.md
@@ -21,7 +21,7 @@ Provides information about a Render Cron Job resource.
 
 ### Optional
 
-- `log_stream_override` (Attributes) Configure the [log stream override settings](https://docs.render.com/log-streams#overriding-defaults) for this service. These will override the global log stream settings of the user or team. (see [below for nested schema](#nestedatt--log_stream_override))
+- `log_stream_override` (Attributes) Configure the [log stream override settings](https://render.com/docs/log-streams#overriding-defaults) for this service. These will override the global log stream settings of the user or team. (see [below for nested schema](#nestedatt--log_stream_override))
 
 ### Read-Only
 
@@ -83,7 +83,7 @@ Read-Only:
 
 Read-Only:
 
-- `auto_deploy` (Boolean) [Automatic deploy](https://docs.render.com/deploys#automatic-git-deploys) on every push to your repository, or changes to your service settings or environment.
+- `auto_deploy` (Boolean) [Automatic deploy](https://render.com/docs/deploys#automatic-git-deploys) on every push to your repository, or changes to your service settings or environment.
 - `branch` (String) Branch to build
 - `build_filter` (Attributes) Filter for files and paths to monitor for automatic deploys. Filter paths are absolute. If you've defined a root directory, you can still define paths outside of the root directory. (see [below for nested schema](#nestedatt--runtime_source--docker--build_filter))
 - `context` (String) [Docker build context directory.](https://docs.docker.com/reference/dockerfile/#usage) This is relative to your repository root. Defaults to the root.
@@ -120,7 +120,7 @@ Read-Only:
 
 Read-Only:
 
-- `auto_deploy` (Boolean) [Automatic deploy](https://docs.render.com/deploys#automatic-git-deploys) on every push to your repository, or changes to your service settings or environment.
+- `auto_deploy` (Boolean) [Automatic deploy](https://render.com/docs/deploys#automatic-git-deploys) on every push to your repository, or changes to your service settings or environment.
 - `branch` (String) Branch to build
 - `build_command` (String) Command to build the service
 - `build_filter` (Attributes) Filter for files and paths to monitor for automatic deploys. Filter paths are absolute. If you've defined a root directory, you can still define paths outside of the root directory. (see [below for nested schema](#nestedatt--runtime_source--native_runtime--build_filter))

--- a/docs/data-sources/log_stream.md
+++ b/docs/data-sources/log_stream.md
@@ -3,12 +3,12 @@
 page_title: "render_log_stream Data Source - render"
 subcategory: ""
 description: |-
-  Configure the log stream override settings https://docs.render.com/log-streams#setup for this owner.
+  Configure the log stream override settings https://render.com/docs/log-streams#setup for this owner.
 ---
 
 # render_log_stream (Data Source)
 
-Configure the [log stream override settings](https://docs.render.com/log-streams#setup) for this owner.
+Configure the [log stream override settings](https://render.com/docs/log-streams#setup) for this owner.
 
 
 

--- a/docs/data-sources/postgres.md
+++ b/docs/data-sources/postgres.md
@@ -23,7 +23,7 @@ description: |-
 
 - `datadog_api_key` (String, Sensitive) Datadog API key to use when sending postgres metrics
 - `disk_size_gb` (Number) Disk size in GB.
-- `log_stream_override` (Attributes) Configure the [log stream override settings](https://docs.render.com/log-streams#overriding-defaults) for this service. These will override the global log stream settings of the user or team. (see [below for nested schema](#nestedatt--log_stream_override))
+- `log_stream_override` (Attributes) Configure the [log stream override settings](https://render.com/docs/log-streams#overriding-defaults) for this service. These will override the global log stream settings of the user or team. (see [below for nested schema](#nestedatt--log_stream_override))
 - `primary_postgres_id` (String) If this is a replica, the ID of the primary postgres instance
 
 ### Read-Only

--- a/docs/data-sources/private_service.md
+++ b/docs/data-sources/private_service.md
@@ -21,7 +21,7 @@ Provides information about a Render Private Service.
 
 ### Optional
 
-- `log_stream_override` (Attributes) Configure the [log stream override settings](https://docs.render.com/log-streams#overriding-defaults) for this service. These will override the global log stream settings of the user or team. (see [below for nested schema](#nestedatt--log_stream_override))
+- `log_stream_override` (Attributes) Configure the [log stream override settings](https://render.com/docs/log-streams#overriding-defaults) for this service. These will override the global log stream settings of the user or team. (see [below for nested schema](#nestedatt--log_stream_override))
 
 ### Read-Only
 
@@ -35,7 +35,7 @@ Provides information about a Render Private Service.
 - `num_instances` (Number)
 - `plan` (String) Plan to use for the service
 - `pre_deploy_command` (String) This command runs before starting your service. It is typically used for tasks like running a database migration or uploading assets to a CDN.
-- `previews` (Attributes) [Pull request previews](https://docs.render.com/pull-request-previews#pull-request-previews-git-backed) settings (see [below for nested schema](#nestedatt--previews))
+- `previews` (Attributes) [Pull request previews](https://render.com/docs/pull-request-previews#pull-request-previews-git-backed) settings (see [below for nested schema](#nestedatt--previews))
 - `pull_request_previews_enabled` (Boolean, Deprecated)
 - `region` (String) Region to deploy the service
 - `root_directory` (String) Defaults to repository root. When you specify a root directory that is different from your repository root, Render runs all your commands in the specified directory and ignores changes outside the directory.
@@ -133,7 +133,7 @@ Read-Only:
 
 Read-Only:
 
-- `generation` (String) Generation mode for [pull request previews](https://docs.render.com/pull-request-previews#pull-request-previews-git-backed). One of `off`, `manual`, or `automatic`. Defaults to `off`.
+- `generation` (String) Generation mode for [pull request previews](https://render.com/docs/pull-request-previews#pull-request-previews-git-backed). One of `off`, `manual`, or `automatic`. Defaults to `off`.
 
 
 <a id="nestedatt--runtime_source"></a>
@@ -150,7 +150,7 @@ Read-Only:
 
 Read-Only:
 
-- `auto_deploy` (Boolean) [Automatic deploy](https://docs.render.com/deploys#automatic-git-deploys) on every push to your repository, or changes to your service settings or environment.
+- `auto_deploy` (Boolean) [Automatic deploy](https://render.com/docs/deploys#automatic-git-deploys) on every push to your repository, or changes to your service settings or environment.
 - `branch` (String) Branch to build
 - `build_filter` (Attributes) Filter for files and paths to monitor for automatic deploys. Filter paths are absolute. If you've defined a root directory, you can still define paths outside of the root directory. (see [below for nested schema](#nestedatt--runtime_source--docker--build_filter))
 - `context` (String) [Docker build context directory.](https://docs.docker.com/reference/dockerfile/#usage) This is relative to your repository root. Defaults to the root.
@@ -187,7 +187,7 @@ Read-Only:
 
 Read-Only:
 
-- `auto_deploy` (Boolean) [Automatic deploy](https://docs.render.com/deploys#automatic-git-deploys) on every push to your repository, or changes to your service settings or environment.
+- `auto_deploy` (Boolean) [Automatic deploy](https://render.com/docs/deploys#automatic-git-deploys) on every push to your repository, or changes to your service settings or environment.
 - `branch` (String) Branch to build
 - `build_command` (String) Command to build the service
 - `build_filter` (Attributes) Filter for files and paths to monitor for automatic deploys. Filter paths are absolute. If you've defined a root directory, you can still define paths outside of the root directory. (see [below for nested schema](#nestedatt--runtime_source--native_runtime--build_filter))

--- a/docs/data-sources/redis.md
+++ b/docs/data-sources/redis.md
@@ -21,7 +21,7 @@ Provides information about a Render Redis instance.
 
 ### Optional
 
-- `log_stream_override` (Attributes) Configure the [log stream override settings](https://docs.render.com/log-streams#overriding-defaults) for this service. These will override the global log stream settings of the user or team. (see [below for nested schema](#nestedatt--log_stream_override))
+- `log_stream_override` (Attributes) Configure the [log stream override settings](https://render.com/docs/log-streams#overriding-defaults) for this service. These will override the global log stream settings of the user or team. (see [below for nested schema](#nestedatt--log_stream_override))
 
 ### Read-Only
 

--- a/docs/data-sources/static_site.md
+++ b/docs/data-sources/static_site.md
@@ -25,7 +25,7 @@ Provides information about a Render Static Site.
 
 ### Read-Only
 
-- `auto_deploy` (Boolean) [Automatic deploy](https://docs.render.com/deploys#automatic-git-deploys) on every push to your repository, or changes to your service settings or environment.
+- `auto_deploy` (Boolean) [Automatic deploy](https://render.com/docs/deploys#automatic-git-deploys) on every push to your repository, or changes to your service settings or environment.
 - `branch` (String) Branch to build
 - `build_command` (String) Command to build the service
 - `build_filter` (Attributes) Filter for files and paths to monitor for automatic deploys. Filter paths are absolute. If you've defined a root directory, you can still define paths outside of the root directory. (see [below for nested schema](#nestedatt--build_filter))
@@ -34,7 +34,7 @@ Provides information about a Render Static Site.
 - `headers` (Attributes List) (see [below for nested schema](#nestedatt--headers))
 - `name` (String) Name of the service
 - `notification_override` (Attributes) Set the notification settings for this service. These will override the notification settings of the owner. (see [below for nested schema](#nestedatt--notification_override))
-- `previews` (Attributes) [Pull request previews](https://docs.render.com/pull-request-previews#pull-request-previews-git-backed) settings (see [below for nested schema](#nestedatt--previews))
+- `previews` (Attributes) [Pull request previews](https://render.com/docs/pull-request-previews#pull-request-previews-git-backed) settings (see [below for nested schema](#nestedatt--previews))
 - `publish_path` (String) Path to the directory to publish
 - `pull_request_previews_enabled` (Boolean, Deprecated)
 - `repo_url` (String) URL of the repository to build
@@ -100,7 +100,7 @@ Read-Only:
 
 Read-Only:
 
-- `generation` (String) Generation mode for [pull request previews](https://docs.render.com/pull-request-previews#pull-request-previews-git-backed). One of `off`, `manual`, or `automatic`. Defaults to `off`.
+- `generation` (String) Generation mode for [pull request previews](https://render.com/docs/pull-request-previews#pull-request-previews-git-backed). One of `off`, `manual`, or `automatic`. Defaults to `off`.
 
 
 <a id="nestedatt--routes"></a>

--- a/docs/data-sources/web_service.md
+++ b/docs/data-sources/web_service.md
@@ -22,7 +22,7 @@ Provides information about a Render Web Service.
 ### Optional
 
 - `custom_domains` (Attributes Set) Custom domains to associate with the service. (see [below for nested schema](#nestedatt--custom_domains))
-- `log_stream_override` (Attributes) Configure the [log stream override settings](https://docs.render.com/log-streams#overriding-defaults) for this service. These will override the global log stream settings of the user or team. (see [below for nested schema](#nestedatt--log_stream_override))
+- `log_stream_override` (Attributes) Configure the [log stream override settings](https://render.com/docs/log-streams#overriding-defaults) for this service. These will override the global log stream settings of the user or team. (see [below for nested schema](#nestedatt--log_stream_override))
 - `maintenance_mode` (Attributes) Maintenance mode settings (see [below for nested schema](#nestedatt--maintenance_mode))
 
 ### Read-Only
@@ -31,14 +31,14 @@ Provides information about a Render Web Service.
 - `disk` (Attributes) (see [below for nested schema](#nestedatt--disk))
 - `env_vars` (Attributes Map) Map of environment variable names to their values. (see [below for nested schema](#nestedatt--env_vars))
 - `environment_id` (String) Unique identifier for the environment that the resource belongs to
-- `health_check_path` (String) If you're running a server, enter the path where your server will always return a 200 OK response. We use it to monitor your app and for [zero downtime deploys](https://docs.render.com/deploys#zero-downtime-deploys).
+- `health_check_path` (String) If you're running a server, enter the path where your server will always return a 200 OK response. We use it to monitor your app and for [zero downtime deploys](https://render.com/docs/deploys#zero-downtime-deploys).
 - `max_shutdown_delay_seconds` (Number) The maximum amount of time (in seconds) that Render waits for your application process to exit gracefully after sending it a SIGTERM signal before sending a SIGKILL signal.
 - `name` (String) Name of the service
 - `notification_override` (Attributes) Set the notification settings for this service. These will override the notification settings of the owner. (see [below for nested schema](#nestedatt--notification_override))
 - `num_instances` (Number)
 - `plan` (String) Plan to use for the service
 - `pre_deploy_command` (String) This command runs before starting your service. It is typically used for tasks like running a database migration or uploading assets to a CDN.
-- `previews` (Attributes) [Pull request previews](https://docs.render.com/pull-request-previews#pull-request-previews-git-backed) settings (see [below for nested schema](#nestedatt--previews))
+- `previews` (Attributes) [Pull request previews](https://render.com/docs/pull-request-previews#pull-request-previews-git-backed) settings (see [below for nested schema](#nestedatt--previews))
 - `pull_request_previews_enabled` (Boolean, Deprecated)
 - `region` (String) Region to deploy the service
 - `root_directory` (String) Defaults to repository root. When you specify a root directory that is different from your repository root, Render runs all your commands in the specified directory and ignores changes outside the directory.
@@ -160,7 +160,7 @@ Read-Only:
 
 Read-Only:
 
-- `generation` (String) Generation mode for [pull request previews](https://docs.render.com/pull-request-previews#pull-request-previews-git-backed). One of `off`, `manual`, or `automatic`. Defaults to `off`.
+- `generation` (String) Generation mode for [pull request previews](https://render.com/docs/pull-request-previews#pull-request-previews-git-backed). One of `off`, `manual`, or `automatic`. Defaults to `off`.
 
 
 <a id="nestedatt--runtime_source"></a>
@@ -177,7 +177,7 @@ Read-Only:
 
 Read-Only:
 
-- `auto_deploy` (Boolean) [Automatic deploy](https://docs.render.com/deploys#automatic-git-deploys) on every push to your repository, or changes to your service settings or environment.
+- `auto_deploy` (Boolean) [Automatic deploy](https://render.com/docs/deploys#automatic-git-deploys) on every push to your repository, or changes to your service settings or environment.
 - `branch` (String) Branch to build
 - `build_filter` (Attributes) Filter for files and paths to monitor for automatic deploys. Filter paths are absolute. If you've defined a root directory, you can still define paths outside of the root directory. (see [below for nested schema](#nestedatt--runtime_source--docker--build_filter))
 - `context` (String) [Docker build context directory.](https://docs.docker.com/reference/dockerfile/#usage) This is relative to your repository root. Defaults to the root.
@@ -214,7 +214,7 @@ Read-Only:
 
 Read-Only:
 
-- `auto_deploy` (Boolean) [Automatic deploy](https://docs.render.com/deploys#automatic-git-deploys) on every push to your repository, or changes to your service settings or environment.
+- `auto_deploy` (Boolean) [Automatic deploy](https://render.com/docs/deploys#automatic-git-deploys) on every push to your repository, or changes to your service settings or environment.
 - `branch` (String) Branch to build
 - `build_command` (String) Command to build the service
 - `build_filter` (Attributes) Filter for files and paths to monitor for automatic deploys. Filter paths are absolute. If you've defined a root directory, you can still define paths outside of the root directory. (see [below for nested schema](#nestedatt--runtime_source--native_runtime--build_filter))

--- a/docs/resources/background_worker.md
+++ b/docs/resources/background_worker.md
@@ -85,25 +85,25 @@ resource "render_background_worker" "git_example" {
 
 - `name` (String) Name of the service
 - `plan` (String) Plan to use for the service. Must be one of `starter`, `standard`, `pro`, `pro_plus`, `pro_max`, `pro_ultra`, or a custom plan.
-- `region` (String) [Region](https://docs.render.com/regions) to deploy the service. One of `frankfurt`, `ohio`, `oregon`, `singapore`, `virginia`.
-- `runtime_source` (Attributes) Source of the build artifacts or image that run your service. You must provide one of [native_runtime](https://docs.render.com/native-runtimes), [docker](https://docs.render.com/docker), or [image](https://docs.render.com/deploy-an-image). (see [below for nested schema](#nestedatt--runtime_source))
+- `region` (String) [Region](https://render.com/docs/regions) to deploy the service. One of `frankfurt`, `ohio`, `oregon`, `singapore`, `virginia`.
+- `runtime_source` (Attributes) Source of the build artifacts or image that run your service. You must provide one of [native_runtime](https://render.com/docs/native-runtimes), [docker](https://render.com/docs/docker), or [image](https://render.com/docs/deploy-an-image). (see [below for nested schema](#nestedatt--runtime_source))
 
 ### Optional
 
-- `autoscaling` (Attributes) [Autoscaling settings](https://docs.render.com/scaling#autoscaling) for the service (see [below for nested schema](#nestedatt--autoscaling))
-- `disk` (Attributes) [Persistent disk](https://docs.render.com/disks) to attach to the service. (see [below for nested schema](#nestedatt--disk))
+- `autoscaling` (Attributes) [Autoscaling settings](https://render.com/docs/scaling#autoscaling) for the service (see [below for nested schema](#nestedatt--autoscaling))
+- `disk` (Attributes) [Persistent disk](https://render.com/docs/disks) to attach to the service. (see [below for nested schema](#nestedatt--disk))
 - `env_vars` (Attributes Map) Map of environment variable names to their values. (see [below for nested schema](#nestedatt--env_vars))
-- `environment_id` (String) ID of the [project environment](https://docs.render.com/projects) that the resource belongs to
-- `log_stream_override` (Attributes) Configure the [log stream override settings](https://docs.render.com/log-streams#overriding-defaults) for this service. These will override the global log stream settings of the user or team. (see [below for nested schema](#nestedatt--log_stream_override))
+- `environment_id` (String) ID of the [project environment](https://render.com/docs/projects) that the resource belongs to
+- `log_stream_override` (Attributes) Configure the [log stream override settings](https://render.com/docs/log-streams#overriding-defaults) for this service. These will override the global log stream settings of the user or team. (see [below for nested schema](#nestedatt--log_stream_override))
 - `max_shutdown_delay_seconds` (Number) The maximum amount of time (in seconds) that Render waits for your application process to exit gracefully after sending it a SIGTERM signal before sending a SIGKILL signal.
-- `notification_override` (Attributes) Configure the [notification settings](https://docs.render.com/notifications) for this service. These will override the global notification settings of the user or team. (see [below for nested schema](#nestedatt--notification_override))
+- `notification_override` (Attributes) Configure the [notification settings](https://render.com/docs/notifications) for this service. These will override the global notification settings of the user or team. (see [below for nested schema](#nestedatt--notification_override))
 - `num_instances` (Number) Number of replicas of the service to run. Defaults to 1 on service creation and current instance count on update. If you want to manage the service's instance count outside Terraform, leave num_instances unset.
 - `pre_deploy_command` (String) This command runs before starting your service. It is typically used for tasks like running a database migration or uploading assets to a CDN.
-- `previews` (Attributes) [Pull request previews](https://docs.render.com/pull-request-previews#pull-request-previews-git-backed) settings (see [below for nested schema](#nestedatt--previews))
-- `pull_request_previews_enabled` (Boolean, Deprecated) Enable [pull request previews](https://docs.render.com/pull-request-previews#pull-request-previews-git-backed) for the service.
-- `root_directory` (String) When you specify a [root directory](https://docs.render.com/monorepo-support#root-directory), Render runs all your commands in the specified directory and ignores changes outside the directory. Defaults to the repository root.
+- `previews` (Attributes) [Pull request previews](https://render.com/docs/pull-request-previews#pull-request-previews-git-backed) settings (see [below for nested schema](#nestedatt--previews))
+- `pull_request_previews_enabled` (Boolean, Deprecated) Enable [pull request previews](https://render.com/docs/pull-request-previews#pull-request-previews-git-backed) for the service.
+- `root_directory` (String) When you specify a [root directory](https://render.com/docs/monorepo-support#root-directory), Render runs all your commands in the specified directory and ignores changes outside the directory. Defaults to the repository root.
 - `secret_files` (Attributes Map) A map of secret file paths to their contents. (see [below for nested schema](#nestedatt--secret_files))
-- `start_command` (String) Command to run the service. When using native runtimes, this will be used as the start command and is required. For [Docker](https://docs.render.com/docker) and [image-backed](https://docs.render.com/deploy-an-image) services, this will override the default Docker command for the image.
+- `start_command` (String) Command to run the service. When using native runtimes, this will be used as the start command and is required. For [Docker](https://render.com/docs/docker) and [image-backed](https://render.com/docs/deploy-an-image) services, this will override the default Docker command for the image.
 
 ### Read-Only
 
@@ -115,9 +115,9 @@ resource "render_background_worker" "git_example" {
 
 Optional:
 
-- `docker` (Attributes) Details for building and deploying a service [using a Dockerfile](https://docs.render.com/docker). (see [below for nested schema](#nestedatt--runtime_source--docker))
-- `image` (Attributes) Details for deploying a service using a [Docker image from a registry](https://docs.render.com/deploy-an-image). (see [below for nested schema](#nestedatt--runtime_source--image))
-- `native_runtime` (Attributes) Details for building and deploying a service using one of Render's [native runtimes](https://docs.render.com/native-runtimes). (see [below for nested schema](#nestedatt--runtime_source--native_runtime))
+- `docker` (Attributes) Details for building and deploying a service [using a Dockerfile](https://render.com/docs/docker). (see [below for nested schema](#nestedatt--runtime_source--docker))
+- `image` (Attributes) Details for deploying a service using a [Docker image from a registry](https://render.com/docs/deploy-an-image). (see [below for nested schema](#nestedatt--runtime_source--image))
+- `native_runtime` (Attributes) Details for building and deploying a service using one of Render's [native runtimes](https://render.com/docs/native-runtimes). (see [below for nested schema](#nestedatt--runtime_source--native_runtime))
 
 <a id="nestedatt--runtime_source--docker"></a>
 ### Nested Schema for `runtime_source.docker`
@@ -129,8 +129,8 @@ Required:
 
 Optional:
 
-- `auto_deploy` (Boolean) [Automatic deploy](https://docs.render.com/deploys#automatic-git-deploys) on every push to your repository, or changes to your service settings or environment.
-- `build_filter` (Attributes) Apply [build filters](https://docs.render.com/monorepo-support#build-filters) to configure which changes in your git repository trigger automatic deploys. If you've defined a root directory, you can still define paths outside of the root directory. (see [below for nested schema](#nestedatt--runtime_source--docker--build_filter))
+- `auto_deploy` (Boolean) [Automatic deploy](https://render.com/docs/deploys#automatic-git-deploys) on every push to your repository, or changes to your service settings or environment.
+- `build_filter` (Attributes) Apply [build filters](https://render.com/docs/monorepo-support#build-filters) to configure which changes in your git repository trigger automatic deploys. If you've defined a root directory, you can still define paths outside of the root directory. (see [below for nested schema](#nestedatt--runtime_source--docker--build_filter))
 - `context` (String) [Docker build context directory.](https://docs.docker.com/reference/dockerfile/#usage) This is relative to your repository root. Defaults to the root.
 - `dockerfile_path` (String) Path to your Dockerfile relative to the repository root. This is not relative to your Docker build context. Example: `./subdir/Dockerfile.`
 - `registry_credential_id` (String) ID of the registry credential to use when pulling the image.
@@ -171,8 +171,8 @@ Required:
 
 Optional:
 
-- `auto_deploy` (Boolean) [Automatic deploy](https://docs.render.com/deploys#automatic-git-deploys) on every push to your repository, or changes to your service settings or environment.
-- `build_filter` (Attributes) Apply [build filters](https://docs.render.com/monorepo-support#build-filters) to configure which changes in your git repository trigger automatic deploys. If you've defined a root directory, you can still define paths outside of the root directory. (see [below for nested schema](#nestedatt--runtime_source--native_runtime--build_filter))
+- `auto_deploy` (Boolean) [Automatic deploy](https://render.com/docs/deploys#automatic-git-deploys) on every push to your repository, or changes to your service settings or environment.
+- `build_filter` (Attributes) Apply [build filters](https://render.com/docs/monorepo-support#build-filters) to configure which changes in your git repository trigger automatic deploys. If you've defined a root directory, you can still define paths outside of the root directory. (see [below for nested schema](#nestedatt--runtime_source--native_runtime--build_filter))
 
 <a id="nestedatt--runtime_source--native_runtime--build_filter"></a>
 ### Nested Schema for `runtime_source.native_runtime.build_filter`
@@ -273,7 +273,7 @@ Optional:
 
 Optional:
 
-- `generation` (String) Generation mode for [pull request previews](https://docs.render.com/pull-request-previews#pull-request-previews-git-backed). One of `off`, `manual`, or `automatic`. Defaults to `off`.
+- `generation` (String) Generation mode for [pull request previews](https://render.com/docs/pull-request-previews#pull-request-previews-git-backed). One of `off`, `manual`, or `automatic`. Defaults to `off`.
 
 
 <a id="nestedatt--secret_files"></a>

--- a/docs/resources/cron_job.md
+++ b/docs/resources/cron_job.md
@@ -50,19 +50,19 @@ resource "render_cron_job" "cron-job-example" {
 
 - `name` (String) Name of the service
 - `plan` (String) Plan to use for the service. Must be one of `starter`, `standard`, `pro`, `pro_plus`, `pro_max`, `pro_ultra`, or a custom plan.
-- `region` (String) [Region](https://docs.render.com/regions) to deploy the service. One of `frankfurt`, `ohio`, `oregon`, `singapore`, `virginia`.
-- `runtime_source` (Attributes) Source of the build artifacts or image that run your service. You must provide one of [native_runtime](https://docs.render.com/native-runtimes), [docker](https://docs.render.com/docker), or [image](https://docs.render.com/deploy-an-image). (see [below for nested schema](#nestedatt--runtime_source))
+- `region` (String) [Region](https://render.com/docs/regions) to deploy the service. One of `frankfurt`, `ohio`, `oregon`, `singapore`, `virginia`.
+- `runtime_source` (Attributes) Source of the build artifacts or image that run your service. You must provide one of [native_runtime](https://render.com/docs/native-runtimes), [docker](https://render.com/docs/docker), or [image](https://render.com/docs/deploy-an-image). (see [below for nested schema](#nestedatt--runtime_source))
 - `schedule` (String) Cron schedule to run the job
 
 ### Optional
 
 - `env_vars` (Attributes Map) Map of environment variable names to their values. (see [below for nested schema](#nestedatt--env_vars))
-- `environment_id` (String) ID of the [project environment](https://docs.render.com/projects) that the resource belongs to
-- `log_stream_override` (Attributes) Configure the [log stream override settings](https://docs.render.com/log-streams#overriding-defaults) for this service. These will override the global log stream settings of the user or team. (see [below for nested schema](#nestedatt--log_stream_override))
-- `notification_override` (Attributes) Configure the [notification settings](https://docs.render.com/notifications) for this service. These will override the global notification settings of the user or team. (see [below for nested schema](#nestedatt--notification_override))
-- `root_directory` (String) When you specify a [root directory](https://docs.render.com/monorepo-support#root-directory), Render runs all your commands in the specified directory and ignores changes outside the directory. Defaults to the repository root.
+- `environment_id` (String) ID of the [project environment](https://render.com/docs/projects) that the resource belongs to
+- `log_stream_override` (Attributes) Configure the [log stream override settings](https://render.com/docs/log-streams#overriding-defaults) for this service. These will override the global log stream settings of the user or team. (see [below for nested schema](#nestedatt--log_stream_override))
+- `notification_override` (Attributes) Configure the [notification settings](https://render.com/docs/notifications) for this service. These will override the global notification settings of the user or team. (see [below for nested schema](#nestedatt--notification_override))
+- `root_directory` (String) When you specify a [root directory](https://render.com/docs/monorepo-support#root-directory), Render runs all your commands in the specified directory and ignores changes outside the directory. Defaults to the repository root.
 - `secret_files` (Attributes Map) A map of secret file paths to their contents. (see [below for nested schema](#nestedatt--secret_files))
-- `start_command` (String) Command to run the service. When using native runtimes, this will be used as the start command and is required. For [Docker](https://docs.render.com/docker) and [image-backed](https://docs.render.com/deploy-an-image) services, this will override the default Docker command for the image.
+- `start_command` (String) Command to run the service. When using native runtimes, this will be used as the start command and is required. For [Docker](https://render.com/docs/docker) and [image-backed](https://render.com/docs/deploy-an-image) services, this will override the default Docker command for the image.
 
 ### Read-Only
 
@@ -74,9 +74,9 @@ resource "render_cron_job" "cron-job-example" {
 
 Optional:
 
-- `docker` (Attributes) Details for building and deploying a service [using a Dockerfile](https://docs.render.com/docker). (see [below for nested schema](#nestedatt--runtime_source--docker))
-- `image` (Attributes) Details for deploying a service using a [Docker image from a registry](https://docs.render.com/deploy-an-image). (see [below for nested schema](#nestedatt--runtime_source--image))
-- `native_runtime` (Attributes) Details for building and deploying a service using one of Render's [native runtimes](https://docs.render.com/native-runtimes). (see [below for nested schema](#nestedatt--runtime_source--native_runtime))
+- `docker` (Attributes) Details for building and deploying a service [using a Dockerfile](https://render.com/docs/docker). (see [below for nested schema](#nestedatt--runtime_source--docker))
+- `image` (Attributes) Details for deploying a service using a [Docker image from a registry](https://render.com/docs/deploy-an-image). (see [below for nested schema](#nestedatt--runtime_source--image))
+- `native_runtime` (Attributes) Details for building and deploying a service using one of Render's [native runtimes](https://render.com/docs/native-runtimes). (see [below for nested schema](#nestedatt--runtime_source--native_runtime))
 
 <a id="nestedatt--runtime_source--docker"></a>
 ### Nested Schema for `runtime_source.docker`
@@ -88,8 +88,8 @@ Required:
 
 Optional:
 
-- `auto_deploy` (Boolean) [Automatic deploy](https://docs.render.com/deploys#automatic-git-deploys) on every push to your repository, or changes to your service settings or environment.
-- `build_filter` (Attributes) Apply [build filters](https://docs.render.com/monorepo-support#build-filters) to configure which changes in your git repository trigger automatic deploys. If you've defined a root directory, you can still define paths outside of the root directory. (see [below for nested schema](#nestedatt--runtime_source--docker--build_filter))
+- `auto_deploy` (Boolean) [Automatic deploy](https://render.com/docs/deploys#automatic-git-deploys) on every push to your repository, or changes to your service settings or environment.
+- `build_filter` (Attributes) Apply [build filters](https://render.com/docs/monorepo-support#build-filters) to configure which changes in your git repository trigger automatic deploys. If you've defined a root directory, you can still define paths outside of the root directory. (see [below for nested schema](#nestedatt--runtime_source--docker--build_filter))
 - `context` (String) [Docker build context directory.](https://docs.docker.com/reference/dockerfile/#usage) This is relative to your repository root. Defaults to the root.
 - `dockerfile_path` (String) Path to your Dockerfile relative to the repository root. This is not relative to your Docker build context. Example: `./subdir/Dockerfile.`
 - `registry_credential_id` (String) ID of the registry credential to use when pulling the image.
@@ -130,8 +130,8 @@ Required:
 
 Optional:
 
-- `auto_deploy` (Boolean) [Automatic deploy](https://docs.render.com/deploys#automatic-git-deploys) on every push to your repository, or changes to your service settings or environment.
-- `build_filter` (Attributes) Apply [build filters](https://docs.render.com/monorepo-support#build-filters) to configure which changes in your git repository trigger automatic deploys. If you've defined a root directory, you can still define paths outside of the root directory. (see [below for nested schema](#nestedatt--runtime_source--native_runtime--build_filter))
+- `auto_deploy` (Boolean) [Automatic deploy](https://render.com/docs/deploys#automatic-git-deploys) on every push to your repository, or changes to your service settings or environment.
+- `build_filter` (Attributes) Apply [build filters](https://render.com/docs/monorepo-support#build-filters) to configure which changes in your git repository trigger automatic deploys. If you've defined a root directory, you can still define paths outside of the root directory. (see [below for nested schema](#nestedatt--runtime_source--native_runtime--build_filter))
 
 <a id="nestedatt--runtime_source--native_runtime--build_filter"></a>
 ### Nested Schema for `runtime_source.native_runtime.build_filter`

--- a/docs/resources/env_group.md
+++ b/docs/resources/env_group.md
@@ -52,7 +52,7 @@ resource "render_env_group" "example" {
 ### Optional
 
 - `env_vars` (Attributes Map) Map of environment variable names to their values. (see [below for nested schema](#nestedatt--env_vars))
-- `environment_id` (String) ID of the [project environment](https://docs.render.com/projects) that the resource belongs to
+- `environment_id` (String) ID of the [project environment](https://render.com/docs/projects) that the resource belongs to
 - `secret_files` (Attributes Map) A map of secret file paths to their contents. (see [below for nested schema](#nestedatt--secret_files))
 
 ### Read-Only

--- a/docs/resources/log_stream.md
+++ b/docs/resources/log_stream.md
@@ -3,12 +3,12 @@
 page_title: "render_log_stream Resource - render"
 subcategory: ""
 description: |-
-  Configure the log stream override settings https://docs.render.com/log-streams#setup for this owner.
+  Configure the log stream override settings https://render.com/docs/log-streams#setup for this owner.
 ---
 
 # render_log_stream (Resource)
 
-Configure the [log stream override settings](https://docs.render.com/log-streams#setup) for this owner.
+Configure the [log stream override settings](https://render.com/docs/log-streams#setup) for this owner.
 
 
 

--- a/docs/resources/postgres.md
+++ b/docs/resources/postgres.md
@@ -42,10 +42,10 @@ resource "render_postgres" "example" {
 - `database_user` (String) Name of the user in the postgres instance
 - `datadog_api_key` (String, Sensitive) Datadog API key to use when sending postgres metrics
 - `disk_size_gb` (Number) Disk size in GB.
-- `environment_id` (String) ID of the [project environment](https://docs.render.com/projects) that the resource belongs to
+- `environment_id` (String) ID of the [project environment](https://render.com/docs/projects) that the resource belongs to
 - `high_availability_enabled` (Boolean) Whether high availability is enabled for this postgres
 - `ip_allow_list` (Attributes Set) List of IP addresses that are allowed to connect to the instance. If no IP addresses are provided, only connections via the private network will be allowed. (see [below for nested schema](#nestedatt--ip_allow_list))
-- `log_stream_override` (Attributes) Configure the [log stream override settings](https://docs.render.com/log-streams#overriding-defaults) for this service. These will override the global log stream settings of the user or team. (see [below for nested schema](#nestedatt--log_stream_override))
+- `log_stream_override` (Attributes) Configure the [log stream override settings](https://render.com/docs/log-streams#overriding-defaults) for this service. These will override the global log stream settings of the user or team. (see [below for nested schema](#nestedatt--log_stream_override))
 - `read_replicas` (Attributes Set) List of read replicas. (see [below for nested schema](#nestedatt--read_replicas))
 
 ### Read-Only

--- a/docs/resources/private_service.md
+++ b/docs/resources/private_service.md
@@ -81,25 +81,25 @@ resource "render_private_service" "example" {
 
 - `name` (String) Name of the service
 - `plan` (String) Plan to use for the service. Must be one of `starter`, `standard`, `pro`, `pro_plus`, `pro_max`, `pro_ultra`, or a custom plan.
-- `region` (String) [Region](https://docs.render.com/regions) to deploy the service. One of `frankfurt`, `ohio`, `oregon`, `singapore`, `virginia`.
-- `runtime_source` (Attributes) Source of the build artifacts or image that run your service. You must provide one of [native_runtime](https://docs.render.com/native-runtimes), [docker](https://docs.render.com/docker), or [image](https://docs.render.com/deploy-an-image). (see [below for nested schema](#nestedatt--runtime_source))
+- `region` (String) [Region](https://render.com/docs/regions) to deploy the service. One of `frankfurt`, `ohio`, `oregon`, `singapore`, `virginia`.
+- `runtime_source` (Attributes) Source of the build artifacts or image that run your service. You must provide one of [native_runtime](https://render.com/docs/native-runtimes), [docker](https://render.com/docs/docker), or [image](https://render.com/docs/deploy-an-image). (see [below for nested schema](#nestedatt--runtime_source))
 
 ### Optional
 
-- `autoscaling` (Attributes) [Autoscaling settings](https://docs.render.com/scaling#autoscaling) for the service (see [below for nested schema](#nestedatt--autoscaling))
-- `disk` (Attributes) [Persistent disk](https://docs.render.com/disks) to attach to the service. (see [below for nested schema](#nestedatt--disk))
+- `autoscaling` (Attributes) [Autoscaling settings](https://render.com/docs/scaling#autoscaling) for the service (see [below for nested schema](#nestedatt--autoscaling))
+- `disk` (Attributes) [Persistent disk](https://render.com/docs/disks) to attach to the service. (see [below for nested schema](#nestedatt--disk))
 - `env_vars` (Attributes Map) Map of environment variable names to their values. (see [below for nested schema](#nestedatt--env_vars))
-- `environment_id` (String) ID of the [project environment](https://docs.render.com/projects) that the resource belongs to
-- `log_stream_override` (Attributes) Configure the [log stream override settings](https://docs.render.com/log-streams#overriding-defaults) for this service. These will override the global log stream settings of the user or team. (see [below for nested schema](#nestedatt--log_stream_override))
+- `environment_id` (String) ID of the [project environment](https://render.com/docs/projects) that the resource belongs to
+- `log_stream_override` (Attributes) Configure the [log stream override settings](https://render.com/docs/log-streams#overriding-defaults) for this service. These will override the global log stream settings of the user or team. (see [below for nested schema](#nestedatt--log_stream_override))
 - `max_shutdown_delay_seconds` (Number) The maximum amount of time (in seconds) that Render waits for your application process to exit gracefully after sending it a SIGTERM signal before sending a SIGKILL signal.
-- `notification_override` (Attributes) Configure the [notification settings](https://docs.render.com/notifications) for this service. These will override the global notification settings of the user or team. (see [below for nested schema](#nestedatt--notification_override))
+- `notification_override` (Attributes) Configure the [notification settings](https://render.com/docs/notifications) for this service. These will override the global notification settings of the user or team. (see [below for nested schema](#nestedatt--notification_override))
 - `num_instances` (Number) Number of replicas of the service to run. Defaults to 1 on service creation and current instance count on update. If you want to manage the service's instance count outside Terraform, leave num_instances unset.
 - `pre_deploy_command` (String) This command runs before starting your service. It is typically used for tasks like running a database migration or uploading assets to a CDN.
-- `previews` (Attributes) [Pull request previews](https://docs.render.com/pull-request-previews#pull-request-previews-git-backed) settings (see [below for nested schema](#nestedatt--previews))
-- `pull_request_previews_enabled` (Boolean, Deprecated) Enable [pull request previews](https://docs.render.com/pull-request-previews#pull-request-previews-git-backed) for the service.
-- `root_directory` (String) When you specify a [root directory](https://docs.render.com/monorepo-support#root-directory), Render runs all your commands in the specified directory and ignores changes outside the directory. Defaults to the repository root.
+- `previews` (Attributes) [Pull request previews](https://render.com/docs/pull-request-previews#pull-request-previews-git-backed) settings (see [below for nested schema](#nestedatt--previews))
+- `pull_request_previews_enabled` (Boolean, Deprecated) Enable [pull request previews](https://render.com/docs/pull-request-previews#pull-request-previews-git-backed) for the service.
+- `root_directory` (String) When you specify a [root directory](https://render.com/docs/monorepo-support#root-directory), Render runs all your commands in the specified directory and ignores changes outside the directory. Defaults to the repository root.
 - `secret_files` (Attributes Map) A map of secret file paths to their contents. (see [below for nested schema](#nestedatt--secret_files))
-- `start_command` (String) Command to run the service. When using native runtimes, this will be used as the start command and is required. For [Docker](https://docs.render.com/docker) and [image-backed](https://docs.render.com/deploy-an-image) services, this will override the default Docker command for the image.
+- `start_command` (String) Command to run the service. When using native runtimes, this will be used as the start command and is required. For [Docker](https://render.com/docs/docker) and [image-backed](https://render.com/docs/deploy-an-image) services, this will override the default Docker command for the image.
 
 ### Read-Only
 
@@ -112,9 +112,9 @@ resource "render_private_service" "example" {
 
 Optional:
 
-- `docker` (Attributes) Details for building and deploying a service [using a Dockerfile](https://docs.render.com/docker). (see [below for nested schema](#nestedatt--runtime_source--docker))
-- `image` (Attributes) Details for deploying a service using a [Docker image from a registry](https://docs.render.com/deploy-an-image). (see [below for nested schema](#nestedatt--runtime_source--image))
-- `native_runtime` (Attributes) Details for building and deploying a service using one of Render's [native runtimes](https://docs.render.com/native-runtimes). (see [below for nested schema](#nestedatt--runtime_source--native_runtime))
+- `docker` (Attributes) Details for building and deploying a service [using a Dockerfile](https://render.com/docs/docker). (see [below for nested schema](#nestedatt--runtime_source--docker))
+- `image` (Attributes) Details for deploying a service using a [Docker image from a registry](https://render.com/docs/deploy-an-image). (see [below for nested schema](#nestedatt--runtime_source--image))
+- `native_runtime` (Attributes) Details for building and deploying a service using one of Render's [native runtimes](https://render.com/docs/native-runtimes). (see [below for nested schema](#nestedatt--runtime_source--native_runtime))
 
 <a id="nestedatt--runtime_source--docker"></a>
 ### Nested Schema for `runtime_source.docker`
@@ -126,8 +126,8 @@ Required:
 
 Optional:
 
-- `auto_deploy` (Boolean) [Automatic deploy](https://docs.render.com/deploys#automatic-git-deploys) on every push to your repository, or changes to your service settings or environment.
-- `build_filter` (Attributes) Apply [build filters](https://docs.render.com/monorepo-support#build-filters) to configure which changes in your git repository trigger automatic deploys. If you've defined a root directory, you can still define paths outside of the root directory. (see [below for nested schema](#nestedatt--runtime_source--docker--build_filter))
+- `auto_deploy` (Boolean) [Automatic deploy](https://render.com/docs/deploys#automatic-git-deploys) on every push to your repository, or changes to your service settings or environment.
+- `build_filter` (Attributes) Apply [build filters](https://render.com/docs/monorepo-support#build-filters) to configure which changes in your git repository trigger automatic deploys. If you've defined a root directory, you can still define paths outside of the root directory. (see [below for nested schema](#nestedatt--runtime_source--docker--build_filter))
 - `context` (String) [Docker build context directory.](https://docs.docker.com/reference/dockerfile/#usage) This is relative to your repository root. Defaults to the root.
 - `dockerfile_path` (String) Path to your Dockerfile relative to the repository root. This is not relative to your Docker build context. Example: `./subdir/Dockerfile.`
 - `registry_credential_id` (String) ID of the registry credential to use when pulling the image.
@@ -168,8 +168,8 @@ Required:
 
 Optional:
 
-- `auto_deploy` (Boolean) [Automatic deploy](https://docs.render.com/deploys#automatic-git-deploys) on every push to your repository, or changes to your service settings or environment.
-- `build_filter` (Attributes) Apply [build filters](https://docs.render.com/monorepo-support#build-filters) to configure which changes in your git repository trigger automatic deploys. If you've defined a root directory, you can still define paths outside of the root directory. (see [below for nested schema](#nestedatt--runtime_source--native_runtime--build_filter))
+- `auto_deploy` (Boolean) [Automatic deploy](https://render.com/docs/deploys#automatic-git-deploys) on every push to your repository, or changes to your service settings or environment.
+- `build_filter` (Attributes) Apply [build filters](https://render.com/docs/monorepo-support#build-filters) to configure which changes in your git repository trigger automatic deploys. If you've defined a root directory, you can still define paths outside of the root directory. (see [below for nested schema](#nestedatt--runtime_source--native_runtime--build_filter))
 
 <a id="nestedatt--runtime_source--native_runtime--build_filter"></a>
 ### Nested Schema for `runtime_source.native_runtime.build_filter`
@@ -270,7 +270,7 @@ Optional:
 
 Optional:
 
-- `generation` (String) Generation mode for [pull request previews](https://docs.render.com/pull-request-previews#pull-request-previews-git-backed). One of `off`, `manual`, or `automatic`. Defaults to `off`.
+- `generation` (String) Generation mode for [pull request previews](https://render.com/docs/pull-request-previews#pull-request-previews-git-backed). One of `off`, `manual`, or `automatic`. Defaults to `off`.
 
 
 <a id="nestedatt--secret_files"></a>

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -3,12 +3,12 @@
 page_title: "render_project Resource - render"
 subcategory: ""
 description: |-
-  Project https://docs.render.com/projects to organize collections of environments and resources.
+  Project https://render.com/docs/projects to organize collections of environments and resources.
 ---
 
 # render_project (Resource)
 
-[Project](https://docs.render.com/projects) to organize collections of environments and resources.
+[Project](https://render.com/docs/projects) to organize collections of environments and resources.
 
 ## Example Usage
 

--- a/docs/resources/redis.md
+++ b/docs/resources/redis.md
@@ -35,13 +35,13 @@ resource "render_redis" "example" {
 
 - `max_memory_policy` (String) Policy for evicting keys when the maxmemory limit is reached. Valid values are `allkeys_lfu`, `allkeys_lru`, `allkeys_random`, `noeviction`, `volatile_lfu`, `volatile_lru`, `volatile_random`, `volatile_ttl.`
 - `name` (String) Name of the service
-- `region` (String) [Region](https://docs.render.com/regions) to deploy the service. One of `frankfurt`, `ohio`, `oregon`, `singapore`, `virginia`.
+- `region` (String) [Region](https://render.com/docs/regions) to deploy the service. One of `frankfurt`, `ohio`, `oregon`, `singapore`, `virginia`.
 
 ### Optional
 
-- `environment_id` (String) ID of the [project environment](https://docs.render.com/projects) that the resource belongs to
+- `environment_id` (String) ID of the [project environment](https://render.com/docs/projects) that the resource belongs to
 - `ip_allow_list` (Attributes Set) List of IP addresses that are allowed to connect to the instance. If no IP addresses are provided, only connections via the private network will be allowed. (see [below for nested schema](#nestedatt--ip_allow_list))
-- `log_stream_override` (Attributes) Configure the [log stream override settings](https://docs.render.com/log-streams#overriding-defaults) for this service. These will override the global log stream settings of the user or team. (see [below for nested schema](#nestedatt--log_stream_override))
+- `log_stream_override` (Attributes) Configure the [log stream override settings](https://render.com/docs/log-streams#overriding-defaults) for this service. These will override the global log stream settings of the user or team. (see [below for nested schema](#nestedatt--log_stream_override))
 - `plan` (String) Plan for the Redis instance. Must be one of `free`, `starter`, `standard`, `pro`, `pro_plus`, or a custom plan.
 
 ### Read-Only

--- a/docs/resources/static_site.md
+++ b/docs/resources/static_site.md
@@ -106,18 +106,18 @@ resource "render_static_site" "example" {
 
 ### Optional
 
-- `auto_deploy` (Boolean) [Automatic deploy](https://docs.render.com/deploys#automatic-git-deploys) on every push to your repository, or changes to your service settings or environment.
-- `build_filter` (Attributes) Apply [build filters](https://docs.render.com/monorepo-support#build-filters) to configure which changes in your git repository trigger automatic deploys. If you've defined a root directory, you can still define paths outside of the root directory. (see [below for nested schema](#nestedatt--build_filter))
+- `auto_deploy` (Boolean) [Automatic deploy](https://render.com/docs/deploys#automatic-git-deploys) on every push to your repository, or changes to your service settings or environment.
+- `build_filter` (Attributes) Apply [build filters](https://render.com/docs/monorepo-support#build-filters) to configure which changes in your git repository trigger automatic deploys. If you've defined a root directory, you can still define paths outside of the root directory. (see [below for nested schema](#nestedatt--build_filter))
 - `custom_domains` (Attributes Set) Custom domains to associate with the service. (see [below for nested schema](#nestedatt--custom_domains))
 - `env_vars` (Attributes Map) Map of environment variable names to their values. (see [below for nested schema](#nestedatt--env_vars))
-- `environment_id` (String) ID of the [project environment](https://docs.render.com/projects) that the resource belongs to
-- `headers` (Attributes Set) List of [headers](https://docs.render.com/static-site-headers) to apply to requests for static sites (see [below for nested schema](#nestedatt--headers))
-- `notification_override` (Attributes) Configure the [notification settings](https://docs.render.com/notifications) for this service. These will override the global notification settings of the user or team. (see [below for nested schema](#nestedatt--notification_override))
-- `previews` (Attributes) [Pull request previews](https://docs.render.com/pull-request-previews#pull-request-previews-git-backed) settings (see [below for nested schema](#nestedatt--previews))
+- `environment_id` (String) ID of the [project environment](https://render.com/docs/projects) that the resource belongs to
+- `headers` (Attributes Set) List of [headers](https://render.com/docs/static-site-headers) to apply to requests for static sites (see [below for nested schema](#nestedatt--headers))
+- `notification_override` (Attributes) Configure the [notification settings](https://render.com/docs/notifications) for this service. These will override the global notification settings of the user or team. (see [below for nested schema](#nestedatt--notification_override))
+- `previews` (Attributes) [Pull request previews](https://render.com/docs/pull-request-previews#pull-request-previews-git-backed) settings (see [below for nested schema](#nestedatt--previews))
 - `publish_path` (String) Path to the directory that contains the build artifacts to publish for a static site. Defaults to public/.
-- `pull_request_previews_enabled` (Boolean, Deprecated) Enable [pull request previews](https://docs.render.com/pull-request-previews#pull-request-previews-git-backed) for the service.
-- `root_directory` (String) When you specify a [root directory](https://docs.render.com/monorepo-support#root-directory), Render runs all your commands in the specified directory and ignores changes outside the directory. Defaults to the repository root.
-- `routes` (Attributes List) List of [redirect and rewrite rules](https://docs.render.com/redirects-rewrites) to apply to a static site. (see [below for nested schema](#nestedatt--routes))
+- `pull_request_previews_enabled` (Boolean, Deprecated) Enable [pull request previews](https://render.com/docs/pull-request-previews#pull-request-previews-git-backed) for the service.
+- `root_directory` (String) When you specify a [root directory](https://render.com/docs/monorepo-support#root-directory), Render runs all your commands in the specified directory and ignores changes outside the directory. Defaults to the repository root.
+- `routes` (Attributes List) List of [redirect and rewrite rules](https://render.com/docs/redirects-rewrites) to apply to a static site. (see [below for nested schema](#nestedatt--routes))
 
 ### Read-Only
 
@@ -182,7 +182,7 @@ Optional:
 
 Optional:
 
-- `generation` (String) Generation mode for [pull request previews](https://docs.render.com/pull-request-previews#pull-request-previews-git-backed). One of `off`, `manual`, or `automatic`. Defaults to `off`.
+- `generation` (String) Generation mode for [pull request previews](https://render.com/docs/pull-request-previews#pull-request-previews-git-backed). One of `off`, `manual`, or `automatic`. Defaults to `off`.
 
 
 <a id="nestedatt--routes"></a>

--- a/docs/resources/web_service.md
+++ b/docs/resources/web_service.md
@@ -71,28 +71,28 @@ resource "render_web_service" "web" {
 
 - `name` (String) Name of the service
 - `plan` (String) Plan to use for the service. Must be one of `starter`, `standard`, `pro`, `pro_plus`, `pro_max`, `pro_ultra`, or a custom plan.
-- `region` (String) [Region](https://docs.render.com/regions) to deploy the service. One of `frankfurt`, `ohio`, `oregon`, `singapore`, `virginia`.
-- `runtime_source` (Attributes) Source of the build artifacts or image that run your service. You must provide one of [native_runtime](https://docs.render.com/native-runtimes), [docker](https://docs.render.com/docker), or [image](https://docs.render.com/deploy-an-image). (see [below for nested schema](#nestedatt--runtime_source))
+- `region` (String) [Region](https://render.com/docs/regions) to deploy the service. One of `frankfurt`, `ohio`, `oregon`, `singapore`, `virginia`.
+- `runtime_source` (Attributes) Source of the build artifacts or image that run your service. You must provide one of [native_runtime](https://render.com/docs/native-runtimes), [docker](https://render.com/docs/docker), or [image](https://render.com/docs/deploy-an-image). (see [below for nested schema](#nestedatt--runtime_source))
 
 ### Optional
 
-- `autoscaling` (Attributes) [Autoscaling settings](https://docs.render.com/scaling#autoscaling) for the service (see [below for nested schema](#nestedatt--autoscaling))
+- `autoscaling` (Attributes) [Autoscaling settings](https://render.com/docs/scaling#autoscaling) for the service (see [below for nested schema](#nestedatt--autoscaling))
 - `custom_domains` (Attributes Set) Custom domains to associate with the service. (see [below for nested schema](#nestedatt--custom_domains))
-- `disk` (Attributes) [Persistent disk](https://docs.render.com/disks) to attach to the service. (see [below for nested schema](#nestedatt--disk))
+- `disk` (Attributes) [Persistent disk](https://render.com/docs/disks) to attach to the service. (see [below for nested schema](#nestedatt--disk))
 - `env_vars` (Attributes Map) Map of environment variable names to their values. (see [below for nested schema](#nestedatt--env_vars))
-- `environment_id` (String) ID of the [project environment](https://docs.render.com/projects) that the resource belongs to
-- `health_check_path` (String) If you're running a server, enter the path where your server will always return a 200 OK response. We use it to monitor your app and for [zero downtime deploys](https://docs.render.com/deploys#zero-downtime-deploys).
-- `log_stream_override` (Attributes) Configure the [log stream override settings](https://docs.render.com/log-streams#overriding-defaults) for this service. These will override the global log stream settings of the user or team. (see [below for nested schema](#nestedatt--log_stream_override))
+- `environment_id` (String) ID of the [project environment](https://render.com/docs/projects) that the resource belongs to
+- `health_check_path` (String) If you're running a server, enter the path where your server will always return a 200 OK response. We use it to monitor your app and for [zero downtime deploys](https://render.com/docs/deploys#zero-downtime-deploys).
+- `log_stream_override` (Attributes) Configure the [log stream override settings](https://render.com/docs/log-streams#overriding-defaults) for this service. These will override the global log stream settings of the user or team. (see [below for nested schema](#nestedatt--log_stream_override))
 - `maintenance_mode` (Attributes) Maintenance mode settings for the service. (see [below for nested schema](#nestedatt--maintenance_mode))
 - `max_shutdown_delay_seconds` (Number) The maximum amount of time (in seconds) that Render waits for your application process to exit gracefully after sending it a SIGTERM signal before sending a SIGKILL signal.
-- `notification_override` (Attributes) Configure the [notification settings](https://docs.render.com/notifications) for this service. These will override the global notification settings of the user or team. (see [below for nested schema](#nestedatt--notification_override))
+- `notification_override` (Attributes) Configure the [notification settings](https://render.com/docs/notifications) for this service. These will override the global notification settings of the user or team. (see [below for nested schema](#nestedatt--notification_override))
 - `num_instances` (Number) Number of replicas of the service to run. Defaults to 1 on service creation and current instance count on update. If you want to manage the service's instance count outside Terraform, leave num_instances unset.
 - `pre_deploy_command` (String) This command runs before starting your service. It is typically used for tasks like running a database migration or uploading assets to a CDN.
-- `previews` (Attributes) [Pull request previews](https://docs.render.com/pull-request-previews#pull-request-previews-git-backed) settings (see [below for nested schema](#nestedatt--previews))
-- `pull_request_previews_enabled` (Boolean, Deprecated) Enable [pull request previews](https://docs.render.com/pull-request-previews#pull-request-previews-git-backed) for the service.
-- `root_directory` (String) When you specify a [root directory](https://docs.render.com/monorepo-support#root-directory), Render runs all your commands in the specified directory and ignores changes outside the directory. Defaults to the repository root.
+- `previews` (Attributes) [Pull request previews](https://render.com/docs/pull-request-previews#pull-request-previews-git-backed) settings (see [below for nested schema](#nestedatt--previews))
+- `pull_request_previews_enabled` (Boolean, Deprecated) Enable [pull request previews](https://render.com/docs/pull-request-previews#pull-request-previews-git-backed) for the service.
+- `root_directory` (String) When you specify a [root directory](https://render.com/docs/monorepo-support#root-directory), Render runs all your commands in the specified directory and ignores changes outside the directory. Defaults to the repository root.
 - `secret_files` (Attributes Map) A map of secret file paths to their contents. (see [below for nested schema](#nestedatt--secret_files))
-- `start_command` (String) Command to run the service. When using native runtimes, this will be used as the start command and is required. For [Docker](https://docs.render.com/docker) and [image-backed](https://docs.render.com/deploy-an-image) services, this will override the default Docker command for the image.
+- `start_command` (String) Command to run the service. When using native runtimes, this will be used as the start command and is required. For [Docker](https://render.com/docs/docker) and [image-backed](https://render.com/docs/deploy-an-image) services, this will override the default Docker command for the image.
 
 ### Read-Only
 
@@ -105,9 +105,9 @@ resource "render_web_service" "web" {
 
 Optional:
 
-- `docker` (Attributes) Details for building and deploying a service [using a Dockerfile](https://docs.render.com/docker). (see [below for nested schema](#nestedatt--runtime_source--docker))
-- `image` (Attributes) Details for deploying a service using a [Docker image from a registry](https://docs.render.com/deploy-an-image). (see [below for nested schema](#nestedatt--runtime_source--image))
-- `native_runtime` (Attributes) Details for building and deploying a service using one of Render's [native runtimes](https://docs.render.com/native-runtimes). (see [below for nested schema](#nestedatt--runtime_source--native_runtime))
+- `docker` (Attributes) Details for building and deploying a service [using a Dockerfile](https://render.com/docs/docker). (see [below for nested schema](#nestedatt--runtime_source--docker))
+- `image` (Attributes) Details for deploying a service using a [Docker image from a registry](https://render.com/docs/deploy-an-image). (see [below for nested schema](#nestedatt--runtime_source--image))
+- `native_runtime` (Attributes) Details for building and deploying a service using one of Render's [native runtimes](https://render.com/docs/native-runtimes). (see [below for nested schema](#nestedatt--runtime_source--native_runtime))
 
 <a id="nestedatt--runtime_source--docker"></a>
 ### Nested Schema for `runtime_source.docker`
@@ -119,8 +119,8 @@ Required:
 
 Optional:
 
-- `auto_deploy` (Boolean) [Automatic deploy](https://docs.render.com/deploys#automatic-git-deploys) on every push to your repository, or changes to your service settings or environment.
-- `build_filter` (Attributes) Apply [build filters](https://docs.render.com/monorepo-support#build-filters) to configure which changes in your git repository trigger automatic deploys. If you've defined a root directory, you can still define paths outside of the root directory. (see [below for nested schema](#nestedatt--runtime_source--docker--build_filter))
+- `auto_deploy` (Boolean) [Automatic deploy](https://render.com/docs/deploys#automatic-git-deploys) on every push to your repository, or changes to your service settings or environment.
+- `build_filter` (Attributes) Apply [build filters](https://render.com/docs/monorepo-support#build-filters) to configure which changes in your git repository trigger automatic deploys. If you've defined a root directory, you can still define paths outside of the root directory. (see [below for nested schema](#nestedatt--runtime_source--docker--build_filter))
 - `context` (String) [Docker build context directory.](https://docs.docker.com/reference/dockerfile/#usage) This is relative to your repository root. Defaults to the root.
 - `dockerfile_path` (String) Path to your Dockerfile relative to the repository root. This is not relative to your Docker build context. Example: `./subdir/Dockerfile.`
 - `registry_credential_id` (String) ID of the registry credential to use when pulling the image.
@@ -161,8 +161,8 @@ Required:
 
 Optional:
 
-- `auto_deploy` (Boolean) [Automatic deploy](https://docs.render.com/deploys#automatic-git-deploys) on every push to your repository, or changes to your service settings or environment.
-- `build_filter` (Attributes) Apply [build filters](https://docs.render.com/monorepo-support#build-filters) to configure which changes in your git repository trigger automatic deploys. If you've defined a root directory, you can still define paths outside of the root directory. (see [below for nested schema](#nestedatt--runtime_source--native_runtime--build_filter))
+- `auto_deploy` (Boolean) [Automatic deploy](https://render.com/docs/deploys#automatic-git-deploys) on every push to your repository, or changes to your service settings or environment.
+- `build_filter` (Attributes) Apply [build filters](https://render.com/docs/monorepo-support#build-filters) to configure which changes in your git repository trigger automatic deploys. If you've defined a root directory, you can still define paths outside of the root directory. (see [below for nested schema](#nestedatt--runtime_source--native_runtime--build_filter))
 
 <a id="nestedatt--runtime_source--native_runtime--build_filter"></a>
 ### Nested Schema for `runtime_source.native_runtime.build_filter`
@@ -287,7 +287,7 @@ Optional:
 
 Optional:
 
-- `generation` (String) Generation mode for [pull request previews](https://docs.render.com/pull-request-previews#pull-request-previews-git-backed). One of `off`, `manual`, or `automatic`. Defaults to `off`.
+- `generation` (String) Generation mode for [pull request previews](https://render.com/docs/pull-request-previews#pull-request-previews-git-backed). One of `off`, `manual`, or `automatic`. Defaults to `off`.
 
 
 <a id="nestedatt--secret_files"></a>

--- a/internal/client/types_gen.go
+++ b/internal/client/types_gen.go
@@ -827,7 +827,7 @@ type InstanceId = string
 type MaintenanceMode struct {
 	Enabled bool `json:"enabled"`
 
-	// Uri The page to be served when [maintenance mode](https://docs.render.com/maintenance-mode) is enabled. When empty, the default maintenance mode page is served.
+	// Uri The page to be served when [maintenance mode](https://render.com/docs/maintenance-mode) is enabled. When empty, the default maintenance mode page is served.
 	Uri string `json:"uri"`
 }
 
@@ -1959,25 +1959,25 @@ type ListLogsParams struct {
 	// Instance Filter logs by the instance they were emitted from. An instance is the id of a specific running server.
 	Instance *externalRef5.LogFilterInstance `form:"instance,omitempty" json:"instance,omitempty"`
 
-	// Host Filter request logs by their host. [Wildcards and regex](https://docs.render.com/logging#wildcards-and-regular-expressions) are supported.
+	// Host Filter request logs by their host. [Wildcards and regex](https://render.com/docs/logging#wildcards-and-regular-expressions) are supported.
 	Host *externalRef5.LogFilterHost `form:"host,omitempty" json:"host,omitempty"`
 
-	// StatusCode Filter request logs by their status code. [Wildcards and regex](https://docs.render.com/logging#wildcards-and-regular-expressions) are supported.
+	// StatusCode Filter request logs by their status code. [Wildcards and regex](https://render.com/docs/logging#wildcards-and-regular-expressions) are supported.
 	StatusCode *externalRef5.LogFilterStatusCode `form:"statusCode,omitempty" json:"statusCode,omitempty"`
 
-	// Method Filter request logs by their requests method. [Wildcards and regex](https://docs.render.com/logging#wildcards-and-regular-expressions) are supported.
+	// Method Filter request logs by their requests method. [Wildcards and regex](https://render.com/docs/logging#wildcards-and-regular-expressions) are supported.
 	Method *externalRef5.LogFilterMethod `form:"method,omitempty" json:"method,omitempty"`
 
-	// Level Filter logs by their severity level. [Wildcards and regex](https://docs.render.com/logging#wildcards-and-regular-expressions) are supported.
+	// Level Filter logs by their severity level. [Wildcards and regex](https://render.com/docs/logging#wildcards-and-regular-expressions) are supported.
 	Level *externalRef5.LogFilterLevel `form:"level,omitempty" json:"level,omitempty"`
 
 	// Type Filter logs by their type. Types include `app` for application logs, `request` for request logs, and `build` for build logs. You can find the full set of types available for a query by using the `GET /logs/values` endpoint.
 	Type *externalRef5.LogFilterType `form:"type,omitempty" json:"type,omitempty"`
 
-	// Text Filter by the text of the logs. [Wildcards and regex](https://docs.render.com/logging#wildcards-and-regular-expressions) are supported.
+	// Text Filter by the text of the logs. [Wildcards and regex](https://render.com/docs/logging#wildcards-and-regular-expressions) are supported.
 	Text *externalRef5.LogFilterText `form:"text,omitempty" json:"text,omitempty"`
 
-	// Path Filter request logs by their path. [Wildcards and regex](https://docs.render.com/logging#wildcards-and-regular-expressions) are supported.
+	// Path Filter request logs by their path. [Wildcards and regex](https://render.com/docs/logging#wildcards-and-regular-expressions) are supported.
 	Path *externalRef5.LogFilterPath `form:"path,omitempty" json:"path,omitempty"`
 
 	// Limit The maximum number of items to return. For details, see [Pagination](https://api-docs.render.com/reference/pagination).
@@ -2026,25 +2026,25 @@ type SubscribeLogsParams struct {
 	// Instance Filter logs by the instance they were emitted from. An instance is the id of a specific running server.
 	Instance *externalRef5.LogFilterInstance `form:"instance,omitempty" json:"instance,omitempty"`
 
-	// Host Filter request logs by their host. [Wildcards and regex](https://docs.render.com/logging#wildcards-and-regular-expressions) are supported.
+	// Host Filter request logs by their host. [Wildcards and regex](https://render.com/docs/logging#wildcards-and-regular-expressions) are supported.
 	Host *externalRef5.LogFilterHost `form:"host,omitempty" json:"host,omitempty"`
 
-	// StatusCode Filter request logs by their status code. [Wildcards and regex](https://docs.render.com/logging#wildcards-and-regular-expressions) are supported.
+	// StatusCode Filter request logs by their status code. [Wildcards and regex](https://render.com/docs/logging#wildcards-and-regular-expressions) are supported.
 	StatusCode *externalRef5.LogFilterStatusCode `form:"statusCode,omitempty" json:"statusCode,omitempty"`
 
-	// Method Filter request logs by their requests method. [Wildcards and regex](https://docs.render.com/logging#wildcards-and-regular-expressions) are supported.
+	// Method Filter request logs by their requests method. [Wildcards and regex](https://render.com/docs/logging#wildcards-and-regular-expressions) are supported.
 	Method *externalRef5.LogFilterMethod `form:"method,omitempty" json:"method,omitempty"`
 
-	// Level Filter logs by their severity level. [Wildcards and regex](https://docs.render.com/logging#wildcards-and-regular-expressions) are supported.
+	// Level Filter logs by their severity level. [Wildcards and regex](https://render.com/docs/logging#wildcards-and-regular-expressions) are supported.
 	Level *externalRef5.LogFilterLevel `form:"level,omitempty" json:"level,omitempty"`
 
 	// Type Filter logs by their type. Types include `app` for application logs, `request` for request logs, and `build` for build logs. You can find the full set of types available for a query by using the `GET /logs/values` endpoint.
 	Type *externalRef5.LogFilterType `form:"type,omitempty" json:"type,omitempty"`
 
-	// Text Filter by the text of the logs. [Wildcards and regex](https://docs.render.com/logging#wildcards-and-regular-expressions) are supported.
+	// Text Filter by the text of the logs. [Wildcards and regex](https://render.com/docs/logging#wildcards-and-regular-expressions) are supported.
 	Text *externalRef5.LogFilterText `form:"text,omitempty" json:"text,omitempty"`
 
-	// Path Filter request logs by their path. [Wildcards and regex](https://docs.render.com/logging#wildcards-and-regular-expressions) are supported.
+	// Path Filter request logs by their path. [Wildcards and regex](https://render.com/docs/logging#wildcards-and-regular-expressions) are supported.
 	Path *externalRef5.LogFilterPath `form:"path,omitempty" json:"path,omitempty"`
 
 	// Limit The maximum number of items to return. For details, see [Pagination](https://api-docs.render.com/reference/pagination).
@@ -2075,25 +2075,25 @@ type ListLogsValuesParams struct {
 	// Instance Filter logs by the instance they were emitted from. An instance is the id of a specific running server.
 	Instance *externalRef5.LogFilterInstance `form:"instance,omitempty" json:"instance,omitempty"`
 
-	// Host Filter request logs by their host. [Wildcards and regex](https://docs.render.com/logging#wildcards-and-regular-expressions) are supported.
+	// Host Filter request logs by their host. [Wildcards and regex](https://render.com/docs/logging#wildcards-and-regular-expressions) are supported.
 	Host *externalRef5.LogFilterHost `form:"host,omitempty" json:"host,omitempty"`
 
-	// StatusCode Filter request logs by their status code. [Wildcards and regex](https://docs.render.com/logging#wildcards-and-regular-expressions) are supported.
+	// StatusCode Filter request logs by their status code. [Wildcards and regex](https://render.com/docs/logging#wildcards-and-regular-expressions) are supported.
 	StatusCode *externalRef5.LogFilterStatusCode `form:"statusCode,omitempty" json:"statusCode,omitempty"`
 
-	// Method Filter request logs by their requests method. [Wildcards and regex](https://docs.render.com/logging#wildcards-and-regular-expressions) are supported.
+	// Method Filter request logs by their requests method. [Wildcards and regex](https://render.com/docs/logging#wildcards-and-regular-expressions) are supported.
 	Method *externalRef5.LogFilterMethod `form:"method,omitempty" json:"method,omitempty"`
 
-	// Level Filter logs by their severity level. [Wildcards and regex](https://docs.render.com/logging#wildcards-and-regular-expressions) are supported.
+	// Level Filter logs by their severity level. [Wildcards and regex](https://render.com/docs/logging#wildcards-and-regular-expressions) are supported.
 	Level *externalRef5.LogFilterLevel `form:"level,omitempty" json:"level,omitempty"`
 
 	// Type Filter logs by their type. Types include `app` for application logs, `request` for request logs, and `build` for build logs. You can find the full set of types available for a query by using the `GET /logs/values` endpoint.
 	Type *externalRef5.LogFilterType `form:"type,omitempty" json:"type,omitempty"`
 
-	// Text Filter by the text of the logs. [Wildcards and regex](https://docs.render.com/logging#wildcards-and-regular-expressions) are supported.
+	// Text Filter by the text of the logs. [Wildcards and regex](https://render.com/docs/logging#wildcards-and-regular-expressions) are supported.
 	Text *externalRef5.LogFilterText `form:"text,omitempty" json:"text,omitempty"`
 
-	// Path Filter request logs by their path. [Wildcards and regex](https://docs.render.com/logging#wildcards-and-regular-expressions) are supported.
+	// Path Filter request logs by their path. [Wildcards and regex](https://render.com/docs/logging#wildcards-and-regular-expressions) are supported.
 	Path *externalRef5.LogFilterPath `form:"path,omitempty" json:"path,omitempty"`
 
 	// Limit The maximum number of items to return. For details, see [Pagination](https://api-docs.render.com/reference/pagination).

--- a/internal/provider/backgroundworker/resource/testdata/docker_cassette.yaml
+++ b/internal/provider/backgroundworker/resource/testdata/docker_cassette.yaml
@@ -2370,7 +2370,7 @@ interactions:
         content_length: 584
         uncompressed: false
         body: |
-            {"id":"dep-crfi4pa39eqs702lfe9g","commit":{"id":"bca0502a57b3f3a1a935ebdf8e85d0d704038bd3","message":"Fix render.yaml: \"env\" --\u003e \"runtime\" (#3)\n\nPer the `render.yaml` schema, `env` is still supported but is superseded by `runtime`. Using `env` will show a schema error if using the `render.yaml` validator in an IDE like VS Code.\r\n\r\nSee https://docs.render.com/blueprint-spec#runtime","createdAt":"2024-08-14T21:28:24Z"},"status":"build_in_progress","trigger":"api","createdAt":"2024-09-09T16:29:26.485154Z","updatedAt":"2024-09-09T16:29:26.485154Z","finishedAt":null}
+            {"id":"dep-crfi4pa39eqs702lfe9g","commit":{"id":"bca0502a57b3f3a1a935ebdf8e85d0d704038bd3","message":"Fix render.yaml: \"env\" --\u003e \"runtime\" (#3)\n\nPer the `render.yaml` schema, `env` is still supported but is superseded by `runtime`. Using `env` will show a schema error if using the `render.yaml` validator in an IDE like VS Code.\r\n\r\nSee https://render.com/docs/blueprint-spec#runtime","createdAt":"2024-08-14T21:28:24Z"},"status":"build_in_progress","trigger":"api","createdAt":"2024-09-09T16:29:26.485154Z","updatedAt":"2024-09-09T16:29:26.485154Z","finishedAt":null}
         headers:
             Content-Length:
                 - "584"

--- a/internal/provider/cronjob/resource/testdata/docker_cassette.yaml
+++ b/internal/provider/cronjob/resource/testdata/docker_cassette.yaml
@@ -2080,7 +2080,7 @@ interactions:
         content_length: 584
         uncompressed: false
         body: |
-            {"id":"dep-crfi56i39eqs702lfg0g","commit":{"id":"bca0502a57b3f3a1a935ebdf8e85d0d704038bd3","message":"Fix render.yaml: \"env\" --\u003e \"runtime\" (#3)\n\nPer the `render.yaml` schema, `env` is still supported but is superseded by `runtime`. Using `env` will show a schema error if using the `render.yaml` validator in an IDE like VS Code.\r\n\r\nSee https://docs.render.com/blueprint-spec#runtime","createdAt":"2024-08-14T21:28:24Z"},"status":"build_in_progress","trigger":"api","createdAt":"2024-09-09T16:30:19.926213Z","updatedAt":"2024-09-09T16:30:19.926213Z","finishedAt":null}
+            {"id":"dep-crfi56i39eqs702lfg0g","commit":{"id":"bca0502a57b3f3a1a935ebdf8e85d0d704038bd3","message":"Fix render.yaml: \"env\" --\u003e \"runtime\" (#3)\n\nPer the `render.yaml` schema, `env` is still supported but is superseded by `runtime`. Using `env` will show a schema error if using the `render.yaml` validator in an IDE like VS Code.\r\n\r\nSee https://render.com/docs/blueprint-spec#runtime","createdAt":"2024-08-14T21:28:24Z"},"status":"build_in_progress","trigger":"api","createdAt":"2024-09-09T16:30:19.926213Z","updatedAt":"2024-09-09T16:30:19.926213Z","finishedAt":null}
         headers:
             Content-Length:
                 - "584"

--- a/internal/provider/logstreams/datasource/schema.go
+++ b/internal/provider/logstreams/datasource/schema.go
@@ -25,6 +25,6 @@ func Schema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "The endpoint to send logs to.",
 			},
 		},
-		Description: "Configure the [log stream override settings](https://docs.render.com/log-streams#setup) for this owner.",
+		Description: "Configure the [log stream override settings](https://render.com/docs/log-streams#setup) for this owner.",
 	}
 }

--- a/internal/provider/logstreams/resource/schema.go
+++ b/internal/provider/logstreams/resource/schema.go
@@ -31,6 +31,6 @@ func Schema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "The token to use when sending logs.",
 			},
 		},
-		Description: "Configure the [log stream override settings](https://docs.render.com/log-streams#setup) for this owner.",
+		Description: "Configure the [log stream override settings](https://render.com/docs/log-streams#setup) for this owner.",
 	}
 }

--- a/internal/provider/privateservice/resource/testdata/docker_cassette.yaml
+++ b/internal/provider/privateservice/resource/testdata/docker_cassette.yaml
@@ -2370,7 +2370,7 @@ interactions:
         content_length: 584
         uncompressed: false
         body: |
-            {"id":"dep-crfhv9c8m55c70055thg","commit":{"id":"bca0502a57b3f3a1a935ebdf8e85d0d704038bd3","message":"Fix render.yaml: \"env\" --\u003e \"runtime\" (#3)\n\nPer the `render.yaml` schema, `env` is still supported but is superseded by `runtime`. Using `env` will show a schema error if using the `render.yaml` validator in an IDE like VS Code.\r\n\r\nSee https://docs.render.com/blueprint-spec#runtime","createdAt":"2024-08-14T21:28:24Z"},"status":"build_in_progress","trigger":"api","createdAt":"2024-09-09T16:17:43.277301Z","updatedAt":"2024-09-09T16:17:43.277301Z","finishedAt":null}
+            {"id":"dep-crfhv9c8m55c70055thg","commit":{"id":"bca0502a57b3f3a1a935ebdf8e85d0d704038bd3","message":"Fix render.yaml: \"env\" --\u003e \"runtime\" (#3)\n\nPer the `render.yaml` schema, `env` is still supported but is superseded by `runtime`. Using `env` will show a schema error if using the `render.yaml` validator in an IDE like VS Code.\r\n\r\nSee https://render.com/docs/blueprint-spec#runtime","createdAt":"2024-08-14T21:28:24Z"},"status":"build_in_progress","trigger":"api","createdAt":"2024-09-09T16:17:43.277301Z","updatedAt":"2024-09-09T16:17:43.277301Z","finishedAt":null}
         headers:
             Content-Length:
                 - "584"

--- a/internal/provider/project/resource/schema.go
+++ b/internal/provider/project/resource/schema.go
@@ -11,7 +11,7 @@ import (
 func Schema(ctx context.Context) schema.Schema {
 	return schema.Schema{
 		Description:         "Project to organize collections of environments and resources",
-		MarkdownDescription: "[Project](https://docs.render.com/projects) to organize collections of environments and resources.",
+		MarkdownDescription: "[Project](https://render.com/docs/projects) to organize collections of environments and resources.",
 		Attributes: map[string]schema.Attribute{
 			"id":           resource.ProjectID,
 			"name":         resource.ProjectName,

--- a/internal/provider/types/datasource/logstreamoverride.go
+++ b/internal/provider/types/datasource/logstreamoverride.go
@@ -31,5 +31,5 @@ var LogStreamOverride = schema.SingleNestedAttribute{
 	},
 	Optional:    true,
 	Computed:    true,
-	Description: "Configure the [log stream override settings](https://docs.render.com/log-streams#overriding-defaults) for this service. These will override the global log stream settings of the user or team.",
+	Description: "Configure the [log stream override settings](https://render.com/docs/log-streams#overriding-defaults) for this service. These will override the global log stream settings of the user or team.",
 }

--- a/internal/provider/types/datasource/runtimesource.go
+++ b/internal/provider/types/datasource/runtimesource.go
@@ -21,7 +21,7 @@ var AutoDeploy = schema.BoolAttribute{
 	Computed:            true,
 	Default:             booldefault.StaticBool(true),
 	Description:         "Automatic deploy on every push to your repository, or changes to your service settings or environment.",
-	MarkdownDescription: "[Automatic deploy](https://docs.render.com/deploys#automatic-git-deploys) on every push to your repository, or changes to your service settings or environment.",
+	MarkdownDescription: "[Automatic deploy](https://render.com/docs/deploys#automatic-git-deploys) on every push to your repository, or changes to your service settings or environment.",
 }
 
 var DockerDetails = schema.SingleNestedAttribute{

--- a/internal/provider/types/datasource/services.go
+++ b/internal/provider/types/datasource/services.go
@@ -95,7 +95,7 @@ var Region = schema.StringAttribute{
 var HealthCheckPath = schema.StringAttribute{
 	Computed:            true,
 	Description:         "If you're running a server, enter the path where your server will always return a 200 OK response. We use it to monitor your app and for zero downtime deploys.",
-	MarkdownDescription: "If you're running a server, enter the path where your server will always return a 200 OK response. We use it to monitor your app and for [zero downtime deploys](https://docs.render.com/deploys#zero-downtime-deploys).",
+	MarkdownDescription: "If you're running a server, enter the path where your server will always return a 200 OK response. We use it to monitor your app and for [zero downtime deploys](https://render.com/docs/deploys#zero-downtime-deploys).",
 }
 
 var MaintenanceMode = schema.SingleNestedAttribute{
@@ -188,12 +188,12 @@ var RootDirectory = schema.StringAttribute{
 var Previews = schema.SingleNestedAttribute{
 	Computed:            true,
 	Description:         "Pull request previews settings",
-	MarkdownDescription: "[Pull request previews](https://docs.render.com/pull-request-previews#pull-request-previews-git-backed) settings",
+	MarkdownDescription: "[Pull request previews](https://render.com/docs/pull-request-previews#pull-request-previews-git-backed) settings",
 	Attributes: map[string]schema.Attribute{
 		"generation": schema.StringAttribute{
 			Computed:            true,
 			Description:         "Generation mode for pull request previews. One of `off`, `manual`, or `automatic`. Defaults to `off`.",
-			MarkdownDescription: "Generation mode for [pull request previews](https://docs.render.com/pull-request-previews#pull-request-previews-git-backed). One of `off`, `manual`, or `automatic`. Defaults to `off`.",
+			MarkdownDescription: "Generation mode for [pull request previews](https://render.com/docs/pull-request-previews#pull-request-previews-git-backed). One of `off`, `manual`, or `automatic`. Defaults to `off`.",
 		},
 	},
 }

--- a/internal/provider/types/resource/autoscaling.go
+++ b/internal/provider/types/resource/autoscaling.go
@@ -8,7 +8,7 @@ import (
 
 var Autoscaling = schema.SingleNestedAttribute{
 	Description:         "Autoscaling settings for the service",
-	MarkdownDescription: "[Autoscaling settings](https://docs.render.com/scaling#autoscaling) for the service",
+	MarkdownDescription: "[Autoscaling settings](https://render.com/docs/scaling#autoscaling) for the service",
 	Attributes: map[string]schema.Attribute{
 		"criteria": schema.SingleNestedAttribute{
 			Attributes: map[string]schema.Attribute{

--- a/internal/provider/types/resource/environment.go
+++ b/internal/provider/types/resource/environment.go
@@ -14,7 +14,7 @@ import (
 var ResourceEnvironmentID = schema.StringAttribute{
 	Optional:            true,
 	Description:         "ID of the project environment that the resource belongs to",
-	MarkdownDescription: "ID of the [project environment](https://docs.render.com/projects) that the resource belongs to",
+	MarkdownDescription: "ID of the [project environment](https://render.com/docs/projects) that the resource belongs to",
 }
 
 var EnvironmentID = schema.StringAttribute{

--- a/internal/provider/types/resource/header.go
+++ b/internal/provider/types/resource/header.go
@@ -10,7 +10,7 @@ import (
 var Headers = schema.SetNestedAttribute{
 	Optional:            true,
 	Description:         "List of headers to apply to requests for static sites",
-	MarkdownDescription: "List of [headers](https://docs.render.com/static-site-headers) to apply to requests for static sites",
+	MarkdownDescription: "List of [headers](https://render.com/docs/static-site-headers) to apply to requests for static sites",
 	NestedObject: schema.NestedAttributeObject{
 		Attributes: map[string]schema.Attribute{
 			"path": schema.StringAttribute{

--- a/internal/provider/types/resource/logstreamoverride.go
+++ b/internal/provider/types/resource/logstreamoverride.go
@@ -31,5 +31,5 @@ var LogStreamOverride = schema.SingleNestedAttribute{
 	},
 	Optional:    true,
 	Computed:    true,
-	Description: "Configure the [log stream override settings](https://docs.render.com/log-streams#overriding-defaults) for this service. These will override the global log stream settings of the user or team.",
+	Description: "Configure the [log stream override settings](https://render.com/docs/log-streams#overriding-defaults) for this service. These will override the global log stream settings of the user or team.",
 }

--- a/internal/provider/types/resource/notificationoverride.go
+++ b/internal/provider/types/resource/notificationoverride.go
@@ -29,5 +29,5 @@ var NotificationOverride = schema.SingleNestedAttribute{
 	},
 	Optional:    true,
 	Computed:    true,
-	Description: "Configure the [notification settings](https://docs.render.com/notifications) for this service. These will override the global notification settings of the user or team.",
+	Description: "Configure the [notification settings](https://render.com/docs/notifications) for this service. These will override the global notification settings of the user or team.",
 }

--- a/internal/provider/types/resource/runtimesource.go
+++ b/internal/provider/types/resource/runtimesource.go
@@ -26,7 +26,7 @@ type DockerDetailsModel struct {
 var DockerDetails = schema.SingleNestedAttribute{
 	Optional:            true,
 	Description:         "Details for building and deploying a service using a Dockerfile.",
-	MarkdownDescription: "Details for building and deploying a service [using a Dockerfile](https://docs.render.com/docker).",
+	MarkdownDescription: "Details for building and deploying a service [using a Dockerfile](https://render.com/docs/docker).",
 	Attributes: map[string]schema.Attribute{
 		"auto_deploy":  AutoDeploy,
 		"repo_url":     RepoURL,
@@ -51,7 +51,7 @@ var DockerDetails = schema.SingleNestedAttribute{
 
 var NativeRuntimeDetails = schema.SingleNestedAttribute{
 	Description:         "Details for building and deploying a service using one of Render's native runtimes.",
-	MarkdownDescription: "Details for building and deploying a service using one of Render's [native runtimes](https://docs.render.com/native-runtimes).",
+	MarkdownDescription: "Details for building and deploying a service using one of Render's [native runtimes](https://render.com/docs/native-runtimes).",
 	Optional:            true,
 	Attributes: map[string]schema.Attribute{
 		"auto_deploy":   AutoDeploy,
@@ -97,7 +97,7 @@ var RegistryCredentialID = schema.StringAttribute{
 var RuntimeSource = schema.SingleNestedAttribute{
 	Required:            true,
 	Description:         "Source of the build artifacts or image that run your service. You must provide one of native_runtime, docker, or image.",
-	MarkdownDescription: "Source of the build artifacts or image that run your service. You must provide one of [native_runtime](https://docs.render.com/native-runtimes), [docker](https://docs.render.com/docker), or [image](https://docs.render.com/deploy-an-image).",
+	MarkdownDescription: "Source of the build artifacts or image that run your service. You must provide one of [native_runtime](https://render.com/docs/native-runtimes), [docker](https://render.com/docs/docker), or [image](https://render.com/docs/deploy-an-image).",
 	Attributes: map[string]schema.Attribute{
 		"native_runtime": NativeRuntimeDetails,
 		"docker":         DockerDetails,
@@ -112,7 +112,7 @@ var PreDeployCommand = schema.StringAttribute{
 
 var RuntimeSourceImage = schema.SingleNestedAttribute{
 	Description:         "Details for deploying a service using a Docker image from a registry.",
-	MarkdownDescription: "Details for deploying a service using a [Docker image from a registry](https://docs.render.com/deploy-an-image).",
+	MarkdownDescription: "Details for deploying a service using a [Docker image from a registry](https://render.com/docs/deploy-an-image).",
 	Optional:            true,
 	Attributes: map[string]schema.Attribute{
 		"image_url":              ImageURL,

--- a/internal/provider/types/resource/services.go
+++ b/internal/provider/types/resource/services.go
@@ -100,7 +100,7 @@ var ConnectionInfo = schema.SingleNestedAttribute{
 var Region = schema.StringAttribute{
 	Required:            true,
 	Description:         "Region to deploy the service. One of frankfurt, ohio, oregon, singapore, virginia.",
-	MarkdownDescription: "[Region](https://docs.render.com/regions) to deploy the service. One of `frankfurt`, `ohio`, `oregon`, `singapore`, `virginia`.",
+	MarkdownDescription: "[Region](https://render.com/docs/regions) to deploy the service. One of `frankfurt`, `ohio`, `oregon`, `singapore`, `virginia`.",
 	Validators: []validator.String{
 		RegionValidator,
 	},
@@ -113,7 +113,7 @@ var HealthCheckPath = schema.StringAttribute{
 	Optional:            true,
 	Computed:            true,
 	Description:         "If you're running a server, enter the path where your server will always return a 200 OK response. We use it to monitor your app and for zero downtime deploys.",
-	MarkdownDescription: "If you're running a server, enter the path where your server will always return a 200 OK response. We use it to monitor your app and for [zero downtime deploys](https://docs.render.com/deploys#zero-downtime-deploys).",
+	MarkdownDescription: "If you're running a server, enter the path where your server will always return a 200 OK response. We use it to monitor your app and for [zero downtime deploys](https://render.com/docs/deploys#zero-downtime-deploys).",
 	Default:             stringdefault.StaticString(""),
 }
 
@@ -131,7 +131,7 @@ var PRPreviewsEnabled = schema.BoolAttribute{
 	Computed:            true,
 	Description:         "Enable pull request previews for the service.",
 	DeprecationMessage:  "Configure previews.generation instead",
-	MarkdownDescription: "Enable [pull request previews](https://docs.render.com/pull-request-previews#pull-request-previews-git-backed) for the service.",
+	MarkdownDescription: "Enable [pull request previews](https://render.com/docs/pull-request-previews#pull-request-previews-git-backed) for the service.",
 }
 
 var PublishPath = schema.StringAttribute{
@@ -146,7 +146,7 @@ var AutoDeploy = schema.BoolAttribute{
 	Optional:            true,
 	Default:             booldefault.StaticBool(true),
 	Description:         "Automatic deploy on every push to your repository, or changes to your service settings or environment.",
-	MarkdownDescription: "[Automatic deploy](https://docs.render.com/deploys#automatic-git-deploys) on every push to your repository, or changes to your service settings or environment.",
+	MarkdownDescription: "[Automatic deploy](https://render.com/docs/deploys#automatic-git-deploys) on every push to your repository, or changes to your service settings or environment.",
 }
 
 var BuildCommand = schema.StringAttribute{
@@ -157,7 +157,7 @@ var BuildCommand = schema.StringAttribute{
 var StartCommand = schema.StringAttribute{
 	Optional:            true,
 	Description:         "Command to run the service. When using native runtimes, this will be used as the start command. For Docker and image-backed services, this will override the default Docker command for the image.",
-	MarkdownDescription: "Command to run the service. When using native runtimes, this will be used as the start command and is required. For [Docker](https://docs.render.com/docker) and [image-backed](https://docs.render.com/deploy-an-image) services, this will override the default Docker command for the image.",
+	MarkdownDescription: "Command to run the service. When using native runtimes, this will be used as the start command and is required. For [Docker](https://render.com/docs/docker) and [image-backed](https://render.com/docs/deploy-an-image) services, this will override the default Docker command for the image.",
 }
 
 var MaintenanceMode = schema.SingleNestedAttribute{
@@ -200,13 +200,13 @@ var RootDirectory = schema.StringAttribute{
 	Computed:            true,
 	Optional:            true,
 	Description:         "When you specify a root directory, Render runs all your commands in the specified directory and ignores changes outside the directory. Defaults to the repository root.",
-	MarkdownDescription: "When you specify a [root directory](https://docs.render.com/monorepo-support#root-directory), Render runs all your commands in the specified directory and ignores changes outside the directory. Defaults to the repository root.",
+	MarkdownDescription: "When you specify a [root directory](https://render.com/docs/monorepo-support#root-directory), Render runs all your commands in the specified directory and ignores changes outside the directory. Defaults to the repository root.",
 }
 
 var Routes = schema.ListNestedAttribute{
 	Optional:            true,
 	Description:         "List of redirect and rewrite rules to apply to a static site.",
-	MarkdownDescription: "List of [redirect and rewrite rules](https://docs.render.com/redirects-rewrites) to apply to a static site.",
+	MarkdownDescription: "List of [redirect and rewrite rules](https://render.com/docs/redirects-rewrites) to apply to a static site.",
 	NestedObject: schema.NestedAttributeObject{
 		Attributes: map[string]schema.Attribute{
 			"source": schema.StringAttribute{
@@ -241,7 +241,7 @@ var ServiceURL = schema.StringAttribute{
 
 var Disk = schema.SingleNestedAttribute{
 	Description:         "Persistent disk to attach to the service.",
-	MarkdownDescription: "[Persistent disk](https://docs.render.com/disks) to attach to the service.",
+	MarkdownDescription: "[Persistent disk](https://render.com/docs/disks) to attach to the service.",
 	Optional:            true,
 	Attributes: map[string]schema.Attribute{
 		"id": schema.StringAttribute{
@@ -280,7 +280,7 @@ type BuildFilterModel struct {
 var BuildFilter = schema.SingleNestedAttribute{
 	Optional:            true,
 	Description:         "Apply build filters to configure which changes in your git repository trigger automatic deploys. If you've defined a root directory, you can still define paths outside of the root directory.",
-	MarkdownDescription: "Apply [build filters](https://docs.render.com/monorepo-support#build-filters) to configure which changes in your git repository trigger automatic deploys. If you've defined a root directory, you can still define paths outside of the root directory.",
+	MarkdownDescription: "Apply [build filters](https://render.com/docs/monorepo-support#build-filters) to configure which changes in your git repository trigger automatic deploys. If you've defined a root directory, you can still define paths outside of the root directory.",
 	Attributes: map[string]schema.Attribute{
 		"paths": schema.ListAttribute{
 			ElementType: types.StringType,
@@ -305,13 +305,13 @@ var Previews = schema.SingleNestedAttribute{
 	Optional:            true,
 	Computed:            true,
 	Description:         "Pull request previews settings",
-	MarkdownDescription: "[Pull request previews](https://docs.render.com/pull-request-previews#pull-request-previews-git-backed) settings",
+	MarkdownDescription: "[Pull request previews](https://render.com/docs/pull-request-previews#pull-request-previews-git-backed) settings",
 	Attributes: map[string]schema.Attribute{
 		"generation": schema.StringAttribute{
 			Optional:            true,
 			Computed:            true,
 			Description:         "Generation mode for pull request previews. One of `off`, `manual`, or `automatic`. Defaults to `off`.",
-			MarkdownDescription: "Generation mode for [pull request previews](https://docs.render.com/pull-request-previews#pull-request-previews-git-backed). One of `off`, `manual`, or `automatic`. Defaults to `off`.",
+			MarkdownDescription: "Generation mode for [pull request previews](https://render.com/docs/pull-request-previews#pull-request-previews-git-backed). One of `off`, `manual`, or `automatic`. Defaults to `off`.",
 			Validators:          []validator.String{stringvalidator.OneOf("off", "manual", "automatic")},
 		},
 	},

--- a/internal/provider/webservice/resource/testdata/runtime_update_cassette.yaml
+++ b/internal/provider/webservice/resource/testdata/runtime_update_cassette.yaml
@@ -2847,7 +2847,7 @@ interactions:
         content_length: 584
         uncompressed: false
         body: |
-            {"id":"dep-crfhqgc8m55c7030505g","commit":{"id":"bca0502a57b3f3a1a935ebdf8e85d0d704038bd3","message":"Fix render.yaml: \"env\" --\u003e \"runtime\" (#3)\n\nPer the `render.yaml` schema, `env` is still supported but is superseded by `runtime`. Using `env` will show a schema error if using the `render.yaml` validator in an IDE like VS Code.\r\n\r\nSee https://docs.render.com/blueprint-spec#runtime","createdAt":"2024-08-14T21:28:24Z"},"status":"build_in_progress","trigger":"api","createdAt":"2024-09-09T16:07:30.945574Z","updatedAt":"2024-09-09T16:07:30.945574Z","finishedAt":null}
+            {"id":"dep-crfhqgc8m55c7030505g","commit":{"id":"bca0502a57b3f3a1a935ebdf8e85d0d704038bd3","message":"Fix render.yaml: \"env\" --\u003e \"runtime\" (#3)\n\nPer the `render.yaml` schema, `env` is still supported but is superseded by `runtime`. Using `env` will show a schema error if using the `render.yaml` validator in an IDE like VS Code.\r\n\r\nSee https://render.com/docs/blueprint-spec#runtime","createdAt":"2024-08-14T21:28:24Z"},"status":"build_in_progress","trigger":"api","createdAt":"2024-09-09T16:07:30.945574Z","updatedAt":"2024-09-09T16:07:30.945574Z","finishedAt":null}
         headers:
             Content-Length:
                 - "584"


### PR DESCRIPTION
Docs now live at `render.com/docs`.

Update references to save a redirect.