### PR TITLE
Autogenerated custom domains don't produce inconsistency

### DIFF
--- a/docs/data-sources/env_group_link.md
+++ b/docs/data-sources/env_group_link.md
@@ -21,4 +21,4 @@ description: |-
 
 ### Read-Only
 
-- `service_ids` (List of String) List of service ids linked to the environment group
+- `service_ids` (Set of String) Set of service ids linked to the environment group

--- a/docs/data-sources/static_site.md
+++ b/docs/data-sources/static_site.md
@@ -25,6 +25,7 @@ Provides information about a Render Static Site.
 
 ### Read-Only
 
+- `active_custom_domains` (Attributes Set) All active custom domains associated with the service, including any auto-generated redirect domains. (see [below for nested schema](#nestedatt--active_custom_domains))
 - `auto_deploy` (Boolean) [Automatic deploy](https://render.com/docs/deploys#automatic-git-deploys) on every push to your repository, or changes to your service settings or environment.
 - `auto_deploy_trigger` (String) Sets the Automatic deploy behavior for a Git-based service.
 - `branch` (String) Branch to build
@@ -54,6 +55,18 @@ Required:
 Read-Only:
 
 - `domain_type` (String) Type of the custom domain. Either apex or subdomain
+- `name` (String) DNS record of the custom domain
+- `public_suffix` (String) Public suffix of the custom domain
+- `redirect_for_name` (String) DNS record of the custom domain to redirect to
+
+
+<a id="nestedatt--active_custom_domains"></a>
+### Nested Schema for `active_custom_domains`
+
+Read-Only:
+
+- `domain_type` (String) Type of the custom domain. Either apex or subdomain
+- `id` (String) Unique identifier for the custom domain
 - `name` (String) DNS record of the custom domain
 - `public_suffix` (String) Public suffix of the custom domain
 - `redirect_for_name` (String) DNS record of the custom domain to redirect to

--- a/docs/data-sources/web_service.md
+++ b/docs/data-sources/web_service.md
@@ -26,6 +26,7 @@ Provides information about a Render Web Service.
 
 ### Read-Only
 
+- `active_custom_domains` (Attributes Set) All active custom domains associated with the service, including any auto-generated redirect domains. (see [below for nested schema](#nestedatt--active_custom_domains))
 - `autoscaling` (Attributes) (see [below for nested schema](#nestedatt--autoscaling))
 - `disk` (Attributes) (see [below for nested schema](#nestedatt--disk))
 - `env_vars` (Attributes Map) Map of environment variable names to their values. (see [below for nested schema](#nestedatt--env_vars))
@@ -74,6 +75,18 @@ Optional:
 
 - `endpoint` (String) The endpoint to send logs to.
 - `token` (String, Sensitive) The token to use when sending logs.
+
+
+<a id="nestedatt--active_custom_domains"></a>
+### Nested Schema for `active_custom_domains`
+
+Read-Only:
+
+- `domain_type` (String) Type of the custom domain. Either apex or subdomain
+- `id` (String) Unique identifier for the custom domain
+- `name` (String) DNS record of the custom domain
+- `public_suffix` (String) Public suffix of the custom domain
+- `redirect_for_name` (String) DNS record of the custom domain to redirect to
 
 
 <a id="nestedatt--autoscaling"></a>

--- a/docs/resources/static_site.md
+++ b/docs/resources/static_site.md
@@ -122,6 +122,7 @@ resource "render_static_site" "example" {
 
 ### Read-Only
 
+- `active_custom_domains` (Attributes Set) All active custom domains associated with the service, including any auto-generated redirect domains. (see [below for nested schema](#nestedatt--active_custom_domains))
 - `id` (String) Unique identifier for the service
 - `slug` (String) Unique slug for the service
 - `url` (String) URL that the service is accessible from.
@@ -194,6 +195,18 @@ Required:
 - `destination` (String) Destination path to route to.
 - `source` (String) Source path to match.
 - `type` (String) Type of route. Either redirect or rewrite.
+
+
+<a id="nestedatt--active_custom_domains"></a>
+### Nested Schema for `active_custom_domains`
+
+Read-Only:
+
+- `domain_type` (String) Type of the custom domain. Either apex or subdomain
+- `id` (String) Unique identifier for the custom domain
+- `name` (String) DNS record of the custom domain
+- `public_suffix` (String) Public suffix of the custom domain
+- `redirect_for_name` (String) DNS record of the custom domain to redirect to
 
 ## Import
 

--- a/docs/resources/web_service.md
+++ b/docs/resources/web_service.md
@@ -96,6 +96,7 @@ resource "render_web_service" "web" {
 
 ### Read-Only
 
+- `active_custom_domains` (Attributes Set) All active custom domains associated with the service, including any auto-generated redirect domains. (see [below for nested schema](#nestedatt--active_custom_domains))
 - `id` (String) Unique identifier for the service
 - `slug` (String) Unique slug for the service
 - `url` (String) URL that the service is accessible from.
@@ -298,6 +299,18 @@ Optional:
 Required:
 
 - `content` (String, Sensitive) The content of the secret file.
+
+
+<a id="nestedatt--active_custom_domains"></a>
+### Nested Schema for `active_custom_domains`
+
+Read-Only:
+
+- `domain_type` (String) Type of the custom domain. Either apex or subdomain
+- `id` (String) Unique identifier for the custom domain
+- `name` (String) DNS record of the custom domain
+- `public_suffix` (String) Public suffix of the custom domain
+- `redirect_for_name` (String) DNS record of the custom domain to redirect to
 
 ## Import
 

--- a/internal/provider/common/customdomain.go
+++ b/internal/provider/common/customdomain.go
@@ -1,8 +1,11 @@
 package common
 
 import (
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"terraform-provider-render/internal/client"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 type CustomDomainModel struct {
@@ -45,6 +48,31 @@ func CustomDomainClientsToCustomDomainModels(customDomains *[]client.CustomDomai
 	return customDomainModels
 }
 
+// CustomDomainClientsToCustomDomainModelsNonRedirecting returns only custom domains that are not auto-generated redirect domains.
+// A domain is considered auto-generated if RedirectForName is non-empty.
+func CustomDomainClientsToCustomDomainModelsNonRedirecting(customDomains *[]client.CustomDomain) []CustomDomainModel {
+	if customDomains == nil || len(*customDomains) == 0 {
+		return nil
+	}
+	filtered := make([]CustomDomainModel, 0, len(*customDomains))
+	for _, cd := range *customDomains {
+		if cd.RedirectForName != "" {
+			continue
+		}
+		filtered = append(filtered, CustomDomainModel{
+			Id:              types.StringValue(cd.Id),
+			Name:            types.StringValue(cd.Name),
+			DomainType:      types.StringValue(string(cd.DomainType)),
+			PublicSuffix:    types.StringValue(cd.PublicSuffix),
+			RedirectForName: types.StringValue(cd.RedirectForName),
+		})
+	}
+	if len(filtered) == 0 {
+		return nil
+	}
+	return filtered
+}
+
 func customDomainStringToClientType(domainType string) client.CustomDomainDomainType {
 	switch domainType {
 	case "apex":
@@ -53,4 +81,44 @@ func customDomainStringToClientType(domainType string) client.CustomDomainDomain
 		return client.CustomDomainDomainTypeSubdomain
 	}
 	return ""
+}
+
+var customDomainAttrTypes = map[string]attr.Type{
+	"id":                types.StringType,
+	"name":              types.StringType,
+	"domain_type":       types.StringType,
+	"public_suffix":     types.StringType,
+	"redirect_for_name": types.StringType,
+}
+
+// CustomDomainSetFromClient converts client custom domains to a Terraform Set of Objects
+// matching the CustomDomain schema. Returns a null set when input is nil or empty.
+func CustomDomainSetFromClient(customDomains *[]client.CustomDomain, diags diag.Diagnostics) types.Set {
+	objType := types.ObjectType{AttrTypes: customDomainAttrTypes}
+	if customDomains == nil || len(*customDomains) == 0 {
+		return types.SetNull(objType)
+	}
+
+	var elems []attr.Value
+	for _, cd := range *customDomains {
+		obj, oDiags := types.ObjectValue(customDomainAttrTypes, map[string]attr.Value{
+			"id":                types.StringValue(cd.Id),
+			"name":              types.StringValue(cd.Name),
+			"domain_type":       types.StringValue(string(cd.DomainType)),
+			"public_suffix":     types.StringValue(cd.PublicSuffix),
+			"redirect_for_name": types.StringValue(cd.RedirectForName),
+		})
+		diags.Append(oDiags...)
+		if diags.HasError() {
+			return types.SetNull(objType)
+		}
+		elems = append(elems, obj)
+	}
+
+	set, sDiags := types.SetValue(objType, elems)
+	diags.Append(sDiags...)
+	if diags.HasError() {
+		return types.SetNull(objType)
+	}
+	return set
 }

--- a/internal/provider/postgres/resource/schema.go
+++ b/internal/provider/postgres/resource/schema.go
@@ -150,8 +150,8 @@ func PostgresResourceSchema(ctx context.Context) schema.Schema {
 				},
 			},
 			"version": schema.StringAttribute{
-				Description:         "The Postgres version",
-				MarkdownDescription: "The Postgres version",
+				Description:         "The Postgres version. Currently supported: `11`, `12`, `13`, `14`, `15`, `16`, and `17`",
+				MarkdownDescription: "The Postgres version. Currently supported: `11`, `12`, `13`, `14`, `15`, `16`, and `17`",
 				Required:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),

--- a/internal/provider/staticsite/datasource/schema.go
+++ b/internal/provider/staticsite/datasource/schema.go
@@ -19,6 +19,7 @@ func Schema(ctx context.Context) schema.Schema {
 			"build_command":                 datasource.BuildCommand,
 			"build_filter":                  datasource.BuildFilter,
 			"custom_domains":                datasource.CustomDomains,
+			"active_custom_domains":         datasource.ActiveCustomDomains,
 			"environment_id":                datasource.ResourceEnvironmentID,
 			"env_vars":                      datasource.EnvVars,
 			"headers":                       datasource.Headers,

--- a/internal/provider/staticsite/models.go
+++ b/internal/provider/staticsite/models.go
@@ -17,6 +17,7 @@ type StaticSiteModel struct {
 	BuildFilter                *common.BuildFilterModel      `tfsdk:"build_filter"`
 	EnvironmentID              types.String                  `tfsdk:"environment_id"`
 	CustomDomains              []common.CustomDomainModel    `tfsdk:"custom_domains"`
+	ActiveCustomDomains        types.Set                     `tfsdk:"active_custom_domains"`
 	EnvVars                    map[string]common.EnvVarModel `tfsdk:"env_vars"`
 	Headers                    []common.HeaderModel          `tfsdk:"headers"`
 	Name                       types.String                  `tfsdk:"name"`
@@ -54,7 +55,8 @@ func ModelForServiceResult(service *common.WrappedStaticSite, state StaticSiteMo
 		AutoDeploy:           types.BoolValue(service.AutoDeploy == client.AutoDeployYes),
 		AutoDeployTrigger:    common.AutoDeployTriggerToString(service.AutoDeployTrigger),
 		BuildFilter:          common.BuildFilterModelForClient(service.BuildFilter),
-		CustomDomains:        common.CustomDomainClientsToCustomDomainModels(service.CustomDomains),
+		CustomDomains:        common.CustomDomainClientsToCustomDomainModelsNonRedirecting(service.CustomDomains),
+		ActiveCustomDomains:  common.CustomDomainSetFromClient(service.CustomDomains, diags),
 		EnvironmentID:        types.StringPointerValue(service.EnvironmentId),
 		Headers:              common.ClientHeadersToRouteModels(service.Headers),
 		Name:                 types.StringValue(service.Name),

--- a/internal/provider/staticsite/resource/schema.go
+++ b/internal/provider/staticsite/resource/schema.go
@@ -19,6 +19,7 @@ func Schema(ctx context.Context) schema.Schema {
 			"build_command":                 resource.BuildCommand,
 			"build_filter":                  resource.BuildFilter,
 			"custom_domains":                resource.CustomDomains,
+			"active_custom_domains":         resource.ActiveCustomDomains,
 			"environment_id":                resource.ResourceEnvironmentID,
 			"env_vars":                      resource.EnvVars,
 			"headers":                       resource.Headers,

--- a/internal/provider/types/datasource/customdomain.go
+++ b/internal/provider/types/datasource/customdomain.go
@@ -1,6 +1,8 @@
 package datasource
 
-import "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+import (
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+)
 
 var CustomDomain = schema.NestedAttributeObject{
 	Attributes: map[string]schema.Attribute{
@@ -31,4 +33,36 @@ var CustomDomains = schema.SetNestedAttribute{
 	Optional:     true,
 	Description:  "Custom domains to associate with the service.",
 	NestedObject: CustomDomain,
+}
+
+// ActiveCustomDomain is identical to CustomDomain, but no fields are required because everything is computed
+var ActiveCustomDomain = schema.NestedAttributeObject{
+	Attributes: map[string]schema.Attribute{
+		"id": schema.StringAttribute{
+			Computed:    true,
+			Description: "Unique identifier for the custom domain",
+		},
+		"name": schema.StringAttribute{
+			Computed:    true,
+			Description: "DNS record of the custom domain",
+		},
+		"domain_type": schema.StringAttribute{
+			Computed:    true,
+			Description: "Type of the custom domain. Either apex or subdomain",
+		},
+		"public_suffix": schema.StringAttribute{
+			Computed:    true,
+			Description: "Public suffix of the custom domain",
+		},
+		"redirect_for_name": schema.StringAttribute{
+			Computed:    true,
+			Description: "DNS record of the custom domain to redirect to",
+		},
+	},
+}
+
+var ActiveCustomDomains = schema.SetNestedAttribute{
+	Computed:     true,
+	Description:  "All active custom domains associated with the service, including any auto-generated redirect domains.",
+	NestedObject: ActiveCustomDomain,
 }

--- a/internal/provider/types/resource/customdomain.go
+++ b/internal/provider/types/resource/customdomain.go
@@ -42,3 +42,36 @@ var CustomDomains = schema.SetNestedAttribute{
 		setvalidator.SizeAtLeast(1),
 	},
 }
+
+// ActiveCustomDomain is identical to CustomDomain, but no fields are required because everything is computed
+var ActiveCustomDomain = schema.NestedAttributeObject{
+	Attributes: map[string]schema.Attribute{
+		"id": schema.StringAttribute{
+			Computed:    true,
+			Description: "Unique identifier for the custom domain",
+		},
+		"name": schema.StringAttribute{
+			Computed:    true,
+			Description: "DNS record of the custom domain",
+			Validators:  []validator.String{validators.StringNotEmpty},
+		},
+		"domain_type": schema.StringAttribute{
+			Computed:    true,
+			Description: "Type of the custom domain. Either apex or subdomain",
+		},
+		"public_suffix": schema.StringAttribute{
+			Computed:    true,
+			Description: "Public suffix of the custom domain",
+		},
+		"redirect_for_name": schema.StringAttribute{
+			Computed:    true,
+			Description: "DNS record of the custom domain to redirect to",
+		},
+	},
+}
+
+var ActiveCustomDomains = schema.SetNestedAttribute{
+	Computed:     true,
+	Description:  "All active custom domains associated with the service, including any auto-generated redirect domains.",
+	NestedObject: ActiveCustomDomain,
+}

--- a/internal/provider/webservice/datasource/schema.go
+++ b/internal/provider/webservice/datasource/schema.go
@@ -14,6 +14,7 @@ func Schema(ctx context.Context) schema.Schema {
 			"id":                            datasource.ServiceID,
 			"autoscaling":                   datasource.Autoscaling,
 			"custom_domains":                datasource.CustomDomains,
+			"active_custom_domains":         datasource.ActiveCustomDomains,
 			"runtime_source":                datasource.RuntimeSource,
 			"disk":                          datasource.Disk,
 			"environment_id":                datasource.ResourceEnvironmentID,

--- a/internal/provider/webservice/models.go
+++ b/internal/provider/webservice/models.go
@@ -12,6 +12,7 @@ type WebServiceModel struct {
 	Id                         types.String               `tfsdk:"id"`
 	Autoscaling                *common.AutoscalingModel   `tfsdk:"autoscaling"`
 	CustomDomains              []common.CustomDomainModel `tfsdk:"custom_domains"`
+	ActiveCustomDomains        types.Set                  `tfsdk:"active_custom_domains"`
 	RuntimeSource              *common.RuntimeSourceModel `tfsdk:"runtime_source"`
 	Disk                       *common.DiskModel          `tfsdk:"disk"`
 	EnvironmentID              types.String               `tfsdk:"environment_id"`
@@ -55,7 +56,8 @@ func ModelForServiceResult(service *common.WrappedService, plan WebServiceModel,
 
 	webServicesModel := &WebServiceModel{
 		Id:                         types.StringValue(service.Id),
-		CustomDomains:              common.CustomDomainClientsToCustomDomainModels(service.CustomDomains),
+		CustomDomains:              common.CustomDomainClientsToCustomDomainModelsNonRedirecting(service.CustomDomains),
+		ActiveCustomDomains:        common.CustomDomainSetFromClient(service.CustomDomains, diags),
 		EnvironmentID:              types.StringPointerValue(service.EnvironmentId),
 		HealthCheckPath:            types.StringValue(details.HealthCheckPath),
 		Name:                       types.StringValue(service.Name),

--- a/internal/provider/webservice/resource/schema.go
+++ b/internal/provider/webservice/resource/schema.go
@@ -2,6 +2,7 @@ package resource
 
 import (
 	"context"
+
 	"terraform-provider-render/internal/provider/types/resource"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -14,6 +15,7 @@ func Schema(ctx context.Context) schema.Schema {
 			"id":                            resource.ServiceID,
 			"autoscaling":                   resource.Autoscaling,
 			"custom_domains":                resource.CustomDomains,
+			"active_custom_domains":         resource.ActiveCustomDomains,
 			"runtime_source":                resource.RuntimeSource,
 			"disk":                          resource.Disk,
 			"environment_id":                resource.ResourceEnvironmentID,


### PR DESCRIPTION
When creating custom domains, Render sometimes creates a second redirect domain by either adding or removing a `www.` prefix. We were including these generated domains in the state for `custom_domains`, which is considered an inconsistency error.

To fix this, we've introduced a new `active_custom_domains` property that includes all custom domains, and restrict `custom_domains` only to user-provided domains.

We've made the decision to have the same structure in datasources, which is not strictly necessary. datasources could continue to show all domains in `custom_domains`, and not have `active_custom_domains`, but we've chosen this direction for consistency between the resources and the datasources.