### PR TITLE
Fix goreleaser v2 deprecations

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,6 @@
 # Visit https://goreleaser.com for documentation on how to customize this
 # behavior.
+version: 1
 before:
   hooks:
     # this is just an example and not a requirement for provider building/publishing
@@ -57,4 +58,4 @@ release:
   # If you want to manually examine the release before its live, uncomment this line:
   # draft: true
 changelog:
-  skip: true
+  disable: true


### PR DESCRIPTION
To use goreleaser v2, we need to address a couple deprecations. There are more deprecations present on the v2 line, but we can't fix them until we've upgraded.

We'll also need to change `version: 1` to `version: 2` when we're ready to upgrade.