### PR TITLE
Make render_env_group_link's service_ids field use Set

### DIFF
--- a/docs/resources/env_group_link.md
+++ b/docs/resources/env_group_link.md
@@ -50,7 +50,7 @@ resource "render_env_group_link" "envgroup_links" {
 ### Required
 
 - `env_group_id` (String) Unique identifier for the environment group
-- `service_ids` (List of String) List of service ids linked to the environment group
+- `service_ids` (Set of String) Set of service ids linked to the environment group
 
 ## Import
 

--- a/internal/provider/envgroup/datasource/link.go
+++ b/internal/provider/envgroup/datasource/link.go
@@ -68,5 +68,10 @@ func (d *envGroupLinkDataSource) Read(ctx context.Context, req datasource.ReadRe
 		return
 	}
 
-	resp.State.Set(ctx, envgroup.LinkModelFromClient(&envGroupLink))
+	model, modelDiags := envgroup.LinkModelFromClient(&envGroupLink)
+	resp.Diagnostics.Append(modelDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.State.Set(ctx, model)
 }

--- a/internal/provider/envgroup/datasource/link_test.go
+++ b/internal/provider/envgroup/datasource/link_test.go
@@ -46,8 +46,52 @@ func TestAccEnvGroupLinkDataSource(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "env_group_id", "some-id"),
 
 					resource.TestCheckResourceAttr(resourceName, "service_ids.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "service_ids.0", "service1"),
-					resource.TestCheckResourceAttr(resourceName, "service_ids.1", "service2"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "service_ids.*", "service1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "service_ids.*", "service2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccEnvGroupLinkDataSource_OrderingAndDuplicates(t *testing.T) {
+	fakeServer := httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+		var envGroup = &client.EnvGroup{
+			Id:   "order-test-id",
+			Name: "order-test-name",
+			// not in sorted order and with duplicates
+			ServiceLinks: []client.EnvGroupLink{
+				{Id: "service3"},
+				{Id: "service1"},
+				{Id: "service2"},
+				{Id: "service1"},
+			},
+		}
+		res, err := json.Marshal(envGroup)
+		require.NoError(t, err)
+
+		resp.Header().Set("Content-Type", "application/json")
+		_, err = resp.Write(res)
+		require.NoError(t, err)
+	}))
+	defer fakeServer.Close()
+
+	var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
+		"render": providerserver.NewProtocol6WithError(provider.New("test", provider.WithHost(fakeServer.URL))()),
+	}
+
+	resourceName := "data.render_env_group_link.order_test"
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerCfg + `data "render_env_group_link" "order_test" { env_group_id = "order-test-id" }`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "env_group_id", "order-test-id"),
+					resource.TestCheckResourceAttr(resourceName, "service_ids.#", "3"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "service_ids.*", "service1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "service_ids.*", "service2"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "service_ids.*", "service3"),
 				),
 			},
 		},

--- a/internal/provider/envgroup/datasource/schema.go
+++ b/internal/provider/envgroup/datasource/schema.go
@@ -38,11 +38,11 @@ func EnvGroupLinkDataSourceSchema(ctx context.Context) schema.Schema {
 				Description:         "Unique identifier for the environment group",
 				MarkdownDescription: "Unique identifier for the environment group",
 			},
-			"service_ids": schema.ListAttribute{
+			"service_ids": schema.SetAttribute{
 				ElementType:         types.StringType,
 				Computed:            true,
-				Description:         "List of service ids linked to the environment group",
-				MarkdownDescription: "List of service ids linked to the environment group",
+				Description:         "Set of service ids linked to the environment group",
+				MarkdownDescription: "Set of service ids linked to the environment group",
 			},
 		},
 	}

--- a/internal/provider/envgroup/resource/schema.go
+++ b/internal/provider/envgroup/resource/schema.go
@@ -3,7 +3,7 @@ package resource
 import (
 	"context"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -41,13 +41,13 @@ func EnvGroupLinkResourceSchema(ctx context.Context) schema.Schema {
 				Description:         "Unique identifier for the environment group",
 				MarkdownDescription: "Unique identifier for the environment group",
 			},
-			"service_ids": schema.ListAttribute{
+			"service_ids": schema.SetAttribute{
 				ElementType:         types.StringType,
 				Required:            true,
-				Description:         "List of service ids linked to the environment group",
-				MarkdownDescription: "List of service ids linked to the environment group",
-				Validators: []validator.List{
-					listvalidator.SizeAtLeast(1),
+				Description:         "Set of service ids linked to the environment group",
+				MarkdownDescription: "Set of service ids linked to the environment group",
+				Validators: []validator.Set{
+					setvalidator.SizeAtLeast(1),
 				},
 			},
 		},


### PR DESCRIPTION
# Summary
Make render_env_group_link's service_ids field use Set to prevent order mattering.

2 things will change:
- Order will no longer matter
  - this is okay / desirable since order shouldn't matter when specifying linked `service_ids`
- Duplicates will be ignored
  - this *seems* okay since I wasn't able to put in duplicate entries into `service_ids` anyways

So this seems like a backwards compatible change.

# Testing
Tested manually by testing terraform with the following in `service_ids`:
- creating with duplicates + different orders using new provider code
- creating using old provider code and then updating with duplicates and different orders using new provider code

Also added unit tests

# Rollout
Will merge after team onsite for safety

Resolves https://github.com/render-oss/terraform-provider-render/issues/62