### PR TITLE
Add support for `log_stream_override` on replicas

### DIFF
--- a/docs/data-sources/postgres.md
+++ b/docs/data-sources/postgres.md
@@ -37,7 +37,7 @@ description: |-
 - `name` (String) Descriptive name for this postgres
 - `parameter_overrides` (Map of String) Parameter overrides for the postgres instance.
 - `plan` (String) Plan to use for this postgres
-- `read_replicas` (Attributes List) List of read replicas. (see [below for nested schema](#nestedatt--read_replicas))
+- `read_replicas` (Attributes Set) List of read replicas. (see [below for nested schema](#nestedatt--read_replicas))
 - `region` (String) Region the postgres instance in
 - `role` (String) Whether this postgres is a primary or replica
 - `version` (String) The Postgres version
@@ -78,24 +78,18 @@ Read-Only:
 <a id="nestedatt--read_replicas"></a>
 ### Nested Schema for `read_replicas`
 
-Optional:
-
-- `log_stream_override` (Attributes) Configure the [log stream override settings](https://render.com/docs/log-streams#overriding-defaults) for this service. These will override the global log stream settings of the user or team. (see [below for nested schema](#nestedatt--read_replicas--log_stream_override))
-
 Read-Only:
 
 - `id` (String) ID of the read replica.
+- `log_stream_override` (Attributes) The [log stream override settings](https://render.com/docs/log-streams#overriding-defaults) for this replica. (see [below for nested schema](#nestedatt--read_replicas--log_stream_override))
 - `name` (String) Name of the read replica.
 - `parameter_overrides` (Map of String) Parameter overrides for the read replica.
 
 <a id="nestedatt--read_replicas--log_stream_override"></a>
 ### Nested Schema for `read_replicas.log_stream_override`
 
-Required:
+Read-Only:
 
-- `setting` (String) Whether to send or drop logs for this service. Must be one of `send` or `drop`.
-
-Optional:
-
-- `endpoint` (String) The endpoint to send logs to.
-- `token` (String, Sensitive) The token to use when sending logs.
+- `endpoint` (String) The endpoint logs are sent to.
+- `setting` (String) Whether to send or drop logs for this replica.
+- `token` (String, Sensitive) The token used when sending logs.

--- a/docs/data-sources/postgres.md
+++ b/docs/data-sources/postgres.md
@@ -35,8 +35,9 @@ description: |-
 - `high_availability_enabled` (Boolean) Whether high availability is enabled for this postgres
 - `ip_allow_list` (Attributes Set) List of IP addresses that are allowed to connect to the Redis instance. If no IP addresses are provided, only connections via the private network will be allowed. (see [below for nested schema](#nestedatt--ip_allow_list))
 - `name` (String) Descriptive name for this postgres
+- `parameter_overrides` (Map of String) Parameter overrides for the postgres instance.
 - `plan` (String) Plan to use for this postgres
-- `read_replicas` (Attributes Set) List of read replicas. (see [below for nested schema](#nestedatt--read_replicas))
+- `read_replicas` (Attributes List) List of read replicas. (see [below for nested schema](#nestedatt--read_replicas))
 - `region` (String) Region the postgres instance in
 - `role` (String) Whether this postgres is a primary or replica
 - `version` (String) The Postgres version
@@ -77,7 +78,24 @@ Read-Only:
 <a id="nestedatt--read_replicas"></a>
 ### Nested Schema for `read_replicas`
 
+Optional:
+
+- `log_stream_override` (Attributes) Configure the [log stream override settings](https://render.com/docs/log-streams#overriding-defaults) for this service. These will override the global log stream settings of the user or team. (see [below for nested schema](#nestedatt--read_replicas--log_stream_override))
+
 Read-Only:
 
 - `id` (String) ID of the read replica.
 - `name` (String) Name of the read replica.
+- `parameter_overrides` (Map of String) Parameter overrides for the read replica.
+
+<a id="nestedatt--read_replicas--log_stream_override"></a>
+### Nested Schema for `read_replicas.log_stream_override`
+
+Required:
+
+- `setting` (String) Whether to send or drop logs for this service. Must be one of `send` or `drop`.
+
+Optional:
+
+- `endpoint` (String) The endpoint to send logs to.
+- `token` (String, Sensitive) The token to use when sending logs.

--- a/docs/resources/postgres.md
+++ b/docs/resources/postgres.md
@@ -61,7 +61,7 @@ resource "render_postgres" "example" {
 - `ip_allow_list` (Attributes Set) List of IP addresses that are allowed to connect to the instance. If no IP addresses are provided, only connections via the private network will be allowed. (see [below for nested schema](#nestedatt--ip_allow_list))
 - `log_stream_override` (Attributes) Configure the [log stream override settings](https://render.com/docs/log-streams#overriding-defaults) for this service. These will override the global log stream settings of the user or team. (see [below for nested schema](#nestedatt--log_stream_override))
 - `parameter_overrides` (Map of String) Parameter overrides for the postgres instance.
-- `read_replicas` (Attributes List) List of read replicas. (see [below for nested schema](#nestedatt--read_replicas))
+- `read_replicas` (Attributes Set) List of read replicas. (see [below for nested schema](#nestedatt--read_replicas))
 
 ### Read-Only
 
@@ -101,7 +101,7 @@ Required:
 
 Optional:
 
-- `log_stream_override` (Attributes) Configure the [log stream override settings](https://render.com/docs/log-streams#overriding-defaults) for this service. These will override the global log stream settings of the user or team. (see [below for nested schema](#nestedatt--read_replicas--log_stream_override))
+- `log_stream_override` (Attributes) Configure the [log stream override settings](https://render.com/docs/log-streams#overriding-defaults) for this replica. These take precedence over the workspace's default log stream and any setting on the primary. (see [below for nested schema](#nestedatt--read_replicas--log_stream_override))
 - `parameter_overrides` (Map of String) Parameter overrides for the read replica.
 
 Read-Only:
@@ -113,7 +113,7 @@ Read-Only:
 
 Required:
 
-- `setting` (String) Whether to send or drop logs for this service. Must be one of `send` or `drop`.
+- `setting` (String) Whether to send or drop logs for this replica. Must be one of `send` or `drop`.
 
 Optional:
 

--- a/docs/resources/postgres.md
+++ b/docs/resources/postgres.md
@@ -48,7 +48,7 @@ resource "render_postgres" "example" {
 - `name` (String) Descriptive name for this postgres
 - `plan` (String) Plan to use for this postgres. Must be `free`, a basic plan (like `basic_256mb`), a pro plan (like `pro_4gb`), an accelerated plan (like `accelerated_16gb`), `starter`, `standard`, `pro`, `pro_plus`, or a custom plan
 - `region` (String) Region the postgres instance in
-- `version` (String) The Postgres version. Currently Supported: `11`, `12`, `13`, `14`, `15`, `16`, `17`, and  `18`
+- `version` (String) The Postgres version. Currently supported: `11`, `12`, `13`, `14`, `15`, `16`, `17`, and `18`
 
 ### Optional
 
@@ -61,7 +61,7 @@ resource "render_postgres" "example" {
 - `ip_allow_list` (Attributes Set) List of IP addresses that are allowed to connect to the instance. If no IP addresses are provided, only connections via the private network will be allowed. (see [below for nested schema](#nestedatt--ip_allow_list))
 - `log_stream_override` (Attributes) Configure the [log stream override settings](https://render.com/docs/log-streams#overriding-defaults) for this service. These will override the global log stream settings of the user or team. (see [below for nested schema](#nestedatt--log_stream_override))
 - `parameter_overrides` (Map of String) Parameter overrides for the postgres instance.
-- `read_replicas` (Attributes Set) List of read replicas. (see [below for nested schema](#nestedatt--read_replicas))
+- `read_replicas` (Attributes List) List of read replicas. (see [below for nested schema](#nestedatt--read_replicas))
 
 ### Read-Only
 
@@ -101,11 +101,25 @@ Required:
 
 Optional:
 
+- `log_stream_override` (Attributes) Configure the [log stream override settings](https://render.com/docs/log-streams#overriding-defaults) for this service. These will override the global log stream settings of the user or team. (see [below for nested schema](#nestedatt--read_replicas--log_stream_override))
 - `parameter_overrides` (Map of String) Parameter overrides for the read replica.
 
 Read-Only:
 
 - `id` (String) ID of the read replica.
+
+<a id="nestedatt--read_replicas--log_stream_override"></a>
+### Nested Schema for `read_replicas.log_stream_override`
+
+Required:
+
+- `setting` (String) Whether to send or drop logs for this service. Must be one of `send` or `drop`.
+
+Optional:
+
+- `endpoint` (String) The endpoint to send logs to.
+- `token` (String, Sensitive) The token to use when sending logs.
+
 
 
 <a id="nestedatt--connection_info"></a>

--- a/internal/provider/common/logstreamoverride.go
+++ b/internal/provider/common/logstreamoverride.go
@@ -3,10 +3,11 @@ package common
 import (
 	"fmt"
 
+	"terraform-provider-render/internal/client/logs"
+
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"terraform-provider-render/internal/client/logs"
 )
 
 var logStreamTypes = map[string]attr.Type{
@@ -25,13 +26,7 @@ func LogStreamOverrideFromClient(client *logs.ResourceLogStreamSetting, plan typ
 		setting = *client.Setting
 	}
 
-	// Map an absent / empty API endpoint to a null state value rather than the
-	// zero string. The API only includes `endpoint` when `setting=send` (per the
-	// OpenAPI spec at public-api-schema/src/logs.yaml: "Cannot be present if
-	// setting is drop"), and an empty endpoint isn't a meaningful state — it's
-	// "no endpoint configured". This null mapping is also what lets the replica
-	// schema (Optional `endpoint`, no Computed) match plan and state cleanly
-	// inside a SetNestedAttribute, since plan endpoint is null when omitted.
+	// endpoint being an empty string or null are functionally equivalent
 	endpoint := types.StringNull()
 	if client.Endpoint != nil && *client.Endpoint != "" {
 		endpoint = types.StringValue(*client.Endpoint)

--- a/internal/provider/common/logstreamoverride.go
+++ b/internal/provider/common/logstreamoverride.go
@@ -25,9 +25,16 @@ func LogStreamOverrideFromClient(client *logs.ResourceLogStreamSetting, plan typ
 		setting = *client.Setting
 	}
 
-	endpoint := ""
-	if client.Endpoint != nil {
-		endpoint = *client.Endpoint
+	// Map an absent / empty API endpoint to a null state value rather than the
+	// zero string. The API only includes `endpoint` when `setting=send` (per the
+	// OpenAPI spec at public-api-schema/src/logs.yaml: "Cannot be present if
+	// setting is drop"), and an empty endpoint isn't a meaningful state — it's
+	// "no endpoint configured". This null mapping is also what lets the replica
+	// schema (Optional `endpoint`, no Computed) match plan and state cleanly
+	// inside a SetNestedAttribute, since plan endpoint is null when omitted.
+	endpoint := types.StringNull()
+	if client.Endpoint != nil && *client.Endpoint != "" {
+		endpoint = types.StringValue(*client.Endpoint)
 	}
 
 	planAttrs := plan.Attributes()
@@ -44,7 +51,7 @@ func LogStreamOverrideFromClient(client *logs.ResourceLogStreamSetting, plan typ
 		logStreamTypes,
 		map[string]attr.Value{
 			"setting":  types.StringValue(string(setting)),
-			"endpoint": types.StringValue(endpoint),
+			"endpoint": endpoint,
 			"token":    token,
 		},
 	)

--- a/internal/provider/postgres/datasource/datasource.go
+++ b/internal/provider/postgres/datasource/datasource.go
@@ -83,5 +83,11 @@ func (d *postgresDataSource) Read(ctx context.Context, req datasource.ReadReques
 		return
 	}
 
-	resp.State.Set(ctx, postgres.ModelFromClient(&pg, &secrets, logStreamOverrides, plan, resp.Diagnostics))
+	replicaLogStreams, err := postgres.GetReplicaLogStreamOverrides(ctx, d.client, pg.ReadReplicas)
+	if err != nil {
+		resp.Diagnostics.AddError("unable to get replica log stream overrides", err.Error())
+		return
+	}
+
+	resp.State.Set(ctx, postgres.ModelFromClient(&pg, &secrets, logStreamOverrides, replicaLogStreams, plan, resp.Diagnostics))
 }

--- a/internal/provider/postgres/datasource/datasource_test.go
+++ b/internal/provider/postgres/datasource/datasource_test.go
@@ -36,11 +36,15 @@ func TestAccPostgresDataSource(t *testing.T) {
 					}),
 					resource.TestCheckResourceAttr(resourceName, "database_user", "test_user"),
 					resource.TestCheckResourceAttr(resourceName, "high_availability_enabled", "false"),
-					resource.TestCheckResourceAttr(resourceName, "plan", "basic_256mb"),
+					resource.TestCheckResourceAttr(resourceName, "plan", "pro_4gb"),
 					resource.TestCheckResourceAttr(resourceName, "disk_size_gb", "20"),
 					resource.TestCheckResourceAttr(resourceName, "region", "oregon"),
 					resource.TestCheckResourceAttr(resourceName, "role", "primary"),
 					resource.TestCheckResourceAttr(resourceName, "version", "16"),
+
+					resource.TestCheckResourceAttr(resourceName, "log_stream_override.setting", "drop"),
+					resource.TestCheckResourceAttr(resourceName, "read_replicas.0.name", "read-replica"),
+					resource.TestCheckResourceAttr(resourceName, "read_replicas.0.log_stream_override.setting", "drop"),
 
 					resource.TestCheckResourceAttrWith(resourceName, "connection_info.password", func(value string) error {
 						if len(value) != 32 {

--- a/internal/provider/postgres/datasource/schema.go
+++ b/internal/provider/postgres/datasource/schema.go
@@ -64,7 +64,7 @@ func PostgresDataSourceSchema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "Region the postgres instance in",
 				Computed:            true,
 			},
-			"read_replicas": schema.ListNestedAttribute{
+			"read_replicas": schema.SetNestedAttribute{
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"name": schema.StringAttribute{
@@ -83,7 +83,7 @@ func PostgresDataSourceSchema(ctx context.Context) schema.Schema {
 							MarkdownDescription: "Parameter overrides for the read replica.",
 							Computed:            true,
 						},
-						"log_stream_override": resource.LogStreamOverride,
+						"log_stream_override": datasource.ReplicaLogStreamOverride,
 					},
 				},
 				Computed:            true,

--- a/internal/provider/postgres/datasource/schema.go
+++ b/internal/provider/postgres/datasource/schema.go
@@ -64,7 +64,7 @@ func PostgresDataSourceSchema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "Region the postgres instance in",
 				Computed:            true,
 			},
-			"read_replicas": schema.SetNestedAttribute{
+			"read_replicas": schema.ListNestedAttribute{
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"name": schema.StringAttribute{
@@ -83,6 +83,7 @@ func PostgresDataSourceSchema(ctx context.Context) schema.Schema {
 							MarkdownDescription: "Parameter overrides for the read replica.",
 							Computed:            true,
 						},
+						"log_stream_override": resource.LogStreamOverride,
 					},
 				},
 				Computed:            true,

--- a/internal/provider/postgres/datasource/testdata/postgres.tf
+++ b/internal/provider/postgres/datasource/testdata/postgres.tf
@@ -3,10 +3,21 @@ resource "render_postgres" "test" {
   database_name = "test_name_mnop"
   database_user = "test_user"
   high_availability_enabled = false
-  plan = "basic_256mb"
+  plan = "pro_4gb"
   disk_size_gb = 20
   region = "oregon"
   version = "16"
+
+  log_stream_override = {
+    setting = "drop"
+  }
+
+  read_replicas = [{
+    name = "read-replica"
+    log_stream_override = {
+      setting = "drop"
+    }
+  }]
 }
 
 data "render_postgres" "test" {

--- a/internal/provider/postgres/datasource/testdata/postgres.tf
+++ b/internal/provider/postgres/datasource/testdata/postgres.tf
@@ -1,12 +1,12 @@
 resource "render_postgres" "test" {
-  name = "some-name"
-  database_name = "test_name_mnop"
-  database_user = "test_user"
+  name                      = "some-name"
+  database_name             = "test_name_mnop"
+  database_user             = "test_user"
   high_availability_enabled = false
-  plan = "pro_4gb"
-  disk_size_gb = 20
-  region = "oregon"
-  version = "16"
+  plan                      = "pro_4gb"
+  disk_size_gb              = 20
+  region                    = "oregon"
+  version                   = "16"
 
   log_stream_override = {
     setting = "drop"

--- a/internal/provider/postgres/datasource/testdata/postgres_datasource_cassette.yaml
+++ b/internal/provider/postgres/datasource/testdata/postgres_datasource_cassette.yaml
@@ -6,13 +6,13 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 254
+        content_length: 271
         transfer_encoding: []
         trailer: {}
         host: https://api.testing.render.com/v1
         remote_addr: ""
         request_uri: ""
-        body: '{"databaseName":"test_name_mnop","databaseUser":"test_user","diskSizeGB":20,"enableHighAvailability":false,"ipAllowList":[],"name":"some-name","ownerId":"some-owner-id","plan":"basic_256mb","readReplicas":null,"region":"oregon","version":"16"}'
+        body: '{"databaseName":"test_name_mnop","databaseUser":"test_user","diskSizeGB":20,"enableHighAvailability":false,"ipAllowList":[],"name":"some-name","ownerId":"some-owner-id","plan":"pro_4gb","readReplicas":[{"name":"read-replica"}],"region":"oregon","version":"16"}'
         form: {}
         headers:
             Authorization:
@@ -29,27 +29,30 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 613
+        content_length: 714
         uncompressed: false
         body: |
-            {"createdAt":"2024-11-18T21:38:30.555049664Z","dashboardUrl":"https://dashboard.render.com/d/dpg-cstr7llumphs73bl49m0-a","databaseName":"test_name_mnop_nno3","databaseUser":"test_user","diskSizeGB":20,"highAvailabilityEnabled":false,"id":"dpg-cstr7llumphs73bl49m0-a","ipAllowList":null,"name":"some-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Scott's Terraform","type":"team"},"plan":"basic_256mb","readReplicas":[],"region":"oregon","role":"primary","status":"unknown","suspended":"not_suspended","suspenders":[],"updatedAt":"2024-11-18T21:38:30.555049664Z","version":"16"}
+            {"createdAt":"2026-05-04T21:53:18.785441951Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7shajjrjlhs73bukk0g-a","databaseName":"test_name_mnop_2mfb","databaseUser":"test_user","diskAutoscalingEnabled":false,"diskSizeGB":20,"highAvailabilityEnabled":false,"id":"dpg-d7shajjrjlhs73bukk0g-a","ipAllowList":null,"name":"some-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"plan":"pro_4gb","readReplicas":[{"id":"dpg-d7shajjrjlhs73bukk0g-b","name":"read-replica"}],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T21:53:18.785441951Z","version":"16"}
         headers:
             Content-Length:
-                - "613"
+                - "714"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 18 Nov 2024 21:38:30 GMT
+                - Mon, 04 May 2026 21:53:19 GMT
             Ratelimit-Limit:
                 - "20"
             Ratelimit-Remaining:
-                - "18"
+                - "15"
             Ratelimit-Reset:
-                - "1289"
+                - "401"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-687866d5bb-vwctc/kE3WJpezVN-179814
+                - api-67697cb9cc-7hdlp/bSeT1VJf0a-440444
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=12,cfOrigin;dur=1001
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -60,7 +63,7 @@ interactions:
                 - 1; mode=block
         status: 201 Created
         code: 201
-        duration: 357.115083ms
+        duration: 1.160243208s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -79,7 +82,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-cstr7llumphs73bl49m0-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7shajjrjlhs73bukk0g-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -90,22 +93,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"createdAt":"2024-11-18T21:38:30.55505Z","dashboardUrl":"https://dashboard.render.com/d/dpg-cstr7llumphs73bl49m0-a","databaseName":"test_name_mnop_nno3","databaseUser":"test_user","diskSizeGB":20,"highAvailabilityEnabled":false,"id":"dpg-cstr7llumphs73bl49m0-a","ipAllowList":null,"name":"some-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Scott's Terraform","type":"team"},"plan":"basic_256mb","readReplicas":[],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2024-11-18T21:38:30.55505Z","version":"16"}
+            {"createdAt":"2026-05-04T21:53:18.785442Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7shajjrjlhs73bukk0g-a","databaseName":"test_name_mnop_2mfb","databaseUser":"test_user","diskAutoscalingEnabled":false,"diskSizeGB":20,"highAvailabilityEnabled":false,"id":"dpg-d7shajjrjlhs73bukk0g-a","ipAllowList":null,"name":"some-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"plan":"pro_4gb","readReplicas":[{"id":"dpg-d7shajjrjlhs73bukk0g-b","name":"read-replica"}],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T21:53:18.785442Z","version":"16"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 18 Nov 2024 21:38:30 GMT
+                - Mon, 04 May 2026 21:53:19 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
                 - "399"
             Ratelimit-Reset:
-                - "29"
+                - "40"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-687866d5bb-k2jsr/f23VPmaQwF-170724
+                - api-67697cb9cc-7hdlp/bSeT1VJf0a-440493
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=8,cfOrigin;dur=113
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -116,7 +122,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 89.176917ms
+        duration: 137.060708ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -135,7 +141,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-cstr7llumphs73bl49m0-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7shajjrjlhs73bukk0g-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -146,22 +152,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"createdAt":"2024-11-18T21:38:30.55505Z","dashboardUrl":"https://dashboard.render.com/d/dpg-cstr7llumphs73bl49m0-a","databaseName":"test_name_mnop_nno3","databaseUser":"test_user","diskSizeGB":20,"highAvailabilityEnabled":false,"id":"dpg-cstr7llumphs73bl49m0-a","ipAllowList":null,"name":"some-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Scott's Terraform","type":"team"},"plan":"basic_256mb","readReplicas":[],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2024-11-18T21:38:30.55505Z","version":"16"}
+            {"createdAt":"2026-05-04T21:53:18.785442Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7shajjrjlhs73bukk0g-a","databaseName":"test_name_mnop_2mfb","databaseUser":"test_user","diskAutoscalingEnabled":false,"diskSizeGB":20,"highAvailabilityEnabled":false,"id":"dpg-d7shajjrjlhs73bukk0g-a","ipAllowList":null,"name":"some-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"plan":"pro_4gb","readReplicas":[{"id":"dpg-d7shajjrjlhs73bukk0g-b","name":"read-replica"}],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T21:53:18.785442Z","version":"16"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 18 Nov 2024 21:38:33 GMT
+                - Mon, 04 May 2026 21:53:22 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
                 - "398"
             Ratelimit-Reset:
-                - "26"
+                - "37"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-687866d5bb-5twmc/WTOYdnQjV7-175925
+                - api-67697cb9cc-nzjtj/tk2FBh0tKJ-533672
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=95
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -172,7 +181,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 74.082917ms
+        duration: 123.662334ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -191,7 +200,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-cstr7llumphs73bl49m0-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7shajjrjlhs73bukk0g-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -202,22 +211,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"createdAt":"2024-11-18T21:38:30.55505Z","dashboardUrl":"https://dashboard.render.com/d/dpg-cstr7llumphs73bl49m0-a","databaseName":"test_name_mnop_nno3","databaseUser":"test_user","diskSizeGB":20,"highAvailabilityEnabled":false,"id":"dpg-cstr7llumphs73bl49m0-a","ipAllowList":null,"name":"some-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Scott's Terraform","type":"team"},"plan":"basic_256mb","readReplicas":[],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2024-11-18T21:38:30.55505Z","version":"16"}
+            {"createdAt":"2026-05-04T21:53:18.785442Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7shajjrjlhs73bukk0g-a","databaseName":"test_name_mnop_2mfb","databaseUser":"test_user","diskAutoscalingEnabled":false,"diskSizeGB":20,"highAvailabilityEnabled":false,"id":"dpg-d7shajjrjlhs73bukk0g-a","ipAllowList":null,"name":"some-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"plan":"pro_4gb","readReplicas":[{"id":"dpg-d7shajjrjlhs73bukk0g-b","name":"read-replica"}],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T21:53:18.785442Z","version":"16"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 18 Nov 2024 21:38:37 GMT
+                - Mon, 04 May 2026 21:53:26 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
                 - "397"
             Ratelimit-Reset:
-                - "22"
+                - "33"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-687866d5bb-4bk2t/FsCu0oZEsO-168344
+                - api-67697cb9cc-rr9lz/iQKxXhmUkr-342888
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=7,cfOrigin;dur=100
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -228,7 +240,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 81.067833ms
+        duration: 124.05ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -247,7 +259,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-cstr7llumphs73bl49m0-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7shajjrjlhs73bukk0g-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -258,22 +270,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"createdAt":"2024-11-18T21:38:30.55505Z","dashboardUrl":"https://dashboard.render.com/d/dpg-cstr7llumphs73bl49m0-a","databaseName":"test_name_mnop_nno3","databaseUser":"test_user","diskSizeGB":20,"highAvailabilityEnabled":false,"id":"dpg-cstr7llumphs73bl49m0-a","ipAllowList":null,"name":"some-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Scott's Terraform","type":"team"},"plan":"basic_256mb","readReplicas":[],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2024-11-18T21:38:30.55505Z","version":"16"}
+            {"createdAt":"2026-05-04T21:53:18.785442Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7shajjrjlhs73bukk0g-a","databaseName":"test_name_mnop_2mfb","databaseUser":"test_user","diskAutoscalingEnabled":false,"diskSizeGB":20,"highAvailabilityEnabled":false,"id":"dpg-d7shajjrjlhs73bukk0g-a","ipAllowList":null,"name":"some-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"plan":"pro_4gb","readReplicas":[{"id":"dpg-d7shajjrjlhs73bukk0g-b","name":"read-replica"}],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T21:53:18.785442Z","version":"16"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 18 Nov 2024 21:38:41 GMT
+                - Mon, 04 May 2026 21:53:30 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
                 - "396"
             Ratelimit-Reset:
-                - "18"
+                - "29"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-687866d5bb-vwctc/kE3WJpezVN-180060
+                - api-67697cb9cc-2x52t/rJPzHDiqR2-369481
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=5,cfOrigin;dur=132
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -284,7 +299,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 67.50475ms
+        duration: 178.260209ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -303,7 +318,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-cstr7llumphs73bl49m0-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7shajjrjlhs73bukk0g-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -314,22 +329,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"createdAt":"2024-11-18T21:38:30.55505Z","dashboardUrl":"https://dashboard.render.com/d/dpg-cstr7llumphs73bl49m0-a","databaseName":"test_name_mnop_nno3","databaseUser":"test_user","diskSizeGB":20,"highAvailabilityEnabled":false,"id":"dpg-cstr7llumphs73bl49m0-a","ipAllowList":null,"name":"some-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Scott's Terraform","type":"team"},"plan":"basic_256mb","readReplicas":[],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2024-11-18T21:38:30.55505Z","version":"16"}
+            {"createdAt":"2026-05-04T21:53:18.785442Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7shajjrjlhs73bukk0g-a","databaseName":"test_name_mnop_2mfb","databaseUser":"test_user","diskAutoscalingEnabled":false,"diskSizeGB":20,"highAvailabilityEnabled":false,"id":"dpg-d7shajjrjlhs73bukk0g-a","ipAllowList":null,"name":"some-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"plan":"pro_4gb","readReplicas":[{"id":"dpg-d7shajjrjlhs73bukk0g-b","name":"read-replica"}],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T21:53:18.785442Z","version":"16"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 18 Nov 2024 21:38:47 GMT
+                - Mon, 04 May 2026 21:53:36 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
                 - "395"
             Ratelimit-Reset:
-                - "12"
+                - "24"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-687866d5bb-k2jsr/f23VPmaQwF-171113
+                - api-67697cb9cc-hr98q/EEsGBcgj5Z-284443
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=100
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -340,7 +358,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 85.787ms
+        duration: 180.06375ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -359,7 +377,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-cstr7llumphs73bl49m0-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7shajjrjlhs73bukk0g-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -370,22 +388,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"createdAt":"2024-11-18T21:38:30.55505Z","dashboardUrl":"https://dashboard.render.com/d/dpg-cstr7llumphs73bl49m0-a","databaseName":"test_name_mnop_nno3","databaseUser":"test_user","diskSizeGB":20,"highAvailabilityEnabled":false,"id":"dpg-cstr7llumphs73bl49m0-a","ipAllowList":null,"name":"some-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Scott's Terraform","type":"team"},"plan":"basic_256mb","readReplicas":[],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2024-11-18T21:38:30.55505Z","version":"16"}
+            {"createdAt":"2026-05-04T21:53:18.785442Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7shajjrjlhs73bukk0g-a","databaseName":"test_name_mnop_2mfb","databaseUser":"test_user","diskAutoscalingEnabled":false,"diskSizeGB":20,"highAvailabilityEnabled":false,"id":"dpg-d7shajjrjlhs73bukk0g-a","ipAllowList":null,"name":"some-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"plan":"pro_4gb","readReplicas":[{"id":"dpg-d7shajjrjlhs73bukk0g-b","name":"read-replica"}],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T21:53:18.785442Z","version":"16"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 18 Nov 2024 21:38:53 GMT
+                - Mon, 04 May 2026 21:53:42 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
                 - "394"
             Ratelimit-Reset:
-                - "6"
+                - "17"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-687866d5bb-5twmc/WTOYdnQjV7-176407
+                - api-67697cb9cc-7hdlp/bSeT1VJf0a-441530
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=8,cfOrigin;dur=116
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -396,7 +417,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 84.440916ms
+        duration: 142.114542ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -415,7 +436,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-cstr7llumphs73bl49m0-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7shajjrjlhs73bukk0g-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -426,22 +447,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"createdAt":"2024-11-18T21:38:30.55505Z","dashboardUrl":"https://dashboard.render.com/d/dpg-cstr7llumphs73bl49m0-a","databaseName":"test_name_mnop_nno3","databaseUser":"test_user","diskSizeGB":20,"highAvailabilityEnabled":false,"id":"dpg-cstr7llumphs73bl49m0-a","ipAllowList":null,"name":"some-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Scott's Terraform","type":"team"},"plan":"basic_256mb","readReplicas":[],"region":"oregon","role":"primary","status":"available","suspended":"not_suspended","suspenders":[],"updatedAt":"2024-11-18T21:38:30.55505Z","version":"16"}
+            {"createdAt":"2026-05-04T21:53:18.785442Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7shajjrjlhs73bukk0g-a","databaseName":"test_name_mnop_2mfb","databaseUser":"test_user","diskAutoscalingEnabled":false,"diskSizeGB":20,"highAvailabilityEnabled":false,"id":"dpg-d7shajjrjlhs73bukk0g-a","ipAllowList":null,"name":"some-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"plan":"pro_4gb","readReplicas":[{"id":"dpg-d7shajjrjlhs73bukk0g-b","name":"read-replica"}],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T21:53:18.785442Z","version":"16"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 18 Nov 2024 21:39:01 GMT
+                - Mon, 04 May 2026 21:53:49 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "399"
+                - "393"
             Ratelimit-Reset:
-                - "59"
+                - "10"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-687866d5bb-4bk2t/FsCu0oZEsO-168844
+                - api-67697cb9cc-rr9lz/iQKxXhmUkr-343799
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=8,cfOrigin;dur=102
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -452,7 +476,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 135.6895ms
+        duration: 201.832459ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -471,7 +495,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-cstr7llumphs73bl49m0-a/connection-info
+        url: https://api.testing.render.com/v1/postgres/dpg-d7shajjrjlhs73bukk0g-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -482,22 +506,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"externalConnectionString":"postgresql://test_user:DGP1koXxaehlTMBZr3HEI8aapXm9yAAn@dpg-cstr7llumphs73bl49m0-a.oregon-postgres.render.com:5432/test_name_mnop_nno3","internalConnectionString":"postgresql://test_user:DGP1koXxaehlTMBZr3HEI8aapXm9yAAn@dpg-cstr7llumphs73bl49m0-a/test_name_mnop_nno3","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-cstr7llumphs73bl49m0-a.oregon-postgres.render.com -p 5432 -U test_user test_name_mnop_nno3"}
+            {"createdAt":"2026-05-04T21:53:18.785442Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7shajjrjlhs73bukk0g-a","databaseName":"test_name_mnop_2mfb","databaseUser":"test_user","diskAutoscalingEnabled":false,"diskSizeGB":20,"highAvailabilityEnabled":false,"id":"dpg-d7shajjrjlhs73bukk0g-a","ipAllowList":null,"name":"some-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"plan":"pro_4gb","readReplicas":[{"id":"dpg-d7shajjrjlhs73bukk0g-b","name":"read-replica"}],"region":"oregon","role":"primary","status":"available","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T21:53:18.785442Z","version":"16"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 18 Nov 2024 21:39:01 GMT
+                - Mon, 04 May 2026 21:53:59 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "398"
+                - "392"
             Ratelimit-Reset:
-                - "58"
+                - "0"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-687866d5bb-vwctc/kE3WJpezVN-180537
+                - api-67697cb9cc-7hdlp/bSeT1VJf0a-442316
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=7,cfOrigin;dur=118
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -508,7 +535,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 80.412791ms
+        duration: 144.995125ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -527,7 +554,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-cstr7llumphs73bl49m0-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7shajjrjlhs73bukk0g-a/connection-info
         method: GET
       response:
         proto: HTTP/2.0
@@ -538,22 +565,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"createdAt":"2024-11-18T21:38:30.55505Z","dashboardUrl":"https://dashboard.render.com/d/dpg-cstr7llumphs73bl49m0-a","databaseName":"test_name_mnop_nno3","databaseUser":"test_user","diskSizeGB":20,"highAvailabilityEnabled":false,"id":"dpg-cstr7llumphs73bl49m0-a","ipAllowList":null,"name":"some-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Scott's Terraform","type":"team"},"plan":"basic_256mb","readReplicas":[],"region":"oregon","role":"primary","status":"available","suspended":"not_suspended","suspenders":[],"updatedAt":"2024-11-18T21:38:30.55505Z","version":"16"}
+            {"externalConnectionString":"postgresql://test_user:IasDIlJ0cwqH4rD1VrS0yihXP6QD5VJU@dpg-d7shajjrjlhs73bukk0g-a.oregon-postgres.render.com:5432/test_name_mnop_2mfb","internalConnectionString":"postgresql://test_user:IasDIlJ0cwqH4rD1VrS0yihXP6QD5VJU@dpg-d7shajjrjlhs73bukk0g-a/test_name_mnop_2mfb","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-d7shajjrjlhs73bukk0g-a.oregon-postgres.render.com -p 5432 -U test_user test_name_mnop_2mfb"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 18 Nov 2024 21:39:01 GMT
+                - Mon, 04 May 2026 21:53:59 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "397"
+                - "391"
             Ratelimit-Reset:
-                - "58"
+                - "0"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-687866d5bb-k2jsr/f23VPmaQwF-171456
+                - api-67697cb9cc-8r4lj/bvH9OfgVXm-582199
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=8,cfOrigin;dur=111
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -564,27 +594,29 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 78.264125ms
+        duration: 137.672834ms
     - id: 10
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 18
         transfer_encoding: []
         trailer: {}
         host: https://api.testing.render.com/v1
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"setting":"drop"}'
         form: {}
         headers:
             Authorization:
                 - some-api-key
+            Content-Type:
+                - application/json
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-cstr7llumphs73bl49m0-a/connection-info
-        method: GET
+        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-d7shajjrjlhs73bukk0g-a
+        method: PUT
       response:
         proto: HTTP/2.0
         proto_major: 2
@@ -594,22 +626,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"externalConnectionString":"postgresql://test_user:DGP1koXxaehlTMBZr3HEI8aapXm9yAAn@dpg-cstr7llumphs73bl49m0-a.oregon-postgres.render.com:5432/test_name_mnop_nno3","internalConnectionString":"postgresql://test_user:DGP1koXxaehlTMBZr3HEI8aapXm9yAAn@dpg-cstr7llumphs73bl49m0-a/test_name_mnop_nno3","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-cstr7llumphs73bl49m0-a.oregon-postgres.render.com -p 5432 -U test_user test_name_mnop_nno3"}
+            {"endpoint":"","resourceId":"dpg-d7shajjrjlhs73bukk0g-a","setting":"drop"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 18 Nov 2024 21:39:01 GMT
+                - Mon, 04 May 2026 21:53:59 GMT
             Ratelimit-Limit:
-                - "400"
+                - "100"
             Ratelimit-Remaining:
-                - "396"
+                - "99"
             Ratelimit-Reset:
-                - "58"
+                - "0"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-687866d5bb-vwctc/kE3WJpezVN-180544
+                - api-67697cb9cc-hr98q/EEsGBcgj5Z-285214
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=11,cfOrigin;dur=84
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -620,27 +655,29 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 80.346334ms
+        duration: 144.481709ms
     - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 18
         transfer_encoding: []
         trailer: {}
         host: https://api.testing.render.com/v1
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"setting":"drop"}'
         form: {}
         headers:
             Authorization:
                 - some-api-key
+            Content-Type:
+                - application/json
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-cstr7llumphs73bl49m0-a
-        method: GET
+        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-d7shajjrjlhs73bukk0g-b
+        method: PUT
       response:
         proto: HTTP/2.0
         proto_major: 2
@@ -650,22 +687,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"message":"not found: dpg-cstr7llumphs73bl49m0-a"}
+            {"endpoint":"","resourceId":"dpg-d7shajjrjlhs73bukk0g-b","setting":"drop"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 18 Nov 2024 21:39:01 GMT
+                - Mon, 04 May 2026 21:53:59 GMT
             Ratelimit-Limit:
-                - "400"
+                - "100"
             Ratelimit-Remaining:
-                - "395"
+                - "98"
             Ratelimit-Reset:
-                - "58"
+                - "0"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-687866d5bb-vwctc/kE3WJpezVN-180551
+                - api-67697cb9cc-2x52t/rJPzHDiqR2-370599
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=9,cfOrigin;dur=85
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -674,9 +714,9 @@ interactions:
                 - DENY
             X-Xss-Protection:
                 - 1; mode=block
-        status: 404 Not Found
-        code: 404
-        duration: 149.904583ms
+        status: 200 OK
+        code: 200
+        duration: 111.540167ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -695,7 +735,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-cstr7llumphs73bl49m0-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7shajjrjlhs73bukk0g-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -706,22 +746,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"createdAt":"2024-11-18T21:38:30.55505Z","dashboardUrl":"https://dashboard.render.com/d/dpg-cstr7llumphs73bl49m0-a","databaseName":"test_name_mnop_nno3","databaseUser":"test_user","diskSizeGB":20,"highAvailabilityEnabled":false,"id":"dpg-cstr7llumphs73bl49m0-a","ipAllowList":null,"name":"some-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Scott's Terraform","type":"team"},"plan":"basic_256mb","readReplicas":[],"region":"oregon","role":"primary","status":"available","suspended":"not_suspended","suspenders":[],"updatedAt":"2024-11-18T21:38:30.55505Z","version":"16"}
+            {"createdAt":"2026-05-04T21:53:18.785442Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7shajjrjlhs73bukk0g-a","databaseName":"test_name_mnop_2mfb","databaseUser":"test_user","diskAutoscalingEnabled":false,"diskSizeGB":20,"highAvailabilityEnabled":false,"id":"dpg-d7shajjrjlhs73bukk0g-a","ipAllowList":null,"name":"some-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"plan":"pro_4gb","readReplicas":[{"id":"dpg-d7shajjrjlhs73bukk0g-b","name":"read-replica"}],"region":"oregon","role":"primary","status":"available","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T21:53:18.785442Z","version":"16"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 18 Nov 2024 21:39:02 GMT
+                - Mon, 04 May 2026 21:53:59 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "394"
+                - "390"
             Ratelimit-Reset:
-                - "58"
+                - "0"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-687866d5bb-k2jsr/f23VPmaQwF-171476
+                - api-67697cb9cc-nzjtj/tk2FBh0tKJ-535370
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=9,cfOrigin;dur=92
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -732,7 +775,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 100.058167ms
+        duration: 120.158958ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -751,7 +794,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-cstr7llumphs73bl49m0-a/connection-info
+        url: https://api.testing.render.com/v1/postgres/dpg-d7shajjrjlhs73bukk0g-a/connection-info
         method: GET
       response:
         proto: HTTP/2.0
@@ -762,22 +805,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"externalConnectionString":"postgresql://test_user:DGP1koXxaehlTMBZr3HEI8aapXm9yAAn@dpg-cstr7llumphs73bl49m0-a.oregon-postgres.render.com:5432/test_name_mnop_nno3","internalConnectionString":"postgresql://test_user:DGP1koXxaehlTMBZr3HEI8aapXm9yAAn@dpg-cstr7llumphs73bl49m0-a/test_name_mnop_nno3","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-cstr7llumphs73bl49m0-a.oregon-postgres.render.com -p 5432 -U test_user test_name_mnop_nno3"}
+            {"externalConnectionString":"postgresql://test_user:IasDIlJ0cwqH4rD1VrS0yihXP6QD5VJU@dpg-d7shajjrjlhs73bukk0g-a.oregon-postgres.render.com:5432/test_name_mnop_2mfb","internalConnectionString":"postgresql://test_user:IasDIlJ0cwqH4rD1VrS0yihXP6QD5VJU@dpg-d7shajjrjlhs73bukk0g-a/test_name_mnop_2mfb","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-d7shajjrjlhs73bukk0g-a.oregon-postgres.render.com -p 5432 -U test_user test_name_mnop_2mfb"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 18 Nov 2024 21:39:02 GMT
+                - Mon, 04 May 2026 21:53:59 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "393"
+                - "389"
             Ratelimit-Reset:
-                - "57"
+                - "0"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-687866d5bb-5twmc/WTOYdnQjV7-176615
+                - api-67697cb9cc-txqml/nqfxnrpqwi-271822
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=8,cfOrigin;dur=102
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -788,7 +834,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 246.573208ms
+        duration: 167.48325ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -807,7 +853,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-cstr7llumphs73bl49m0-a
+        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-d7shajjrjlhs73bukk0g-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -818,22 +864,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"message":"not found: dpg-cstr7llumphs73bl49m0-a"}
+            {"endpoint":"","resourceId":"dpg-d7shajjrjlhs73bukk0g-a","setting":"drop"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 18 Nov 2024 21:39:02 GMT
+                - Mon, 04 May 2026 21:54:00 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "392"
+                - "399"
             Ratelimit-Reset:
-                - "57"
+                - "59"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-687866d5bb-4bk2t/FsCu0oZEsO-168880
+                - api-67697cb9cc-hr98q/EEsGBcgj5Z-285237
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=149
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -842,9 +891,9 @@ interactions:
                 - DENY
             X-Xss-Protection:
                 - 1; mode=block
-        status: 404 Not Found
-        code: 404
-        duration: 106.093042ms
+        status: 200 OK
+        code: 200
+        duration: 169.248167ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -863,7 +912,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-cstr7llumphs73bl49m0-a
+        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-d7shajjrjlhs73bukk0g-b
         method: GET
       response:
         proto: HTTP/2.0
@@ -874,22 +923,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"createdAt":"2024-11-18T21:38:30.55505Z","dashboardUrl":"https://dashboard.render.com/d/dpg-cstr7llumphs73bl49m0-a","databaseName":"test_name_mnop_nno3","databaseUser":"test_user","diskSizeGB":20,"highAvailabilityEnabled":false,"id":"dpg-cstr7llumphs73bl49m0-a","ipAllowList":null,"name":"some-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Scott's Terraform","type":"team"},"plan":"basic_256mb","readReplicas":[],"region":"oregon","role":"primary","status":"available","suspended":"not_suspended","suspenders":[],"updatedAt":"2024-11-18T21:38:30.55505Z","version":"16"}
+            {"endpoint":"","resourceId":"dpg-d7shajjrjlhs73bukk0g-b","setting":"drop"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 18 Nov 2024 21:39:02 GMT
+                - Mon, 04 May 2026 21:54:00 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "391"
+                - "398"
             Ratelimit-Reset:
-                - "57"
+                - "59"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-687866d5bb-vwctc/kE3WJpezVN-180583
+                - api-67697cb9cc-hlhmt/HnNQegxyNd-446018
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=177
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -900,7 +952,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 95.5025ms
+        duration: 192.733708ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -919,7 +971,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-cstr7llumphs73bl49m0-a/connection-info
+        url: https://api.testing.render.com/v1/postgres/dpg-d7shajjrjlhs73bukk0g-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -930,22 +982,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"externalConnectionString":"postgresql://test_user:DGP1koXxaehlTMBZr3HEI8aapXm9yAAn@dpg-cstr7llumphs73bl49m0-a.oregon-postgres.render.com:5432/test_name_mnop_nno3","internalConnectionString":"postgresql://test_user:DGP1koXxaehlTMBZr3HEI8aapXm9yAAn@dpg-cstr7llumphs73bl49m0-a/test_name_mnop_nno3","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-cstr7llumphs73bl49m0-a.oregon-postgres.render.com -p 5432 -U test_user test_name_mnop_nno3"}
+            {"createdAt":"2026-05-04T21:53:18.785442Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7shajjrjlhs73bukk0g-a","databaseName":"test_name_mnop_2mfb","databaseUser":"test_user","diskAutoscalingEnabled":false,"diskSizeGB":20,"highAvailabilityEnabled":false,"id":"dpg-d7shajjrjlhs73bukk0g-a","ipAllowList":null,"name":"some-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"plan":"pro_4gb","readReplicas":[{"id":"dpg-d7shajjrjlhs73bukk0g-b","name":"read-replica"}],"region":"oregon","role":"primary","status":"available","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T21:53:18.785442Z","version":"16"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 18 Nov 2024 21:39:02 GMT
+                - Mon, 04 May 2026 21:54:00 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "390"
+                - "397"
             Ratelimit-Reset:
-                - "57"
+                - "59"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-687866d5bb-k2jsr/f23VPmaQwF-171492
+                - api-67697cb9cc-hr98q/EEsGBcgj5Z-285260
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=5,cfOrigin;dur=113
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -956,7 +1011,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 82.756334ms
+        duration: 174.467792ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -975,7 +1030,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-cstr7llumphs73bl49m0-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7shajjrjlhs73bukk0g-a/connection-info
         method: GET
       response:
         proto: HTTP/2.0
@@ -986,22 +1041,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"message":"not found: dpg-cstr7llumphs73bl49m0-a"}
+            {"externalConnectionString":"postgresql://test_user:IasDIlJ0cwqH4rD1VrS0yihXP6QD5VJU@dpg-d7shajjrjlhs73bukk0g-a.oregon-postgres.render.com:5432/test_name_mnop_2mfb","internalConnectionString":"postgresql://test_user:IasDIlJ0cwqH4rD1VrS0yihXP6QD5VJU@dpg-d7shajjrjlhs73bukk0g-a/test_name_mnop_2mfb","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-d7shajjrjlhs73bukk0g-a.oregon-postgres.render.com -p 5432 -U test_user test_name_mnop_2mfb"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 18 Nov 2024 21:39:03 GMT
+                - Mon, 04 May 2026 21:54:00 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "389"
+                - "396"
             Ratelimit-Reset:
-                - "57"
+                - "59"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-687866d5bb-5twmc/WTOYdnQjV7-176628
+                - api-67697cb9cc-dxjk6/4C2QjVr1j7-568892
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=159
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1010,9 +1068,9 @@ interactions:
                 - DENY
             X-Xss-Protection:
                 - 1; mode=block
-        status: 404 Not Found
-        code: 404
-        duration: 194.5185ms
+        status: 200 OK
+        code: 200
+        duration: 180.980625ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -1031,7 +1089,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-cstr7llumphs73bl49m0-a
+        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-d7shajjrjlhs73bukk0g-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1042,22 +1100,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"createdAt":"2024-11-18T21:38:30.55505Z","dashboardUrl":"https://dashboard.render.com/d/dpg-cstr7llumphs73bl49m0-a","databaseName":"test_name_mnop_nno3","databaseUser":"test_user","diskSizeGB":20,"highAvailabilityEnabled":false,"id":"dpg-cstr7llumphs73bl49m0-a","ipAllowList":null,"name":"some-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Scott's Terraform","type":"team"},"plan":"basic_256mb","readReplicas":[],"region":"oregon","role":"primary","status":"available","suspended":"not_suspended","suspenders":[],"updatedAt":"2024-11-18T21:38:30.55505Z","version":"16"}
+            {"endpoint":"","resourceId":"dpg-d7shajjrjlhs73bukk0g-a","setting":"drop"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 18 Nov 2024 21:39:03 GMT
+                - Mon, 04 May 2026 21:54:01 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "388"
+                - "395"
             Ratelimit-Reset:
-                - "56"
+                - "59"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-687866d5bb-4bk2t/FsCu0oZEsO-168908
+                - api-67697cb9cc-hlhmt/HnNQegxyNd-446042
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=8,cfOrigin;dur=186
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1068,7 +1129,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 78.234875ms
+        duration: 211.52825ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -1087,7 +1148,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-cstr7llumphs73bl49m0-a/connection-info
+        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-d7shajjrjlhs73bukk0g-b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1098,22 +1159,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"externalConnectionString":"postgresql://test_user:DGP1koXxaehlTMBZr3HEI8aapXm9yAAn@dpg-cstr7llumphs73bl49m0-a.oregon-postgres.render.com:5432/test_name_mnop_nno3","internalConnectionString":"postgresql://test_user:DGP1koXxaehlTMBZr3HEI8aapXm9yAAn@dpg-cstr7llumphs73bl49m0-a/test_name_mnop_nno3","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-cstr7llumphs73bl49m0-a.oregon-postgres.render.com -p 5432 -U test_user test_name_mnop_nno3"}
+            {"endpoint":"","resourceId":"dpg-d7shajjrjlhs73bukk0g-b","setting":"drop"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 18 Nov 2024 21:39:03 GMT
+                - Mon, 04 May 2026 21:54:01 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "387"
+                - "394"
             Ratelimit-Reset:
-                - "56"
+                - "58"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-687866d5bb-vwctc/kE3WJpezVN-180606
+                - api-67697cb9cc-7g8wf/qqOGxLHk0I-567790
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=7,cfOrigin;dur=197
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1124,7 +1188,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 142.9835ms
+        duration: 220.164291ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1143,7 +1207,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-cstr7llumphs73bl49m0-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7shajjrjlhs73bukk0g-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1154,22 +1218,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"message":"not found: dpg-cstr7llumphs73bl49m0-a"}
+            {"createdAt":"2026-05-04T21:53:18.785442Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7shajjrjlhs73bukk0g-a","databaseName":"test_name_mnop_2mfb","databaseUser":"test_user","diskAutoscalingEnabled":false,"diskSizeGB":20,"highAvailabilityEnabled":false,"id":"dpg-d7shajjrjlhs73bukk0g-a","ipAllowList":null,"name":"some-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"plan":"pro_4gb","readReplicas":[{"id":"dpg-d7shajjrjlhs73bukk0g-b","name":"read-replica"}],"region":"oregon","role":"primary","status":"available","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T21:53:18.785442Z","version":"16"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 18 Nov 2024 21:39:03 GMT
+                - Mon, 04 May 2026 21:54:01 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "386"
+                - "393"
             Ratelimit-Reset:
-                - "56"
+                - "58"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-687866d5bb-k2jsr/f23VPmaQwF-171511
+                - api-67697cb9cc-7hdlp/bSeT1VJf0a-442441
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=159
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1178,9 +1245,9 @@ interactions:
                 - DENY
             X-Xss-Protection:
                 - 1; mode=block
-        status: 404 Not Found
-        code: 404
-        duration: 87.450375ms
+        status: 200 OK
+        code: 200
+        duration: 196.030833ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1199,7 +1266,420 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-cstr7llumphs73bl49m0-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7shajjrjlhs73bukk0g-a/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"externalConnectionString":"postgresql://test_user:IasDIlJ0cwqH4rD1VrS0yihXP6QD5VJU@dpg-d7shajjrjlhs73bukk0g-a.oregon-postgres.render.com:5432/test_name_mnop_2mfb","internalConnectionString":"postgresql://test_user:IasDIlJ0cwqH4rD1VrS0yihXP6QD5VJU@dpg-d7shajjrjlhs73bukk0g-a/test_name_mnop_2mfb","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-d7shajjrjlhs73bukk0g-a.oregon-postgres.render.com -p 5432 -U test_user test_name_mnop_2mfb"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 21:54:01 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "392"
+            Ratelimit-Reset:
+                - "58"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-8r4lj/bvH9OfgVXm-582347
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=8,cfOrigin;dur=147
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 174.057125ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-d7shajjrjlhs73bukk0g-a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"endpoint":"","resourceId":"dpg-d7shajjrjlhs73bukk0g-a","setting":"drop"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 21:54:01 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "391"
+            Ratelimit-Reset:
+                - "58"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-hr98q/EEsGBcgj5Z-285309
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=178
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 215.209666ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-d7shajjrjlhs73bukk0g-b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"endpoint":"","resourceId":"dpg-d7shajjrjlhs73bukk0g-b","setting":"drop"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 21:54:02 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "390"
+            Ratelimit-Reset:
+                - "57"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-2x52t/rJPzHDiqR2-370717
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=7,cfOrigin;dur=229
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 258.48775ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/postgres/dpg-d7shajjrjlhs73bukk0g-a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"createdAt":"2026-05-04T21:53:18.785442Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7shajjrjlhs73bukk0g-a","databaseName":"test_name_mnop_2mfb","databaseUser":"test_user","diskAutoscalingEnabled":false,"diskSizeGB":20,"highAvailabilityEnabled":false,"id":"dpg-d7shajjrjlhs73bukk0g-a","ipAllowList":null,"name":"some-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"plan":"pro_4gb","readReplicas":[{"id":"dpg-d7shajjrjlhs73bukk0g-b","name":"read-replica"}],"region":"oregon","role":"primary","status":"available","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T21:53:18.785442Z","version":"16"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 21:54:02 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "389"
+            Ratelimit-Reset:
+                - "57"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-nzjtj/tk2FBh0tKJ-535501
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=5,cfOrigin;dur=117
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 153.764916ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/postgres/dpg-d7shajjrjlhs73bukk0g-a/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"externalConnectionString":"postgresql://test_user:IasDIlJ0cwqH4rD1VrS0yihXP6QD5VJU@dpg-d7shajjrjlhs73bukk0g-a.oregon-postgres.render.com:5432/test_name_mnop_2mfb","internalConnectionString":"postgresql://test_user:IasDIlJ0cwqH4rD1VrS0yihXP6QD5VJU@dpg-d7shajjrjlhs73bukk0g-a/test_name_mnop_2mfb","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-d7shajjrjlhs73bukk0g-a.oregon-postgres.render.com -p 5432 -U test_user test_name_mnop_2mfb"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 21:54:02 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "388"
+            Ratelimit-Reset:
+                - "57"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-hr98q/EEsGBcgj5Z-285330
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=7,cfOrigin;dur=112
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 215.4775ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-d7shajjrjlhs73bukk0g-a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"endpoint":"","resourceId":"dpg-d7shajjrjlhs73bukk0g-a","setting":"drop"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 21:54:02 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "387"
+            Ratelimit-Reset:
+                - "57"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-hlhmt/HnNQegxyNd-446120
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=7,cfOrigin;dur=158
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 185.023ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-d7shajjrjlhs73bukk0g-b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"endpoint":"","resourceId":"dpg-d7shajjrjlhs73bukk0g-b","setting":"drop"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 21:54:02 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "386"
+            Ratelimit-Reset:
+                - "57"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-hr98q/EEsGBcgj5Z-285346
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=152
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 172.73375ms
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/postgres/dpg-d7shajjrjlhs73bukk0g-a
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1212,7 +1692,7 @@ interactions:
         body: ""
         headers:
             Date:
-                - Mon, 18 Nov 2024 21:39:03 GMT
+                - Mon, 04 May 2026 21:54:03 GMT
             Ratelimit-Limit:
                 - "100"
             Ratelimit-Remaining:
@@ -1222,7 +1702,10 @@ interactions:
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-687866d5bb-5twmc/WTOYdnQjV7-176643
+                - api-67697cb9cc-dxjk6/4C2QjVr1j7-569047
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=493
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1233,4 +1716,4 @@ interactions:
                 - 1; mode=block
         status: 204 No Content
         code: 204
-        duration: 184.377834ms
+        duration: 550.665292ms

--- a/internal/provider/postgres/logstream.go
+++ b/internal/provider/postgres/logstream.go
@@ -1,0 +1,78 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"terraform-provider-render/internal/client"
+	"terraform-provider-render/internal/client/logs"
+	"terraform-provider-render/internal/provider/common"
+)
+
+// GetReplicaLogStreamOverrides fetches the log stream override for each replica
+// in pgReplicas. Returns a map keyed by replica ID. Replicas with no override
+// are omitted from the map.
+func GetReplicaLogStreamOverrides(ctx context.Context, apiClient *client.ClientWithResponses, pgReplicas client.ReadReplicas) (map[string]*logs.ResourceLogStreamSetting, error) {
+	out := make(map[string]*logs.ResourceLogStreamSetting, len(pgReplicas))
+	for _, replica := range pgReplicas {
+		replicaLSO, err := common.GetLogStreamOverrides(ctx, apiClient, replica.Id)
+		if err != nil {
+			return nil, fmt.Errorf("replica %s: %w", replica.Id, err)
+		}
+		if replicaLSO != nil {
+			out[replica.Id] = replicaLSO
+		}
+	}
+	return out, nil
+}
+
+// UpdateReplicaLogStreamOverrides applies the per-replica log_stream_override
+// changes described by plan and state. pgReplicas is the post-PATCH/POST replica
+// list returned by the API — the source of truth for replica IDs. plan and state
+// are the TF-level replica slices and are matched to pgReplicas by name; name is
+// Required in the schema and unique within a primary, so it's a stable join key.
+//
+// Returns a map keyed by replica ID with the resulting log stream setting.
+// Replicas whose update produced no setting are omitted.
+//
+// Edge case (intentionally not handled here): if a user renames a replica in
+// HCL (state name=A, plan name=B), the API treats this as delete-A + create-B
+// at the parent PATCH (see partitionReplicaNames in pkg/userdb/databaseservice/
+// apiservice.go). The deleted replica's log_stream_setting row is cleaned up
+// server-side as part of the postgres deletion path; we do not need to issue
+// an explicit DELETE here. If the API ever moves to in-place rename (no
+// recreate), this would silently leak the old override.
+func UpdateReplicaLogStreamOverrides(ctx context.Context, apiClient *client.ClientWithResponses, pgReplicas client.ReadReplicas, plan, state []ReadReplica) (map[string]*logs.ResourceLogStreamSetting, error) {
+	planByName := lsoByReplicaName(plan)
+	stateByName := lsoByReplicaName(state)
+
+	out := make(map[string]*logs.ResourceLogStreamSetting, len(pgReplicas))
+	for _, pgReplica := range pgReplicas {
+		replicaLSO, err := common.UpdateLogStreamOverride(
+			ctx,
+			apiClient,
+			pgReplica.Id,
+			&common.LogStreamOverrideStateAndPlan{
+				Plan:  planByName[pgReplica.Name],
+				State: stateByName[pgReplica.Name],
+			},
+		)
+		if err != nil {
+			return nil, fmt.Errorf("replica %s: %w", pgReplica.Id, err)
+		}
+		if replicaLSO != nil {
+			out[pgReplica.Id] = replicaLSO
+		}
+	}
+	return out, nil
+}
+
+func lsoByReplicaName(replicas []ReadReplica) map[string]types.Object {
+	m := make(map[string]types.Object, len(replicas))
+	for _, replica := range replicas {
+		m[replica.Name.ValueString()] = replica.LogStreamOverride
+	}
+	return m
+}

--- a/internal/provider/postgres/models.go
+++ b/internal/provider/postgres/models.go
@@ -95,85 +95,39 @@ func ParameterOverridesToGoMap(m types.Map, diags diag.Diagnostics) *client.Post
 }
 
 func ReadReplicaFromClient(c client.ReadReplicas, existingReplicas []ReadReplica, replicaLogStreams map[string]*logs.ResourceLogStreamSetting, diags diag.Diagnostics) []ReadReplica {
-	// Index API replicas by name. read_replicas is a List on the TF side, but
-	// the API returns replicas in unspecified SQL order (see PGClusterReplicas
-	// in the api repo's pkg/models/postgresdb.go — no ORDER BY). Sorting the
-	// returned slice to match existingReplicas order keeps state aligned with
-	// the user's HCL order regardless of how the API sorts the response.
-
-	// Preserve the plan's null-vs-empty distinction. With ListNestedAttribute,
-	// TF treats null and [] as different; returning [] when the plan was null
-	// (or vice versa) produces an "inconsistent result after apply" error.
-	// existingReplicas reflects what the user wrote in HCL: nil for omitted /
-	// `= null`, non-nil-empty for an explicit `= []`.
-	if len(c) == 0 {
-		if existingReplicas == nil {
-			return nil
-		}
-		return []ReadReplica{}
-	}
-
-	apiByName := make(map[string]client.ReadReplica, len(c))
+	var res []ReadReplica
 	for _, item := range c {
-		apiByName[item.Name] = item
-	}
-
-	res := make([]ReadReplica, 0, len(c))
-	consumed := make(map[string]struct{}, len(c))
-
-	build := func(item client.ReadReplica, existing *ReadReplica) ReadReplica {
+		// Convert parameter overrides
 		paramOverrides := ParameterOverridesToMap(item.ParameterOverrides, diags)
+
+		// Find matching replica in the existing model so we can (a) preserve
+		// null-vs-empty for parameter_overrides, and (b) thread the LSO token
+		// through, since the API doesn't return tokens on GET.
+		var existingReplica *ReadReplica
+		for i, er := range existingReplicas {
+			if er.Name.ValueString() == item.Name || er.ID.ValueString() == item.Id {
+				existingReplica = &existingReplicas[i]
+				break
+			}
+		}
+
 		if item.ParameterOverrides == nil || len(*item.ParameterOverrides) == 0 {
-			if existing != nil && existing.ParameterOverrides.IsNull() {
+			if existingReplica != nil && existingReplica.ParameterOverrides.IsNull() {
 				paramOverrides = types.MapNull(types.StringType)
 			}
 		}
 
 		var existingLSO types.Object
-		if existing != nil {
-			existingLSO = existing.LogStreamOverride
+		if existingReplica != nil {
+			existingLSO = existingReplica.LogStreamOverride
 		}
 
-		return ReadReplica{
+		res = append(res, ReadReplica{
 			Name:               types.StringValue(item.Name),
 			ID:                 types.StringValue(item.Id),
 			ParameterOverrides: paramOverrides,
 			LogStreamOverride:  common.LogStreamOverrideFromClient(replicaLogStreams[item.Id], existingLSO, diags),
-		}
-	}
-
-	// First pass: emit replicas in existingReplicas order, matched by name.
-	// This preserves the user's HCL ordering across refresh cycles in the
-	// resource path (where existingReplicas is plan/state). It also makes
-	// the no-op for the datasource path, where existingReplicas is always
-	// nil because read_replicas is Computed-only there.
-	for i := range existingReplicas {
-		existing := &existingReplicas[i]
-		name := existing.Name.ValueString()
-		if name == "" {
-			continue
-		}
-		item, ok := apiByName[name]
-		if !ok {
-			continue
-		}
-		res = append(res, build(item, existing))
-		consumed[name] = struct{}{}
-	}
-
-	// Second pass: append any API replicas the first pass didn't match.
-	// In the datasource this is the only branch used (existingReplicas is
-	// nil → first pass emits nothing). In the resource it's reached only
-	// when the API returns a replica the existing model doesn't know about
-	// — e.g. drift introduced out-of-band. Calling build with existing=nil
-	// means token will be types.StringNull, which matches the datasource's
-	// established behavior on the top-level log_stream_override (the API
-	// doesn't return tokens, so we have nothing to surface).
-	for _, item := range c {
-		if _, done := consumed[item.Name]; done {
-			continue
-		}
-		res = append(res, build(item, nil))
+		})
 	}
 
 	return res

--- a/internal/provider/postgres/models.go
+++ b/internal/provider/postgres/models.go
@@ -39,6 +39,7 @@ type ReadReplica struct {
 	Name               types.String `tfsdk:"name"`
 	ID                 types.String `tfsdk:"id"`
 	ParameterOverrides types.Map    `tfsdk:"parameter_overrides"`
+	LogStreamOverride  types.Object `tfsdk:"log_stream_override"`
 }
 
 type ConnectionInfo struct {
@@ -93,30 +94,86 @@ func ParameterOverridesToGoMap(m types.Map, diags diag.Diagnostics) *client.Post
 	return &goMap
 }
 
-func ReadReplicaFromClient(c client.ReadReplicas, existingReplicas []ReadReplica, diags diag.Diagnostics) []ReadReplica {
-	var res []ReadReplica
-	for _, item := range c {
-		// Convert parameter overrides
-		paramOverrides := ParameterOverridesToMap(item.ParameterOverrides, diags)
+func ReadReplicaFromClient(c client.ReadReplicas, existingReplicas []ReadReplica, replicaLogStreams map[string]*logs.ResourceLogStreamSetting, diags diag.Diagnostics) []ReadReplica {
+	// Index API replicas by name. read_replicas is a List on the TF side, but
+	// the API returns replicas in unspecified SQL order (see PGClusterReplicas
+	// in the api repo's pkg/models/postgresdb.go — no ORDER BY). Sorting the
+	// returned slice to match existingReplicas order keeps state aligned with
+	// the user's HCL order regardless of how the API sorts the response.
 
-		// Find matching replica in existing model to preserve null vs empty map
+	// Preserve the plan's null-vs-empty distinction. With ListNestedAttribute,
+	// TF treats null and [] as different; returning [] when the plan was null
+	// (or vice versa) produces an "inconsistent result after apply" error.
+	// existingReplicas reflects what the user wrote in HCL: nil for omitted /
+	// `= null`, non-nil-empty for an explicit `= []`.
+	if len(c) == 0 {
+		if existingReplicas == nil {
+			return nil
+		}
+		return []ReadReplica{}
+	}
+
+	apiByName := make(map[string]client.ReadReplica, len(c))
+	for _, item := range c {
+		apiByName[item.Name] = item
+	}
+
+	res := make([]ReadReplica, 0, len(c))
+	consumed := make(map[string]struct{}, len(c))
+
+	build := func(item client.ReadReplica, existing *ReadReplica) ReadReplica {
+		paramOverrides := ParameterOverridesToMap(item.ParameterOverrides, diags)
 		if item.ParameterOverrides == nil || len(*item.ParameterOverrides) == 0 {
-			// API returned empty - check if existing model had null
-			for _, existingReplica := range existingReplicas {
-				if existingReplica.Name.ValueString() == item.Name || existingReplica.ID.ValueString() == item.Id {
-					if existingReplica.ParameterOverrides.IsNull() {
-						paramOverrides = types.MapNull(types.StringType)
-					}
-					break
-				}
+			if existing != nil && existing.ParameterOverrides.IsNull() {
+				paramOverrides = types.MapNull(types.StringType)
 			}
 		}
 
-		res = append(res, ReadReplica{
+		var existingLSO types.Object
+		if existing != nil {
+			existingLSO = existing.LogStreamOverride
+		}
+
+		return ReadReplica{
 			Name:               types.StringValue(item.Name),
 			ID:                 types.StringValue(item.Id),
 			ParameterOverrides: paramOverrides,
-		})
+			LogStreamOverride:  common.LogStreamOverrideFromClient(replicaLogStreams[item.Id], existingLSO, diags),
+		}
+	}
+
+	// First pass: emit replicas in existingReplicas order, matched by name.
+	// This preserves the user's HCL ordering across refresh cycles in the
+	// resource path (where existingReplicas is plan/state). It also makes
+	// the no-op for the datasource path, where existingReplicas is always
+	// nil because read_replicas is Computed-only there.
+	for i := range existingReplicas {
+		existing := &existingReplicas[i]
+		name := existing.Name.ValueString()
+		if name == "" {
+			continue
+		}
+		item, ok := apiByName[name]
+		if !ok {
+			continue
+		}
+		res = append(res, build(item, existing))
+		consumed[name] = struct{}{}
+	}
+
+	// Second pass: append any API replicas the first pass didn't match.
+	// In the datasource this is the only branch used (existingReplicas is
+	// nil → first pass emits nothing). In the resource it's reached only
+	// when the API returns a replica the existing model doesn't know about
+	// — e.g. drift introduced out-of-band. Calling build with existing=nil
+	// means token will be types.StringNull, which matches the datasource's
+	// established behavior on the top-level log_stream_override (the API
+	// doesn't return tokens, so we have nothing to surface).
+	for _, item := range c {
+		if _, done := consumed[item.Name]; done {
+			continue
+		}
+		res = append(res, build(item, nil))
 	}
 
 	return res
@@ -160,7 +217,7 @@ func connectionInfoFromClient(c *client.PostgresConnectionInfo, diags diag.Diagn
 	return objectValue
 }
 
-func ModelFromClient(postgres *client.PostgresDetail, connectionInfo *client.PostgresConnectionInfo, logStreamOverrides *logs.ResourceLogStreamSetting, existingModel PostgresModel, diags diag.Diagnostics) PostgresModel {
+func ModelFromClient(postgres *client.PostgresDetail, connectionInfo *client.PostgresConnectionInfo, logStreamOverrides *logs.ResourceLogStreamSetting, replicaLogStreams map[string]*logs.ResourceLogStreamSetting, existingModel PostgresModel, diags diag.Diagnostics) PostgresModel {
 	// Handle parameter_overrides: preserve null if it was null in existing model
 	parameterOverrides := ParameterOverridesToMap(postgres.ParameterOverrides, diags)
 	if existingModel.ParameterOverrides.IsNull() && (postgres.ParameterOverrides == nil || len(*postgres.ParameterOverrides) == 0) {
@@ -181,7 +238,7 @@ func ModelFromClient(postgres *client.PostgresDetail, connectionInfo *client.Pos
 		Region:                  types.StringValue(string(postgres.Region)),
 		Role:                    types.StringValue(string(postgres.Role)),
 		HighAvailabilityEnabled: types.BoolValue(postgres.HighAvailabilityEnabled),
-		ReadReplicas:            ReadReplicaFromClient(postgres.ReadReplicas, existingModel.ReadReplicas, diags),
+		ReadReplicas:            ReadReplicaFromClient(postgres.ReadReplicas, existingModel.ReadReplicas, replicaLogStreams, diags),
 		Version:                 types.StringValue(string(postgres.Version)),
 		ConnectionInfo:          connectionInfoFromClient(connectionInfo, diags),
 		LogStreamOverride:       common.LogStreamOverrideFromClient(logStreamOverrides, existingModel.LogStreamOverride, diags),

--- a/internal/provider/postgres/resource/resource.go
+++ b/internal/provider/postgres/resource/resource.go
@@ -135,8 +135,14 @@ func (r *postgresResource) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
+	replicaLogStreams, err := postgres.UpdateReplicaLogStreamOverrides(ctx, r.client, pg.ReadReplicas, plan.ReadReplicas, nil)
+	if err != nil {
+		resp.Diagnostics.AddError("unable to create replica log stream overrides", err.Error())
+		return
+	}
+
 	// Set state to fully populated data
-	diags = resp.State.Set(ctx, postgres.ModelFromClient(&pg, &connectionInfo, logStreamOverrides, plan, resp.Diagnostics))
+	diags = resp.State.Set(ctx, postgres.ModelFromClient(&pg, &connectionInfo, logStreamOverrides, replicaLogStreams, plan, resp.Diagnostics))
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -184,8 +190,14 @@ func (r *postgresResource) Read(ctx context.Context, req resource.ReadRequest, r
 		return
 	}
 
+	replicaLogStreams, err := postgres.GetReplicaLogStreamOverrides(ctx, r.client, pg.ReadReplicas)
+	if err != nil {
+		resp.Diagnostics.AddError("unable to get replica log stream overrides", err.Error())
+		return
+	}
+
 	// Set refreshed state
-	diags = resp.State.Set(ctx, postgres.ModelFromClient(&pg, &connectionInfo, logStreamOverrides, state, resp.Diagnostics))
+	diags = resp.State.Set(ctx, postgres.ModelFromClient(&pg, &connectionInfo, logStreamOverrides, replicaLogStreams, state, resp.Diagnostics))
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -272,8 +284,14 @@ func (r *postgresResource) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
+	replicaLogStreams, err := postgres.UpdateReplicaLogStreamOverrides(ctx, r.client, pg.ReadReplicas, plan.ReadReplicas, state.ReadReplicas)
+	if err != nil {
+		resp.Diagnostics.AddError("unable to update replica log stream overrides", err.Error())
+		return
+	}
+
 	// Set state to fully populated data
-	diags = resp.State.Set(ctx, postgres.ModelFromClient(&pg, &connectionInfo, logStreamOverrides, plan, resp.Diagnostics))
+	diags = resp.State.Set(ctx, postgres.ModelFromClient(&pg, &connectionInfo, logStreamOverrides, replicaLogStreams, plan, resp.Diagnostics))
 	resp.Diagnostics.Append(diags...)
 }
 

--- a/internal/provider/postgres/resource/resource_test.go
+++ b/internal/provider/postgres/resource/resource_test.go
@@ -174,6 +174,59 @@ func TestAccPostgresResource(t *testing.T) {
 				),
 			},
 			{
+				// Add a log stream override on the replica
+				ConfigFile: config.StaticFile("./testdata/postgres.tf"),
+				ConfigVariables: config.Variables{
+					"name":                           config.StringVariable("new-name"),
+					"database_name":                  config.StringVariable("db_name"),
+					"database_user":                  config.StringVariable("db_user"),
+					"high_availability_enabled":      config.BoolVariable(true),
+					"plan":                           config.StringVariable("pro_4gb"),
+					"ver":                            config.StringVariable("15"),
+					"read_replica":                   config.BoolVariable(true),
+					"environment_name":               config.StringVariable("second"),
+					"has_log_stream_setting":         config.BoolVariable(false),
+					"has_replica_log_stream_setting": config.BoolVariable(true),
+					"disk_size_gb":                   config.IntegerVariable(25),
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						checks.ExpectNoReplace(),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "read_replicas.0.name", "read-replica"),
+					resource.TestCheckResourceAttr(resourceName, "read_replicas.0.log_stream_override.setting", "drop"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_stream_override.setting"),
+				),
+			},
+			{
+				// Remove the replica's log stream override
+				ConfigFile: config.StaticFile("./testdata/postgres.tf"),
+				ConfigVariables: config.Variables{
+					"name":                           config.StringVariable("new-name"),
+					"database_name":                  config.StringVariable("db_name"),
+					"database_user":                  config.StringVariable("db_user"),
+					"high_availability_enabled":      config.BoolVariable(true),
+					"plan":                           config.StringVariable("pro_4gb"),
+					"ver":                            config.StringVariable("15"),
+					"read_replica":                   config.BoolVariable(true),
+					"environment_name":               config.StringVariable("second"),
+					"has_log_stream_setting":         config.BoolVariable(false),
+					"has_replica_log_stream_setting": config.BoolVariable(false),
+					"disk_size_gb":                   config.IntegerVariable(25),
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						checks.ExpectNoReplace(),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "read_replicas.0.name", "read-replica"),
+					resource.TestCheckNoResourceAttr(resourceName, "read_replicas.0.log_stream_override.setting"),
+				),
+			},
+			{
 				// Update fields that require replacement
 				ConfigFile: config.StaticFile("./testdata/postgres.tf"),
 				ConfigVariables: config.Variables{

--- a/internal/provider/postgres/resource/schema.go
+++ b/internal/provider/postgres/resource/schema.go
@@ -92,7 +92,7 @@ func PostgresResourceSchema(ctx context.Context) schema.Schema {
 				},
 				Validators: []validator.String{resource.RegionValidator},
 			},
-			"read_replicas": schema.SetNestedAttribute{
+			"read_replicas": schema.ListNestedAttribute{
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"name": schema.StringAttribute{
@@ -114,6 +114,7 @@ func PostgresResourceSchema(ctx context.Context) schema.Schema {
 								mapplanmodifier.UseStateForUnknown(),
 							},
 						},
+						"log_stream_override": resource.LogStreamOverride,
 					},
 				},
 				Optional:            true,
@@ -161,8 +162,8 @@ func PostgresResourceSchema(ctx context.Context) schema.Schema {
 				},
 			},
 			"version": schema.StringAttribute{
-				Description:         "The Postgres version. Currently supported: `11`, `12`, `13`, `14`, `15`, `16`, and `17`",
-				MarkdownDescription: "The Postgres version. Currently supported: `11`, `12`, `13`, `14`, `15`, `16`, and `17`",
+				Description:         "The Postgres version. Currently supported: `11`, `12`, `13`, `14`, `15`, `16`, `17`, and `18`",
+				MarkdownDescription: "The Postgres version. Currently supported: `11`, `12`, `13`, `14`, `15`, `16`, `17`, and `18`",
 				Required:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),

--- a/internal/provider/postgres/resource/schema.go
+++ b/internal/provider/postgres/resource/schema.go
@@ -92,7 +92,7 @@ func PostgresResourceSchema(ctx context.Context) schema.Schema {
 				},
 				Validators: []validator.String{resource.RegionValidator},
 			},
-			"read_replicas": schema.ListNestedAttribute{
+			"read_replicas": schema.SetNestedAttribute{
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"name": schema.StringAttribute{
@@ -114,7 +114,7 @@ func PostgresResourceSchema(ctx context.Context) schema.Schema {
 								mapplanmodifier.UseStateForUnknown(),
 							},
 						},
-						"log_stream_override": resource.LogStreamOverride,
+						"log_stream_override": resource.ReplicaLogStreamOverride,
 					},
 				},
 				Optional:            true,

--- a/internal/provider/postgres/resource/testdata/postgres.tf
+++ b/internal/provider/postgres/resource/testdata/postgres.tf
@@ -35,6 +35,11 @@ variable "has_log_stream_setting" {
   type = bool
 }
 
+variable "has_replica_log_stream_setting" {
+  type    = bool
+  default = false
+}
+
 variable "disk_size_gb" {
   type = number
 }
@@ -73,6 +78,9 @@ resource "render_postgres" "test" {
   version = var.ver
   read_replicas = var.read_replica ? [{
     name = "read-replica"
+    log_stream_override = var.has_replica_log_stream_setting ? {
+      setting = "drop"
+    } : null
   }] : null
 
   log_stream_override = var.has_log_stream_setting ? {

--- a/internal/provider/postgres/resource/testdata/postgres.tf
+++ b/internal/provider/postgres/resource/testdata/postgres.tf
@@ -10,6 +10,7 @@ variable "database_user" {
   type = string
 }
 
+
 variable "high_availability_enabled" {
   type = bool
 }
@@ -27,8 +28,8 @@ variable "read_replica" {
 }
 
 variable "environment_name" {
-  type     = string
-  default  = null
+  type    = string
+  default = null
 }
 
 variable "has_log_stream_setting" {
@@ -46,36 +47,36 @@ variable "disk_size_gb" {
 
 locals {
   environment_map = {
-    "first" = render_project.first.environments
+    "first"  = render_project.first.environments
     "second" = render_project.second.environments
   }
 }
 
-resource "render_project" "first"  {
+resource "render_project" "first" {
   name = "first"
   environments = {
     "prod" : { name : "prod", protected_status : "protected" },
   }
 }
 
-resource "render_project" "second"  {
+resource "render_project" "second" {
   name = "second"
   environments = {
     "prod" : { name : "prod", protected_status : "protected" },
   }
   # Ensure there is always an order to creating these
-  depends_on = [    render_project.first  ]
+  depends_on = [render_project.first]
 }
 
 resource "render_postgres" "test" {
-  name = var.name
-  database_name = var.database_name
-  database_user = var.database_user
+  name                      = var.name
+  database_name             = var.database_name
+  database_user             = var.database_user
   high_availability_enabled = var.high_availability_enabled
-  plan = var.plan
-  disk_size_gb = var.disk_size_gb
-  region = "oregon"
-  version = var.ver
+  plan                      = var.plan
+  disk_size_gb              = var.disk_size_gb
+  region                    = "oregon"
+  version                   = var.ver
   read_replicas = var.read_replica ? [{
     name = "read-replica"
     log_stream_override = var.has_replica_log_stream_setting ? {
@@ -88,5 +89,5 @@ resource "render_postgres" "test" {
   } : null
 
   environment_id = var.environment_name != null ? local.environment_map[var.environment_name]["prod"].id : null
-  depends_on = [render_project.first, render_project.second]
+  depends_on     = [render_project.first, render_project.second]
 }

--- a/internal/provider/postgres/resource/testdata/postgres_cassette.yaml
+++ b/internal/provider/postgres/resource/testdata/postgres_cassette.yaml
@@ -6,13 +6,13 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 116
+        content_length: 148
         transfer_encoding: []
         trailer: {}
         host: https://api.testing.render.com/v1
         remote_addr: ""
         request_uri: ""
-        body: '{"environments":[{"name":"prod","protectedStatus":"protected"}],"name":"first","ownerId":"some-owner-id"}'
+        body: '{"environments":[{"name":"prod","networkIsolationEnabled":false,"protectedStatus":"protected"}],"name":"first","ownerId":"some-owner-id"}'
         form: {}
         headers:
             Authorization:
@@ -29,27 +29,30 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 289
+        content_length: 305
         uncompressed: false
         body: |
-            {"createdAt":"2024-11-14T22:37:45.702937Z","environmentIds":["evm-csr7nebv2p9s739qqjj0"],"id":"prj-csr7nebv2p9s739qqjig","name":"first","owner":{"email":"email@example.com","id":"some-owner-id","name":"Scott's Terraform","type":"team"},"updatedAt":"2024-11-14T22:37:45.702937Z"}
+            {"createdAt":"2026-05-04T20:43:01.298824Z","environmentIds":["evm-d7sg9l8k1i2s7381aj20"],"id":"prj-d7sg9l8k1i2s7381aj10","name":"first","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"updatedAt":"2026-05-04T20:43:01.298824Z"}
         headers:
             Content-Length:
-                - "289"
+                - "305"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:37:47 GMT
+                - Mon, 04 May 2026 20:43:01 GMT
             Ratelimit-Limit:
                 - "100"
             Ratelimit-Remaining:
                 - "99"
             Ratelimit-Reset:
-                - "14"
+                - "58"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-008484
+                - api-67697cb9cc-xcbhc/vgcYLi38GW-154027
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=13,cfOrigin;dur=185
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -60,7 +63,7 @@ interactions:
                 - 1; mode=block
         status: 201 Created
         code: 201
-        duration: 1.728966542s
+        duration: 392.107ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -79,7 +82,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/environments/evm-csr7nebv2p9s739qqjj0
+        url: https://api.testing.render.com/v1/environments/evm-d7sg9l8k1i2s7381aj20
         method: GET
       response:
         proto: HTTP/2.0
@@ -90,22 +93,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"databasesIds":null,"envGroupIds":null,"id":"evm-csr7nebv2p9s739qqjj0","name":"prod","projectId":"prj-csr7nebv2p9s739qqjig","protectedStatus":"protected","redisIds":null,"serviceIds":null}
+            {"databasesIds":null,"envGroupIds":null,"id":"evm-d7sg9l8k1i2s7381aj20","ipAllowList":[{"cidrBlock":"0.0.0.0/0","description":"everywhere"}],"name":"prod","networkIsolationEnabled":false,"projectId":"prj-d7sg9l8k1i2s7381aj10","protectedStatus":"protected","redisIds":null,"serviceIds":null}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:37:47 GMT
+                - Mon, 04 May 2026 20:43:01 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
                 - "399"
             Ratelimit-Reset:
-                - "12"
+                - "58"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-008524
+                - api-67697cb9cc-8r4lj/bvH9OfgVXm-326119
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=10,cfOrigin;dur=82
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -116,19 +122,19 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 110.676125ms
+        duration: 110.666ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 117
+        content_length: 149
         transfer_encoding: []
         trailer: {}
         host: https://api.testing.render.com/v1
         remote_addr: ""
         request_uri: ""
-        body: '{"environments":[{"name":"prod","protectedStatus":"protected"}],"name":"second","ownerId":"some-owner-id"}'
+        body: '{"environments":[{"name":"prod","networkIsolationEnabled":false,"protectedStatus":"protected"}],"name":"second","ownerId":"some-owner-id"}'
         form: {}
         headers:
             Authorization:
@@ -145,27 +151,30 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 290
+        content_length: 306
         uncompressed: false
         body: |
-            {"createdAt":"2024-11-14T22:37:47.431359Z","environmentIds":["evm-csr7nerv2p9s739qqjlg"],"id":"prj-csr7nerv2p9s739qqjl0","name":"second","owner":{"email":"email@example.com","id":"some-owner-id","name":"Scott's Terraform","type":"team"},"updatedAt":"2024-11-14T22:37:47.431359Z"}
+            {"createdAt":"2026-05-04T20:43:01.679555Z","environmentIds":["evm-d7sg9lbeo5us73ahovp0"],"id":"prj-d7sg9lbeo5us73ahovo0","name":"second","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"updatedAt":"2026-05-04T20:43:01.679555Z"}
         headers:
             Content-Length:
-                - "290"
+                - "306"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:37:47 GMT
+                - Mon, 04 May 2026 20:43:01 GMT
             Ratelimit-Limit:
                 - "100"
             Ratelimit-Remaining:
                 - "98"
             Ratelimit-Reset:
-                - "12"
+                - "58"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-008527
+                - api-67697cb9cc-hlhmt/HnNQegxyNd-255025
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=14,cfOrigin;dur=178
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -176,7 +185,7 @@ interactions:
                 - 1; mode=block
         status: 201 Created
         code: 201
-        duration: 132.390875ms
+        duration: 214.030292ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -195,7 +204,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/environments/evm-csr7nerv2p9s739qqjlg
+        url: https://api.testing.render.com/v1/environments/evm-d7sg9lbeo5us73ahovp0
         method: GET
       response:
         proto: HTTP/2.0
@@ -206,22 +215,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"databasesIds":null,"envGroupIds":null,"id":"evm-csr7nerv2p9s739qqjlg","name":"prod","projectId":"prj-csr7nerv2p9s739qqjl0","protectedStatus":"protected","redisIds":null,"serviceIds":null}
+            {"databasesIds":null,"envGroupIds":null,"id":"evm-d7sg9lbeo5us73ahovp0","ipAllowList":[{"cidrBlock":"0.0.0.0/0","description":"everywhere"}],"name":"prod","networkIsolationEnabled":false,"projectId":"prj-d7sg9lbeo5us73ahovo0","protectedStatus":"protected","redisIds":null,"serviceIds":null}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:37:47 GMT
+                - Mon, 04 May 2026 20:43:01 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
                 - "398"
             Ratelimit-Reset:
-                - "12"
+                - "58"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-008532
+                - api-67697cb9cc-hr98q/EEsGBcgj5Z-130855
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=8,cfOrigin;dur=88
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -232,7 +244,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 69.561542ms
+        duration: 110.013333ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -244,7 +256,7 @@ interactions:
         host: https://api.testing.render.com/v1
         remote_addr: ""
         request_uri: ""
-        body: '{"databaseName":"db_name","databaseUser":"db_user","diskSizeGB":20,"enableHighAvailability":false,"environmentId":"evm-csr7nebv2p9s739qqjj0","ipAllowList":[],"name":"some-name","ownerId":"some-owner-id","plan":"basic_256mb","readReplicas":null,"region":"oregon","version":"15"}'
+        body: '{"databaseName":"db_name","databaseUser":"db_user","diskSizeGB":20,"enableHighAvailability":false,"environmentId":"evm-d7sg9l8k1i2s7381aj20","ipAllowList":[],"name":"some-name","ownerId":"some-owner-id","plan":"basic_256mb","readReplicas":null,"region":"oregon","version":"15"}'
         form: {}
         headers:
             Authorization:
@@ -261,27 +273,30 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 647
+        content_length: 692
         uncompressed: false
         body: |
-            {"createdAt":"2024-11-14T22:37:48.153701574Z","dashboardUrl":"https://dashboard.render.com/d/dpg-csr7nf3v2p9s739qqjq0-a","databaseName":"db_name_nui3","databaseUser":"db_user","diskSizeGB":20,"environmentId":"evm-csr7nebv2p9s739qqjj0","highAvailabilityEnabled":false,"id":"dpg-csr7nf3v2p9s739qqjq0-a","ipAllowList":null,"name":"some-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Scott's Terraform","type":"team"},"plan":"basic_256mb","readReplicas":[],"region":"oregon","role":"primary","status":"unknown","suspended":"not_suspended","suspenders":[],"updatedAt":"2024-11-14T22:37:48.153701574Z","version":"15"}
+            {"createdAt":"2026-05-04T20:43:02.84289922Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sg9ln7f7vs73d9bg5g-a","databaseName":"db_name_ehyv","databaseUser":"db_user","diskAutoscalingEnabled":false,"diskSizeGB":20,"environmentId":"evm-d7sg9l8k1i2s7381aj20","highAvailabilityEnabled":false,"id":"dpg-d7sg9ln7f7vs73d9bg5g-a","ipAllowList":null,"name":"some-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"plan":"basic_256mb","readReplicas":[],"region":"oregon","role":"primary","status":"unknown","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T20:43:02.84289922Z","version":"15"}
         headers:
             Content-Length:
-                - "647"
+                - "692"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:37:48 GMT
+                - Mon, 04 May 2026 20:43:03 GMT
             Ratelimit-Limit:
                 - "20"
             Ratelimit-Remaining:
-                - "5"
+                - "18"
             Ratelimit-Reset:
-                - "1332"
+                - "1017"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-008537
+                - api-67697cb9cc-mj245/HwjA0atTkv-226324
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=7,cfOrigin;dur=997
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -292,7 +307,7 @@ interactions:
                 - 1; mode=block
         status: 201 Created
         code: 201
-        duration: 574.150042ms
+        duration: 1.022058834s
     - id: 5
       request:
         proto: HTTP/1.1
@@ -311,7 +326,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-csr7nf3v2p9s739qqjq0-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sg9ln7f7vs73d9bg5g-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -322,22 +337,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"createdAt":"2024-11-14T22:37:48.153702Z","dashboardUrl":"https://dashboard.render.com/d/dpg-csr7nf3v2p9s739qqjq0-a","databaseName":"db_name_nui3","databaseUser":"db_user","diskSizeGB":20,"environmentId":"evm-csr7nebv2p9s739qqjj0","highAvailabilityEnabled":false,"id":"dpg-csr7nf3v2p9s739qqjq0-a","ipAllowList":null,"name":"some-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Scott's Terraform","type":"team"},"plan":"basic_256mb","readReplicas":[],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2024-11-14T22:37:48.153702Z","version":"15"}
+            {"createdAt":"2026-05-04T20:43:02.842899Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sg9ln7f7vs73d9bg5g-a","databaseName":"db_name_ehyv","databaseUser":"db_user","diskAutoscalingEnabled":false,"diskSizeGB":20,"environmentId":"evm-d7sg9l8k1i2s7381aj20","highAvailabilityEnabled":false,"id":"dpg-d7sg9ln7f7vs73d9bg5g-a","ipAllowList":null,"name":"some-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"plan":"basic_256mb","readReplicas":[],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T20:43:02.842899Z","version":"15"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:37:48 GMT
+                - Mon, 04 May 2026 20:43:03 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
                 - "397"
             Ratelimit-Reset:
-                - "11"
+                - "56"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-008546
+                - api-67697cb9cc-rr9lz/iQKxXhmUkr-189655
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=8,cfOrigin;dur=104
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -348,7 +366,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 81.808292ms
+        duration: 128.413959ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -367,7 +385,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-csr7nf3v2p9s739qqjq0-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sg9ln7f7vs73d9bg5g-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -378,22 +396,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"createdAt":"2024-11-14T22:37:48.153702Z","dashboardUrl":"https://dashboard.render.com/d/dpg-csr7nf3v2p9s739qqjq0-a","databaseName":"db_name_nui3","databaseUser":"db_user","diskSizeGB":20,"environmentId":"evm-csr7nebv2p9s739qqjj0","highAvailabilityEnabled":false,"id":"dpg-csr7nf3v2p9s739qqjq0-a","ipAllowList":null,"name":"some-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Scott's Terraform","type":"team"},"plan":"basic_256mb","readReplicas":[],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2024-11-14T22:37:48.153702Z","version":"15"}
+            {"createdAt":"2026-05-04T20:43:02.842899Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sg9ln7f7vs73d9bg5g-a","databaseName":"db_name_ehyv","databaseUser":"db_user","diskAutoscalingEnabled":false,"diskSizeGB":20,"environmentId":"evm-d7sg9l8k1i2s7381aj20","highAvailabilityEnabled":false,"id":"dpg-d7sg9ln7f7vs73d9bg5g-a","ipAllowList":null,"name":"some-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"plan":"basic_256mb","readReplicas":[],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T20:43:02.842899Z","version":"15"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:37:51 GMT
+                - Mon, 04 May 2026 20:43:06 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
                 - "396"
             Ratelimit-Reset:
-                - "8"
+                - "53"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-008598
+                - api-67697cb9cc-swx5g/Htral3X5Am-209017
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=100
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -404,7 +425,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 105.558125ms
+        duration: 127.324209ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -423,7 +444,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-csr7nf3v2p9s739qqjq0-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sg9ln7f7vs73d9bg5g-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -434,22 +455,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"createdAt":"2024-11-14T22:37:48.153702Z","dashboardUrl":"https://dashboard.render.com/d/dpg-csr7nf3v2p9s739qqjq0-a","databaseName":"db_name_nui3","databaseUser":"db_user","diskSizeGB":20,"environmentId":"evm-csr7nebv2p9s739qqjj0","highAvailabilityEnabled":false,"id":"dpg-csr7nf3v2p9s739qqjq0-a","ipAllowList":null,"name":"some-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Scott's Terraform","type":"team"},"plan":"basic_256mb","readReplicas":[],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2024-11-14T22:37:48.153702Z","version":"15"}
+            {"createdAt":"2026-05-04T20:43:02.842899Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sg9ln7f7vs73d9bg5g-a","databaseName":"db_name_ehyv","databaseUser":"db_user","diskAutoscalingEnabled":false,"diskSizeGB":20,"environmentId":"evm-d7sg9l8k1i2s7381aj20","highAvailabilityEnabled":false,"id":"dpg-d7sg9ln7f7vs73d9bg5g-a","ipAllowList":null,"name":"some-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"plan":"basic_256mb","readReplicas":[],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T20:43:02.842899Z","version":"15"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:37:55 GMT
+                - Mon, 04 May 2026 20:43:10 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
                 - "395"
             Ratelimit-Reset:
-                - "4"
+                - "50"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-008678
+                - api-67697cb9cc-hlhmt/HnNQegxyNd-255479
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=113
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -460,7 +484,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 88.634542ms
+        duration: 137.2175ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -479,7 +503,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-csr7nf3v2p9s739qqjq0-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sg9ln7f7vs73d9bg5g-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -490,22 +514,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"createdAt":"2024-11-14T22:37:48.153702Z","dashboardUrl":"https://dashboard.render.com/d/dpg-csr7nf3v2p9s739qqjq0-a","databaseName":"db_name_nui3","databaseUser":"db_user","diskSizeGB":20,"environmentId":"evm-csr7nebv2p9s739qqjj0","highAvailabilityEnabled":false,"id":"dpg-csr7nf3v2p9s739qqjq0-a","ipAllowList":null,"name":"some-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Scott's Terraform","type":"team"},"plan":"basic_256mb","readReplicas":[],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2024-11-14T22:37:48.153702Z","version":"15"}
+            {"createdAt":"2026-05-04T20:43:02.842899Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sg9ln7f7vs73d9bg5g-a","databaseName":"db_name_ehyv","databaseUser":"db_user","diskAutoscalingEnabled":false,"diskSizeGB":20,"environmentId":"evm-d7sg9l8k1i2s7381aj20","highAvailabilityEnabled":false,"id":"dpg-d7sg9ln7f7vs73d9bg5g-a","ipAllowList":null,"name":"some-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"plan":"basic_256mb","readReplicas":[],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T20:43:02.842899Z","version":"15"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:37:59 GMT
+                - Mon, 04 May 2026 20:43:14 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
                 - "394"
             Ratelimit-Reset:
-                - "0"
+                - "45"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-008777
+                - api-67697cb9cc-xcbhc/vgcYLi38GW-154650
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=96
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -516,7 +543,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 77.9095ms
+        duration: 145.764916ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -535,7 +562,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-csr7nf3v2p9s739qqjq0-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sg9ln7f7vs73d9bg5g-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -546,22 +573,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"createdAt":"2024-11-14T22:37:48.153702Z","dashboardUrl":"https://dashboard.render.com/d/dpg-csr7nf3v2p9s739qqjq0-a","databaseName":"db_name_nui3","databaseUser":"db_user","diskSizeGB":20,"environmentId":"evm-csr7nebv2p9s739qqjj0","highAvailabilityEnabled":false,"id":"dpg-csr7nf3v2p9s739qqjq0-a","ipAllowList":null,"name":"some-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Scott's Terraform","type":"team"},"plan":"basic_256mb","readReplicas":[],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2024-11-14T22:37:48.153702Z","version":"15"}
+            {"createdAt":"2026-05-04T20:43:02.842899Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sg9ln7f7vs73d9bg5g-a","databaseName":"db_name_ehyv","databaseUser":"db_user","diskAutoscalingEnabled":false,"diskSizeGB":20,"environmentId":"evm-d7sg9l8k1i2s7381aj20","highAvailabilityEnabled":false,"id":"dpg-d7sg9ln7f7vs73d9bg5g-a","ipAllowList":null,"name":"some-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"plan":"basic_256mb","readReplicas":[],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T20:43:02.842899Z","version":"15"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:38:04 GMT
+                - Mon, 04 May 2026 20:43:19 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "399"
+                - "393"
             Ratelimit-Reset:
-                - "55"
+                - "40"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-008906
+                - api-67697cb9cc-mj245/HwjA0atTkv-227322
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=118
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -572,7 +602,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 90.865083ms
+        duration: 138.77375ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -591,7 +621,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-csr7nf3v2p9s739qqjq0-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sg9ln7f7vs73d9bg5g-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -602,22 +632,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"createdAt":"2024-11-14T22:37:48.153702Z","dashboardUrl":"https://dashboard.render.com/d/dpg-csr7nf3v2p9s739qqjq0-a","databaseName":"db_name_nui3","databaseUser":"db_user","diskSizeGB":20,"environmentId":"evm-csr7nebv2p9s739qqjj0","highAvailabilityEnabled":false,"id":"dpg-csr7nf3v2p9s739qqjq0-a","ipAllowList":null,"name":"some-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Scott's Terraform","type":"team"},"plan":"basic_256mb","readReplicas":[],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2024-11-14T22:37:48.153702Z","version":"15"}
+            {"createdAt":"2026-05-04T20:43:02.842899Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sg9ln7f7vs73d9bg5g-a","databaseName":"db_name_ehyv","databaseUser":"db_user","diskAutoscalingEnabled":false,"diskSizeGB":20,"environmentId":"evm-d7sg9l8k1i2s7381aj20","highAvailabilityEnabled":false,"id":"dpg-d7sg9ln7f7vs73d9bg5g-a","ipAllowList":null,"name":"some-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"plan":"basic_256mb","readReplicas":[],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T20:43:02.842899Z","version":"15"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:38:11 GMT
+                - Mon, 04 May 2026 20:43:26 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "398"
+                - "392"
             Ratelimit-Reset:
-                - "48"
+                - "33"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-009026
+                - api-67697cb9cc-7g8wf/qqOGxLHk0I-346669
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=5,cfOrigin;dur=113
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -628,7 +661,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 91.460459ms
+        duration: 162.747667ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -647,7 +680,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-csr7nf3v2p9s739qqjq0-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sg9ln7f7vs73d9bg5g-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -658,22 +691,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"createdAt":"2024-11-14T22:37:48.153702Z","dashboardUrl":"https://dashboard.render.com/d/dpg-csr7nf3v2p9s739qqjq0-a","databaseName":"db_name_nui3","databaseUser":"db_user","diskSizeGB":20,"environmentId":"evm-csr7nebv2p9s739qqjj0","highAvailabilityEnabled":false,"id":"dpg-csr7nf3v2p9s739qqjq0-a","ipAllowList":null,"name":"some-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Scott's Terraform","type":"team"},"plan":"basic_256mb","readReplicas":[],"region":"oregon","role":"primary","status":"available","suspended":"not_suspended","suspenders":[],"updatedAt":"2024-11-14T22:37:48.153702Z","version":"15"}
+            {"createdAt":"2026-05-04T20:43:02.842899Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sg9ln7f7vs73d9bg5g-a","databaseName":"db_name_ehyv","databaseUser":"db_user","diskAutoscalingEnabled":false,"diskSizeGB":20,"environmentId":"evm-d7sg9l8k1i2s7381aj20","highAvailabilityEnabled":false,"id":"dpg-d7sg9ln7f7vs73d9bg5g-a","ipAllowList":null,"name":"some-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"plan":"basic_256mb","readReplicas":[],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T20:43:02.842899Z","version":"15"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:38:18 GMT
+                - Mon, 04 May 2026 20:43:33 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "397"
+                - "391"
             Ratelimit-Reset:
-                - "41"
+                - "26"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-009178
+                - api-67697cb9cc-2th7z/x5t6h1CqqQ-268181
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=96
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -684,7 +720,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 134.158416ms
+        duration: 191.208041ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -703,7 +739,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-csr7nf3v2p9s739qqjq0-a/connection-info
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sg9ln7f7vs73d9bg5g-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -714,22 +750,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"externalConnectionString":"postgresql://db_user:IEE33ctjj8AfvV7yA4nJzNmfoBCGk3Jw@dpg-csr7nf3v2p9s739qqjq0-a.oregon-postgres.render.com:5432/db_name_nui3","internalConnectionString":"postgresql://db_user:IEE33ctjj8AfvV7yA4nJzNmfoBCGk3Jw@dpg-csr7nf3v2p9s739qqjq0-a/db_name_nui3","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-csr7nf3v2p9s739qqjq0-a.oregon-postgres.render.com -p 5432 -U db_user db_name_nui3"}
+            {"createdAt":"2026-05-04T20:43:02.842899Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sg9ln7f7vs73d9bg5g-a","databaseName":"db_name_ehyv","databaseUser":"db_user","diskAutoscalingEnabled":false,"diskSizeGB":20,"environmentId":"evm-d7sg9l8k1i2s7381aj20","highAvailabilityEnabled":false,"id":"dpg-d7sg9ln7f7vs73d9bg5g-a","ipAllowList":null,"name":"some-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"plan":"basic_256mb","readReplicas":[],"region":"oregon","role":"primary","status":"available","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T20:43:02.842899Z","version":"15"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:38:18 GMT
+                - Mon, 04 May 2026 20:43:42 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "396"
+                - "390"
             Ratelimit-Reset:
-                - "41"
+                - "17"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-009181
+                - api-67697cb9cc-8r4lj/bvH9OfgVXm-328870
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=5,cfOrigin;dur=109
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -740,8 +779,67 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 114.263708ms
+        duration: 137.642042ms
     - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sg9ln7f7vs73d9bg5g-a/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"externalConnectionString":"postgresql://db_user:kWnZFH3RCkyZCEvJX2zJfw6NneSC9qPs@dpg-d7sg9ln7f7vs73d9bg5g-a.oregon-postgres.render.com:5432/db_name_ehyv","internalConnectionString":"postgresql://db_user:kWnZFH3RCkyZCEvJX2zJfw6NneSC9qPs@dpg-d7sg9ln7f7vs73d9bg5g-a/db_name_ehyv","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-d7sg9ln7f7vs73d9bg5g-a.oregon-postgres.render.com -p 5432 -U db_user db_name_ehyv"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 20:43:43 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "389"
+            Ratelimit-Reset:
+                - "16"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-rr9lz/iQKxXhmUkr-191543
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=7,cfOrigin;dur=89
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 190.115917ms
+    - id: 14
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -761,7 +859,7 @@ interactions:
                 - application/json
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-csr7nf3v2p9s739qqjq0-a
+        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-d7sg9ln7f7vs73d9bg5g-a
         method: PUT
       response:
         proto: HTTP/2.0
@@ -772,22 +870,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"endpoint":"","resourceId":"dpg-csr7nf3v2p9s739qqjq0-a","setting":"drop"}
+            {"endpoint":"","resourceId":"dpg-d7sg9ln7f7vs73d9bg5g-a","setting":"drop"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:38:19 GMT
+                - Mon, 04 May 2026 20:43:43 GMT
             Ratelimit-Limit:
                 - "100"
             Ratelimit-Remaining:
-                - "99"
+                - "97"
             Ratelimit-Reset:
-                - "40"
+                - "16"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-009185
+                - api-67697cb9cc-2x52t/rJPzHDiqR2-197218
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=11,cfOrigin;dur=82
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -798,63 +899,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 75.270625ms
-    - id: 14
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: https://api.testing.render.com/v1
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Authorization:
-                - some-api-key
-            User-Agent:
-                - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/projects/prj-csr7nebv2p9s739qqjig
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: |
-            {"createdAt":"2024-11-14T22:37:45.702937Z","environmentIds":["evm-csr7nebv2p9s739qqjj0"],"id":"prj-csr7nebv2p9s739qqjig","name":"first","owner":{"email":"email@example.com","id":"some-owner-id","name":"Scott's Terraform","type":"team"},"updatedAt":"2024-11-14T22:37:45.702937Z"}
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-            Date:
-                - Thu, 14 Nov 2024 22:38:23 GMT
-            Ratelimit-Limit:
-                - "400"
-            Ratelimit-Remaining:
-                - "395"
-            Ratelimit-Reset:
-                - "40"
-            Referrer-Policy:
-                - same-origin
-            Render-Request-Id:
-                - api-84fb959cf4-7sdrk/P0l7GjAQv6-009426
-            Vary:
-                - Origin
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Xss-Protection:
-                - 1; mode=block
-        status: 200 OK
-        code: 200
-        duration: 3.778939875s
+        duration: 127.987291ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -873,7 +918,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/environments/evm-csr7nebv2p9s739qqjj0
+        url: https://api.testing.render.com/v1/projects/prj-d7sg9l8k1i2s7381aj10
         method: GET
       response:
         proto: HTTP/2.0
@@ -884,22 +929,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"databasesIds":["dpg-csr7nf3v2p9s739qqjq0-a"],"envGroupIds":null,"id":"evm-csr7nebv2p9s739qqjj0","name":"prod","projectId":"prj-csr7nebv2p9s739qqjig","protectedStatus":"protected","redisIds":null,"serviceIds":null}
+            {"createdAt":"2026-05-04T20:43:01.298824Z","environmentIds":["evm-d7sg9l8k1i2s7381aj20"],"id":"prj-d7sg9l8k1i2s7381aj10","name":"first","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"updatedAt":"2026-05-04T20:43:01.298824Z"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:38:23 GMT
+                - Mon, 04 May 2026 20:43:43 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "394"
+                - "388"
             Ratelimit-Reset:
-                - "36"
+                - "16"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-009254
+                - api-67697cb9cc-mj245/HwjA0atTkv-228668
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=7,cfOrigin;dur=119
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -910,7 +958,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 56.250666ms
+        duration: 207.9675ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -929,7 +977,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/projects/prj-csr7nerv2p9s739qqjl0
+        url: https://api.testing.render.com/v1/environments/evm-d7sg9l8k1i2s7381aj20
         method: GET
       response:
         proto: HTTP/2.0
@@ -940,22 +988,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"createdAt":"2024-11-14T22:37:47.431359Z","environmentIds":["evm-csr7nerv2p9s739qqjlg"],"id":"prj-csr7nerv2p9s739qqjl0","name":"second","owner":{"email":"email@example.com","id":"some-owner-id","name":"Scott's Terraform","type":"team"},"updatedAt":"2024-11-14T22:37:47.431359Z"}
+            {"databasesIds":["dpg-d7sg9ln7f7vs73d9bg5g-a"],"envGroupIds":null,"id":"evm-d7sg9l8k1i2s7381aj20","ipAllowList":[{"cidrBlock":"0.0.0.0/0","description":"everywhere"}],"name":"prod","networkIsolationEnabled":false,"projectId":"prj-d7sg9l8k1i2s7381aj10","protectedStatus":"protected","redisIds":null,"serviceIds":null}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:38:23 GMT
+                - Mon, 04 May 2026 20:43:43 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "393"
+                - "387"
             Ratelimit-Reset:
-                - "36"
+                - "16"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-009257
+                - api-67697cb9cc-txqml/nqfxnrpqwi-114208
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=85
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -966,7 +1017,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 97.93525ms
+        duration: 110.01375ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -985,7 +1036,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/environments/evm-csr7nerv2p9s739qqjlg
+        url: https://api.testing.render.com/v1/projects/prj-d7sg9lbeo5us73ahovo0
         method: GET
       response:
         proto: HTTP/2.0
@@ -996,22 +1047,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"databasesIds":null,"envGroupIds":null,"id":"evm-csr7nerv2p9s739qqjlg","name":"prod","projectId":"prj-csr7nerv2p9s739qqjl0","protectedStatus":"protected","redisIds":null,"serviceIds":null}
+            {"createdAt":"2026-05-04T20:43:01.679555Z","environmentIds":["evm-d7sg9lbeo5us73ahovp0"],"id":"prj-d7sg9lbeo5us73ahovo0","name":"second","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"updatedAt":"2026-05-04T20:43:01.679555Z"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:38:23 GMT
+                - Mon, 04 May 2026 20:43:43 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "392"
+                - "386"
             Ratelimit-Reset:
-                - "36"
+                - "16"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-009260
+                - api-67697cb9cc-2x52t/rJPzHDiqR2-197249
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=115
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1022,7 +1076,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 83.119542ms
+        duration: 139.094417ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -1041,7 +1095,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-csr7nf3v2p9s739qqjq0-a
+        url: https://api.testing.render.com/v1/environments/evm-d7sg9lbeo5us73ahovp0
         method: GET
       response:
         proto: HTTP/2.0
@@ -1052,22 +1106,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"createdAt":"2024-11-14T22:37:48.153702Z","dashboardUrl":"https://dashboard.render.com/d/dpg-csr7nf3v2p9s739qqjq0-a","databaseName":"db_name_nui3","databaseUser":"db_user","diskSizeGB":20,"environmentId":"evm-csr7nebv2p9s739qqjj0","highAvailabilityEnabled":false,"id":"dpg-csr7nf3v2p9s739qqjq0-a","ipAllowList":null,"name":"some-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Scott's Terraform","type":"team"},"plan":"basic_256mb","readReplicas":[],"region":"oregon","role":"primary","status":"available","suspended":"not_suspended","suspenders":[],"updatedAt":"2024-11-14T22:37:48.153702Z","version":"15"}
+            {"databasesIds":null,"envGroupIds":null,"id":"evm-d7sg9lbeo5us73ahovp0","ipAllowList":[{"cidrBlock":"0.0.0.0/0","description":"everywhere"}],"name":"prod","networkIsolationEnabled":false,"projectId":"prj-d7sg9lbeo5us73ahovo0","protectedStatus":"protected","redisIds":null,"serviceIds":null}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:38:23 GMT
+                - Mon, 04 May 2026 20:43:44 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "391"
+                - "385"
             Ratelimit-Reset:
-                - "36"
+                - "15"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-009263
+                - api-67697cb9cc-xcbhc/vgcYLi38GW-156128
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=8,cfOrigin;dur=77
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1078,7 +1135,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 83.018209ms
+        duration: 189.404875ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -1097,7 +1154,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-csr7nf3v2p9s739qqjq0-a/connection-info
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sg9ln7f7vs73d9bg5g-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1108,22 +1165,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"externalConnectionString":"postgresql://db_user:IEE33ctjj8AfvV7yA4nJzNmfoBCGk3Jw@dpg-csr7nf3v2p9s739qqjq0-a.oregon-postgres.render.com:5432/db_name_nui3","internalConnectionString":"postgresql://db_user:IEE33ctjj8AfvV7yA4nJzNmfoBCGk3Jw@dpg-csr7nf3v2p9s739qqjq0-a/db_name_nui3","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-csr7nf3v2p9s739qqjq0-a.oregon-postgres.render.com -p 5432 -U db_user db_name_nui3"}
+            {"createdAt":"2026-05-04T20:43:02.842899Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sg9ln7f7vs73d9bg5g-a","databaseName":"db_name_ehyv","databaseUser":"db_user","diskAutoscalingEnabled":false,"diskSizeGB":20,"environmentId":"evm-d7sg9l8k1i2s7381aj20","highAvailabilityEnabled":false,"id":"dpg-d7sg9ln7f7vs73d9bg5g-a","ipAllowList":null,"name":"some-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"plan":"basic_256mb","readReplicas":[],"region":"oregon","role":"primary","status":"available","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T20:43:02.842899Z","version":"15"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:38:23 GMT
+                - Mon, 04 May 2026 20:43:44 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "390"
+                - "384"
             Ratelimit-Reset:
-                - "36"
+                - "15"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-009266
+                - api-67697cb9cc-w5d8j/dGSnE3CKgI-283609
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=95
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1134,7 +1194,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 77.782208ms
+        duration: 121.161833ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1153,7 +1213,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-csr7nf3v2p9s739qqjq0-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sg9ln7f7vs73d9bg5g-a/connection-info
         method: GET
       response:
         proto: HTTP/2.0
@@ -1164,22 +1224,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"endpoint":"","resourceId":"dpg-csr7nf3v2p9s739qqjq0-a","setting":"drop"}
+            {"externalConnectionString":"postgresql://db_user:kWnZFH3RCkyZCEvJX2zJfw6NneSC9qPs@dpg-d7sg9ln7f7vs73d9bg5g-a.oregon-postgres.render.com:5432/db_name_ehyv","internalConnectionString":"postgresql://db_user:kWnZFH3RCkyZCEvJX2zJfw6NneSC9qPs@dpg-d7sg9ln7f7vs73d9bg5g-a/db_name_ehyv","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-d7sg9ln7f7vs73d9bg5g-a.oregon-postgres.render.com -p 5432 -U db_user db_name_ehyv"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:38:24 GMT
+                - Mon, 04 May 2026 20:43:44 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "389"
+                - "383"
             Ratelimit-Reset:
-                - "36"
+                - "15"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-009268
+                - api-67697cb9cc-xcbhc/vgcYLi38GW-156142
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=5,cfOrigin;dur=108
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1190,7 +1253,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 121.182167ms
+        duration: 134.486916ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1209,7 +1272,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-csr7nf3v2p9s739qqjq0-a
+        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-d7sg9ln7f7vs73d9bg5g-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1220,22 +1283,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"createdAt":"2024-11-14T22:37:48.153702Z","dashboardUrl":"https://dashboard.render.com/d/dpg-csr7nf3v2p9s739qqjq0-a","databaseName":"db_name_nui3","databaseUser":"db_user","diskSizeGB":20,"environmentId":"evm-csr7nebv2p9s739qqjj0","highAvailabilityEnabled":false,"id":"dpg-csr7nf3v2p9s739qqjq0-a","ipAllowList":null,"name":"some-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Scott's Terraform","type":"team"},"plan":"basic_256mb","readReplicas":[],"region":"oregon","role":"primary","status":"available","suspended":"not_suspended","suspenders":[],"updatedAt":"2024-11-14T22:37:48.153702Z","version":"15"}
+            {"endpoint":"","resourceId":"dpg-d7sg9ln7f7vs73d9bg5g-a","setting":"drop"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:38:24 GMT
+                - Mon, 04 May 2026 20:43:44 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "388"
+                - "382"
             Ratelimit-Reset:
-                - "35"
+                - "15"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-009273
+                - api-67697cb9cc-xcbhc/vgcYLi38GW-156150
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=140
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1246,7 +1312,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 77.617ms
+        duration: 184.959417ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1265,7 +1331,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-csr7nf3v2p9s739qqjq0-a/connection-info
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sg9ln7f7vs73d9bg5g-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1276,22 +1342,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"externalConnectionString":"postgresql://db_user:IEE33ctjj8AfvV7yA4nJzNmfoBCGk3Jw@dpg-csr7nf3v2p9s739qqjq0-a.oregon-postgres.render.com:5432/db_name_nui3","internalConnectionString":"postgresql://db_user:IEE33ctjj8AfvV7yA4nJzNmfoBCGk3Jw@dpg-csr7nf3v2p9s739qqjq0-a/db_name_nui3","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-csr7nf3v2p9s739qqjq0-a.oregon-postgres.render.com -p 5432 -U db_user db_name_nui3"}
+            {"createdAt":"2026-05-04T20:43:02.842899Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sg9ln7f7vs73d9bg5g-a","databaseName":"db_name_ehyv","databaseUser":"db_user","diskAutoscalingEnabled":false,"diskSizeGB":20,"environmentId":"evm-d7sg9l8k1i2s7381aj20","highAvailabilityEnabled":false,"id":"dpg-d7sg9ln7f7vs73d9bg5g-a","ipAllowList":null,"name":"some-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"plan":"basic_256mb","readReplicas":[],"region":"oregon","role":"primary","status":"available","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T20:43:02.842899Z","version":"15"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:38:24 GMT
+                - Mon, 04 May 2026 20:43:45 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "387"
+                - "381"
             Ratelimit-Reset:
-                - "35"
+                - "15"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-009276
+                - api-67697cb9cc-hlhmt/HnNQegxyNd-257226
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=5,cfOrigin;dur=101
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1302,7 +1371,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 78.742542ms
+        duration: 119.596167ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1321,7 +1390,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-csr7nf3v2p9s739qqjq0-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sg9ln7f7vs73d9bg5g-a/connection-info
         method: GET
       response:
         proto: HTTP/2.0
@@ -1332,22 +1401,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"endpoint":"","resourceId":"dpg-csr7nf3v2p9s739qqjq0-a","setting":"drop"}
+            {"externalConnectionString":"postgresql://db_user:kWnZFH3RCkyZCEvJX2zJfw6NneSC9qPs@dpg-d7sg9ln7f7vs73d9bg5g-a.oregon-postgres.render.com:5432/db_name_ehyv","internalConnectionString":"postgresql://db_user:kWnZFH3RCkyZCEvJX2zJfw6NneSC9qPs@dpg-d7sg9ln7f7vs73d9bg5g-a/db_name_ehyv","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-d7sg9ln7f7vs73d9bg5g-a.oregon-postgres.render.com -p 5432 -U db_user db_name_ehyv"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:38:24 GMT
+                - Mon, 04 May 2026 20:43:45 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "386"
+                - "380"
             Ratelimit-Reset:
-                - "35"
+                - "14"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-009280
+                - api-67697cb9cc-n8qkv/lMOh2vXId9-328397
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=103
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1358,7 +1430,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 99.624959ms
+        duration: 182.157541ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1377,7 +1449,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/projects/prj-csr7nebv2p9s739qqjig
+        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-d7sg9ln7f7vs73d9bg5g-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1388,22 +1460,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"createdAt":"2024-11-14T22:37:45.702937Z","environmentIds":["evm-csr7nebv2p9s739qqjj0"],"id":"prj-csr7nebv2p9s739qqjig","name":"first","owner":{"email":"email@example.com","id":"some-owner-id","name":"Scott's Terraform","type":"team"},"updatedAt":"2024-11-14T22:37:45.702937Z"}
+            {"endpoint":"","resourceId":"dpg-d7sg9ln7f7vs73d9bg5g-a","setting":"drop"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:38:24 GMT
+                - Mon, 04 May 2026 20:43:45 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "385"
+                - "379"
             Ratelimit-Reset:
-                - "35"
+                - "14"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-009284
+                - api-67697cb9cc-7g8wf/qqOGxLHk0I-347732
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=7,cfOrigin;dur=182
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1414,7 +1489,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 88.184ms
+        duration: 204.171584ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1433,7 +1508,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/environments/evm-csr7nebv2p9s739qqjj0
+        url: https://api.testing.render.com/v1/projects/prj-d7sg9l8k1i2s7381aj10
         method: GET
       response:
         proto: HTTP/2.0
@@ -1444,22 +1519,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"databasesIds":["dpg-csr7nf3v2p9s739qqjq0-a"],"envGroupIds":null,"id":"evm-csr7nebv2p9s739qqjj0","name":"prod","projectId":"prj-csr7nebv2p9s739qqjig","protectedStatus":"protected","redisIds":null,"serviceIds":null}
+            {"createdAt":"2026-05-04T20:43:01.298824Z","environmentIds":["evm-d7sg9l8k1i2s7381aj20"],"id":"prj-d7sg9l8k1i2s7381aj10","name":"first","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"updatedAt":"2026-05-04T20:43:01.298824Z"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:38:25 GMT
+                - Mon, 04 May 2026 20:43:45 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "384"
+                - "378"
             Ratelimit-Reset:
-                - "34"
+                - "14"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-009288
+                - api-67697cb9cc-8r4lj/bvH9OfgVXm-329051
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=145
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1470,7 +1548,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 70.770292ms
+        duration: 218.145625ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1489,7 +1567,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/projects/prj-csr7nerv2p9s739qqjl0
+        url: https://api.testing.render.com/v1/environments/evm-d7sg9l8k1i2s7381aj20
         method: GET
       response:
         proto: HTTP/2.0
@@ -1500,22 +1578,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"createdAt":"2024-11-14T22:37:47.431359Z","environmentIds":["evm-csr7nerv2p9s739qqjlg"],"id":"prj-csr7nerv2p9s739qqjl0","name":"second","owner":{"email":"email@example.com","id":"some-owner-id","name":"Scott's Terraform","type":"team"},"updatedAt":"2024-11-14T22:37:47.431359Z"}
+            {"databasesIds":["dpg-d7sg9ln7f7vs73d9bg5g-a"],"envGroupIds":null,"id":"evm-d7sg9l8k1i2s7381aj20","ipAllowList":[{"cidrBlock":"0.0.0.0/0","description":"everywhere"}],"name":"prod","networkIsolationEnabled":false,"projectId":"prj-d7sg9l8k1i2s7381aj10","protectedStatus":"protected","redisIds":null,"serviceIds":null}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:38:25 GMT
+                - Mon, 04 May 2026 20:43:45 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "383"
+                - "377"
             Ratelimit-Reset:
-                - "34"
+                - "14"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-009292
+                - api-67697cb9cc-2x52t/rJPzHDiqR2-197332
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=5,cfOrigin;dur=78
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1526,7 +1607,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 139.381709ms
+        duration: 101.786709ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1545,7 +1626,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/environments/evm-csr7nerv2p9s739qqjlg
+        url: https://api.testing.render.com/v1/projects/prj-d7sg9lbeo5us73ahovo0
         method: GET
       response:
         proto: HTTP/2.0
@@ -1556,22 +1637,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"databasesIds":null,"envGroupIds":null,"id":"evm-csr7nerv2p9s739qqjlg","name":"prod","projectId":"prj-csr7nerv2p9s739qqjl0","protectedStatus":"protected","redisIds":null,"serviceIds":null}
+            {"createdAt":"2026-05-04T20:43:01.679555Z","environmentIds":["evm-d7sg9lbeo5us73ahovp0"],"id":"prj-d7sg9lbeo5us73ahovo0","name":"second","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"updatedAt":"2026-05-04T20:43:01.679555Z"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:38:25 GMT
+                - Mon, 04 May 2026 20:43:46 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "382"
+                - "376"
             Ratelimit-Reset:
-                - "34"
+                - "14"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-009298
+                - api-67697cb9cc-mj245/HwjA0atTkv-228803
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=115
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1582,7 +1666,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 54.073667ms
+        duration: 134.718542ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1601,7 +1685,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-csr7nf3v2p9s739qqjq0-a
+        url: https://api.testing.render.com/v1/environments/evm-d7sg9lbeo5us73ahovp0
         method: GET
       response:
         proto: HTTP/2.0
@@ -1612,22 +1696,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"createdAt":"2024-11-14T22:37:48.153702Z","dashboardUrl":"https://dashboard.render.com/d/dpg-csr7nf3v2p9s739qqjq0-a","databaseName":"db_name_nui3","databaseUser":"db_user","diskSizeGB":20,"environmentId":"evm-csr7nebv2p9s739qqjj0","highAvailabilityEnabled":false,"id":"dpg-csr7nf3v2p9s739qqjq0-a","ipAllowList":null,"name":"some-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Scott's Terraform","type":"team"},"plan":"basic_256mb","readReplicas":[],"region":"oregon","role":"primary","status":"available","suspended":"not_suspended","suspenders":[],"updatedAt":"2024-11-14T22:37:48.153702Z","version":"15"}
+            {"databasesIds":null,"envGroupIds":null,"id":"evm-d7sg9lbeo5us73ahovp0","ipAllowList":[{"cidrBlock":"0.0.0.0/0","description":"everywhere"}],"name":"prod","networkIsolationEnabled":false,"projectId":"prj-d7sg9lbeo5us73ahovo0","protectedStatus":"protected","redisIds":null,"serviceIds":null}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:38:25 GMT
+                - Mon, 04 May 2026 20:43:46 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "381"
+                - "375"
             Ratelimit-Reset:
-                - "34"
+                - "13"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-009303
+                - api-67697cb9cc-txqml/nqfxnrpqwi-114286
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=86
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1638,7 +1725,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 99.204458ms
+        duration: 190.22175ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1657,7 +1744,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-csr7nf3v2p9s739qqjq0-a/connection-info
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sg9ln7f7vs73d9bg5g-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1668,22 +1755,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"externalConnectionString":"postgresql://db_user:IEE33ctjj8AfvV7yA4nJzNmfoBCGk3Jw@dpg-csr7nf3v2p9s739qqjq0-a.oregon-postgres.render.com:5432/db_name_nui3","internalConnectionString":"postgresql://db_user:IEE33ctjj8AfvV7yA4nJzNmfoBCGk3Jw@dpg-csr7nf3v2p9s739qqjq0-a/db_name_nui3","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-csr7nf3v2p9s739qqjq0-a.oregon-postgres.render.com -p 5432 -U db_user db_name_nui3"}
+            {"createdAt":"2026-05-04T20:43:02.842899Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sg9ln7f7vs73d9bg5g-a","databaseName":"db_name_ehyv","databaseUser":"db_user","diskAutoscalingEnabled":false,"diskSizeGB":20,"environmentId":"evm-d7sg9l8k1i2s7381aj20","highAvailabilityEnabled":false,"id":"dpg-d7sg9ln7f7vs73d9bg5g-a","ipAllowList":null,"name":"some-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"plan":"basic_256mb","readReplicas":[],"region":"oregon","role":"primary","status":"available","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T20:43:02.842899Z","version":"15"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:38:25 GMT
+                - Mon, 04 May 2026 20:43:46 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "380"
+                - "374"
             Ratelimit-Reset:
-                - "34"
+                - "13"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-009308
+                - api-67697cb9cc-hlhmt/HnNQegxyNd-257290
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=101
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1694,7 +1784,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 74.412583ms
+        duration: 122.25825ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1713,7 +1803,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-csr7nf3v2p9s739qqjq0-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sg9ln7f7vs73d9bg5g-a/connection-info
         method: GET
       response:
         proto: HTTP/2.0
@@ -1724,22 +1814,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"endpoint":"","resourceId":"dpg-csr7nf3v2p9s739qqjq0-a","setting":"drop"}
+            {"externalConnectionString":"postgresql://db_user:kWnZFH3RCkyZCEvJX2zJfw6NneSC9qPs@dpg-d7sg9ln7f7vs73d9bg5g-a.oregon-postgres.render.com:5432/db_name_ehyv","internalConnectionString":"postgresql://db_user:kWnZFH3RCkyZCEvJX2zJfw6NneSC9qPs@dpg-d7sg9ln7f7vs73d9bg5g-a/db_name_ehyv","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-d7sg9ln7f7vs73d9bg5g-a.oregon-postgres.render.com -p 5432 -U db_user db_name_ehyv"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:38:25 GMT
+                - Mon, 04 May 2026 20:43:46 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "379"
+                - "373"
             Ratelimit-Reset:
-                - "34"
+                - "13"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-009312
+                - api-67697cb9cc-2th7z/x5t6h1CqqQ-268868
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=100
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1750,8 +1843,67 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 94.360667ms
+        duration: 121.342458ms
     - id: 31
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-d7sg9ln7f7vs73d9bg5g-a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"endpoint":"","resourceId":"dpg-d7sg9ln7f7vs73d9bg5g-a","setting":"drop"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 20:43:46 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "372"
+            Ratelimit-Reset:
+                - "13"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-xcbhc/vgcYLi38GW-156266
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=7,cfOrigin;dur=150
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 181.471875ms
+    - id: 32
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1771,7 +1923,7 @@ interactions:
                 - application/json
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-csr7nf3v2p9s739qqjq0-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sg9ln7f7vs73d9bg5g-a
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -1782,22 +1934,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"createdAt":"2024-11-14T22:37:48.153702Z","dashboardUrl":"https://dashboard.render.com/d/dpg-csr7nf3v2p9s739qqjq0-a","databaseName":"db_name_nui3","databaseUser":"db_user","diskSizeGB":25,"environmentId":"evm-csr7nebv2p9s739qqjj0","highAvailabilityEnabled":true,"id":"dpg-csr7nf3v2p9s739qqjq0-a","ipAllowList":null,"name":"new-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Scott's Terraform","type":"team"},"plan":"pro_4gb","readReplicas":[{"id":"dpg-csr7nf3v2p9s739qqjq0-b","name":"read-replica"}],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2024-11-14T22:38:26.245566Z","version":"15"}
+            {"createdAt":"2026-05-04T20:43:02.842899Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sg9ln7f7vs73d9bg5g-a","databaseName":"db_name_ehyv","databaseUser":"db_user","diskAutoscalingEnabled":false,"diskSizeGB":25,"environmentId":"evm-d7sg9l8k1i2s7381aj20","highAvailabilityEnabled":true,"id":"dpg-d7sg9ln7f7vs73d9bg5g-a","ipAllowList":null,"name":"new-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"plan":"pro_4gb","readReplicas":[{"id":"dpg-d7sg9ln7f7vs73d9bg5g-b","name":"read-replica"}],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T20:43:47.230422Z","version":"15"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:38:26 GMT
+                - Mon, 04 May 2026 20:43:47 GMT
             Ratelimit-Limit:
                 - "100"
             Ratelimit-Remaining:
-                - "98"
+                - "96"
             Ratelimit-Reset:
-                - "33"
+                - "12"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-009319
+                - api-67697cb9cc-xcbhc/vgcYLi38GW-156285
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=537
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1808,8 +1963,8 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 374.593167ms
-    - id: 32
+        duration: 563.423ms
+    - id: 33
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1827,7 +1982,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/environments/dpg-csr7nf3v2p9s739qqjq0-a/resources?resourceIds=dpg-csr7nf3v2p9s739qqjq0-a
+        url: https://api.testing.render.com/v1/environments/dpg-d7sg9ln7f7vs73d9bg5g-a/resources?resourceIds=dpg-d7sg9ln7f7vs73d9bg5g-a
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1840,17 +1995,20 @@ interactions:
         body: ""
         headers:
             Date:
-                - Thu, 14 Nov 2024 22:38:26 GMT
+                - Mon, 04 May 2026 20:43:47 GMT
             Ratelimit-Limit:
                 - "100"
             Ratelimit-Remaining:
-                - "97"
+                - "95"
             Ratelimit-Reset:
-                - "33"
+                - "12"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-009324
+                - api-67697cb9cc-8r4lj/bvH9OfgVXm-329186
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=7,cfOrigin;dur=134
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1861,8 +2019,8 @@ interactions:
                 - 1; mode=block
         status: 204 No Content
         code: 204
-        duration: 106.269916ms
-    - id: 33
+        duration: 162.998792ms
+    - id: 34
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1873,7 +2031,7 @@ interactions:
         host: https://api.testing.render.com/v1
         remote_addr: ""
         request_uri: ""
-        body: '{"resourceIds":["dpg-csr7nf3v2p9s739qqjq0-a"]}'
+        body: '{"resourceIds":["dpg-d7sg9ln7f7vs73d9bg5g-a"]}'
         form: {}
         headers:
             Authorization:
@@ -1882,7 +2040,7 @@ interactions:
                 - application/json
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/environments/evm-csr7nerv2p9s739qqjlg/resources
+        url: https://api.testing.render.com/v1/environments/evm-d7sg9lbeo5us73ahovp0/resources
         method: POST
       response:
         proto: HTTP/2.0
@@ -1890,27 +2048,30 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 245
+        content_length: 346
         uncompressed: false
         body: |
-            {"databasesIds":["dpg-csr7nf3v2p9s739qqjq0-a","dpg-csr7nf3v2p9s739qqjq0-b"],"envGroupIds":null,"id":"evm-csr7nerv2p9s739qqjlg","name":"prod","projectId":"prj-csr7nerv2p9s739qqjl0","protectedStatus":"protected","redisIds":null,"serviceIds":null}
+            {"databasesIds":["dpg-d7sg9ln7f7vs73d9bg5g-b","dpg-d7sg9ln7f7vs73d9bg5g-a"],"envGroupIds":null,"id":"evm-d7sg9lbeo5us73ahovp0","ipAllowList":[{"cidrBlock":"0.0.0.0/0","description":"everywhere"}],"name":"prod","networkIsolationEnabled":false,"projectId":"prj-d7sg9lbeo5us73ahovo0","protectedStatus":"protected","redisIds":null,"serviceIds":null}
         headers:
             Content-Length:
-                - "245"
+                - "346"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:38:26 GMT
+                - Mon, 04 May 2026 20:43:47 GMT
             Ratelimit-Limit:
                 - "100"
             Ratelimit-Remaining:
-                - "96"
+                - "94"
             Ratelimit-Reset:
-                - "33"
+                - "12"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-009328
+                - api-67697cb9cc-8r4lj/bvH9OfgVXm-329190
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=12,cfOrigin;dur=136
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1921,63 +2082,7 @@ interactions:
                 - 1; mode=block
         status: 201 Created
         code: 201
-        duration: 112.526917ms
-    - id: 34
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: https://api.testing.render.com/v1
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Authorization:
-                - some-api-key
-            User-Agent:
-                - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-csr7nf3v2p9s739qqjq0-a/connection-info
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: |
-            {"externalConnectionString":"postgresql://db_user:IEE33ctjj8AfvV7yA4nJzNmfoBCGk3Jw@dpg-csr7nf3v2p9s739qqjq0-a.oregon-postgres.render.com:5432/db_name_nui3","internalConnectionString":"postgresql://db_user:IEE33ctjj8AfvV7yA4nJzNmfoBCGk3Jw@dpg-csr7nf3v2p9s739qqjq0-a/db_name_nui3","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-csr7nf3v2p9s739qqjq0-a.oregon-postgres.render.com -p 5432 -U db_user db_name_nui3"}
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-            Date:
-                - Thu, 14 Nov 2024 22:38:26 GMT
-            Ratelimit-Limit:
-                - "400"
-            Ratelimit-Remaining:
-                - "378"
-            Ratelimit-Reset:
-                - "33"
-            Referrer-Policy:
-                - same-origin
-            Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-009333
-            Vary:
-                - Origin
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Xss-Protection:
-                - 1; mode=block
-        status: 200 OK
-        code: 200
-        duration: 70.794416ms
+        duration: 185.187ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1996,30 +2101,36 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-csr7nf3v2p9s739qqjq0-a
-        method: DELETE
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sg9ln7f7vs73d9bg5g-a/connection-info
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"externalConnectionString":"postgresql://db_user:kWnZFH3RCkyZCEvJX2zJfw6NneSC9qPs@dpg-d7sg9ln7f7vs73d9bg5g-a.oregon-postgres.render.com:5432/db_name_ehyv","internalConnectionString":"postgresql://db_user:kWnZFH3RCkyZCEvJX2zJfw6NneSC9qPs@dpg-d7sg9ln7f7vs73d9bg5g-a/db_name_ehyv","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-d7sg9ln7f7vs73d9bg5g-a.oregon-postgres.render.com -p 5432 -U db_user db_name_ehyv"}
         headers:
+            Content-Type:
+                - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:38:27 GMT
+                - Mon, 04 May 2026 20:43:47 GMT
             Ratelimit-Limit:
-                - "100"
+                - "400"
             Ratelimit-Remaining:
-                - "95"
+                - "371"
             Ratelimit-Reset:
-                - "33"
+                - "12"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-009336
+                - api-67697cb9cc-mj245/HwjA0atTkv-228909
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=101
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2028,9 +2139,9 @@ interactions:
                 - DENY
             X-Xss-Protection:
                 - 1; mode=block
-        status: 204 No Content
-        code: 204
-        duration: 63.946292ms
+        status: 200 OK
+        code: 200
+        duration: 123.257208ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -2049,33 +2160,33 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/projects/prj-csr7nebv2p9s739qqjig
-        method: GET
+        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-d7sg9ln7f7vs73d9bg5g-a
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: |
-            {"createdAt":"2024-11-14T22:37:45.702937Z","environmentIds":["evm-csr7nebv2p9s739qqjj0"],"id":"prj-csr7nebv2p9s739qqjig","name":"first","owner":{"email":"email@example.com","id":"some-owner-id","name":"Scott's Terraform","type":"team"},"updatedAt":"2024-11-14T22:37:45.702937Z"}
+        content_length: 0
+        uncompressed: false
+        body: ""
         headers:
-            Content-Type:
-                - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:38:27 GMT
+                - Mon, 04 May 2026 20:43:48 GMT
             Ratelimit-Limit:
-                - "400"
+                - "100"
             Ratelimit-Remaining:
-                - "377"
+                - "93"
             Ratelimit-Reset:
-                - "32"
+                - "11"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-009342
+                - api-67697cb9cc-txqml/nqfxnrpqwi-114351
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=7,cfOrigin;dur=114
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2084,9 +2195,9 @@ interactions:
                 - DENY
             X-Xss-Protection:
                 - 1; mode=block
-        status: 200 OK
-        code: 200
-        duration: 101.58325ms
+        status: 204 No Content
+        code: 204
+        duration: 143.331583ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -2105,7 +2216,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/environments/evm-csr7nebv2p9s739qqjj0
+        url: https://api.testing.render.com/v1/projects/prj-d7sg9l8k1i2s7381aj10
         method: GET
       response:
         proto: HTTP/2.0
@@ -2116,22 +2227,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"databasesIds":null,"envGroupIds":null,"id":"evm-csr7nebv2p9s739qqjj0","name":"prod","projectId":"prj-csr7nebv2p9s739qqjig","protectedStatus":"protected","redisIds":null,"serviceIds":null}
+            {"createdAt":"2026-05-04T20:43:01.298824Z","environmentIds":["evm-d7sg9l8k1i2s7381aj20"],"id":"prj-d7sg9l8k1i2s7381aj10","name":"first","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"updatedAt":"2026-05-04T20:43:01.298824Z"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:38:27 GMT
+                - Mon, 04 May 2026 20:43:48 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "376"
+                - "370"
             Ratelimit-Reset:
-                - "32"
+                - "11"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-009349
+                - api-67697cb9cc-2th7z/x5t6h1CqqQ-268972
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=8,cfOrigin;dur=126
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2142,7 +2256,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 52.632041ms
+        duration: 157.685209ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -2161,7 +2275,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/projects/prj-csr7nerv2p9s739qqjl0
+        url: https://api.testing.render.com/v1/environments/evm-d7sg9l8k1i2s7381aj20
         method: GET
       response:
         proto: HTTP/2.0
@@ -2172,22 +2286,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"createdAt":"2024-11-14T22:37:47.431359Z","environmentIds":["evm-csr7nerv2p9s739qqjlg"],"id":"prj-csr7nerv2p9s739qqjl0","name":"second","owner":{"email":"email@example.com","id":"some-owner-id","name":"Scott's Terraform","type":"team"},"updatedAt":"2024-11-14T22:37:47.431359Z"}
+            {"databasesIds":null,"envGroupIds":null,"id":"evm-d7sg9l8k1i2s7381aj20","ipAllowList":[{"cidrBlock":"0.0.0.0/0","description":"everywhere"}],"name":"prod","networkIsolationEnabled":false,"projectId":"prj-d7sg9l8k1i2s7381aj10","protectedStatus":"protected","redisIds":null,"serviceIds":null}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:38:27 GMT
+                - Mon, 04 May 2026 20:43:48 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "375"
+                - "369"
             Ratelimit-Reset:
-                - "32"
+                - "11"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-009352
+                - api-67697cb9cc-w5d8j/dGSnE3CKgI-283894
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=7,cfOrigin;dur=77
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2198,7 +2315,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 90.048417ms
+        duration: 102.609042ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -2217,7 +2334,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/environments/evm-csr7nerv2p9s739qqjlg
+        url: https://api.testing.render.com/v1/projects/prj-d7sg9lbeo5us73ahovo0
         method: GET
       response:
         proto: HTTP/2.0
@@ -2228,22 +2345,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"databasesIds":["dpg-csr7nf3v2p9s739qqjq0-a","dpg-csr7nf3v2p9s739qqjq0-b"],"envGroupIds":null,"id":"evm-csr7nerv2p9s739qqjlg","name":"prod","projectId":"prj-csr7nerv2p9s739qqjl0","protectedStatus":"protected","redisIds":null,"serviceIds":null}
+            {"createdAt":"2026-05-04T20:43:01.679555Z","environmentIds":["evm-d7sg9lbeo5us73ahovp0"],"id":"prj-d7sg9lbeo5us73ahovo0","name":"second","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"updatedAt":"2026-05-04T20:43:01.679555Z"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:38:27 GMT
+                - Mon, 04 May 2026 20:43:48 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "374"
+                - "368"
             Ratelimit-Reset:
-                - "32"
+                - "11"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-009355
+                - api-67697cb9cc-rr9lz/iQKxXhmUkr-191807
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=7,cfOrigin;dur=115
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2254,7 +2374,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 72.3ms
+        duration: 197.546834ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -2273,7 +2393,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-csr7nf3v2p9s739qqjq0-a
+        url: https://api.testing.render.com/v1/environments/evm-d7sg9lbeo5us73ahovp0
         method: GET
       response:
         proto: HTTP/2.0
@@ -2284,22 +2404,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"createdAt":"2024-11-14T22:37:48.153702Z","dashboardUrl":"https://dashboard.render.com/d/dpg-csr7nf3v2p9s739qqjq0-a","databaseName":"db_name_nui3","databaseUser":"db_user","diskSizeGB":25,"environmentId":"evm-csr7nerv2p9s739qqjlg","highAvailabilityEnabled":true,"id":"dpg-csr7nf3v2p9s739qqjq0-a","ipAllowList":null,"name":"new-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Scott's Terraform","type":"team"},"plan":"pro_4gb","readReplicas":[{"id":"dpg-csr7nf3v2p9s739qqjq0-b","name":"read-replica"}],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2024-11-14T22:38:26.662975Z","version":"15"}
+            {"databasesIds":["dpg-d7sg9ln7f7vs73d9bg5g-b","dpg-d7sg9ln7f7vs73d9bg5g-a"],"envGroupIds":null,"id":"evm-d7sg9lbeo5us73ahovp0","ipAllowList":[{"cidrBlock":"0.0.0.0/0","description":"everywhere"}],"name":"prod","networkIsolationEnabled":false,"projectId":"prj-d7sg9lbeo5us73ahovo0","protectedStatus":"protected","redisIds":null,"serviceIds":null}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:38:27 GMT
+                - Mon, 04 May 2026 20:43:49 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "373"
+                - "367"
             Ratelimit-Reset:
-                - "32"
+                - "11"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-009358
+                - api-67697cb9cc-hlhmt/HnNQegxyNd-257417
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=81
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2310,7 +2433,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 78.519666ms
+        duration: 99.570959ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2329,7 +2452,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-csr7nf3v2p9s739qqjq0-a/connection-info
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sg9ln7f7vs73d9bg5g-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -2340,22 +2463,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"externalConnectionString":"postgresql://db_user:IEE33ctjj8AfvV7yA4nJzNmfoBCGk3Jw@dpg-csr7nf3v2p9s739qqjq0-a.oregon-postgres.render.com:5432/db_name_nui3","internalConnectionString":"postgresql://db_user:IEE33ctjj8AfvV7yA4nJzNmfoBCGk3Jw@dpg-csr7nf3v2p9s739qqjq0-a/db_name_nui3","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-csr7nf3v2p9s739qqjq0-a.oregon-postgres.render.com -p 5432 -U db_user db_name_nui3"}
+            {"createdAt":"2026-05-04T20:43:02.842899Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sg9ln7f7vs73d9bg5g-a","databaseName":"db_name_ehyv","databaseUser":"db_user","diskAutoscalingEnabled":false,"diskSizeGB":25,"environmentId":"evm-d7sg9lbeo5us73ahovp0","highAvailabilityEnabled":true,"id":"dpg-d7sg9ln7f7vs73d9bg5g-a","ipAllowList":null,"name":"new-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"plan":"pro_4gb","readReplicas":[{"id":"dpg-d7sg9ln7f7vs73d9bg5g-b","name":"read-replica"}],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T20:43:47.760877Z","version":"15"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:38:28 GMT
+                - Mon, 04 May 2026 20:43:49 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "372"
+                - "366"
             Ratelimit-Reset:
-                - "31"
+                - "10"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-009361
+                - api-67697cb9cc-n8qkv/lMOh2vXId9-328594
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=107
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2366,7 +2492,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 112.578042ms
+        duration: 132.587ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2385,7 +2511,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-csr7nf3v2p9s739qqjq0-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sg9ln7f7vs73d9bg5g-a/connection-info
         method: GET
       response:
         proto: HTTP/2.0
@@ -2396,22 +2522,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"message":"not found: dpg-csr7nf3v2p9s739qqjq0-a"}
+            {"externalConnectionString":"postgresql://db_user:kWnZFH3RCkyZCEvJX2zJfw6NneSC9qPs@dpg-d7sg9ln7f7vs73d9bg5g-a.oregon-postgres.render.com:5432/db_name_ehyv","internalConnectionString":"postgresql://db_user:kWnZFH3RCkyZCEvJX2zJfw6NneSC9qPs@dpg-d7sg9ln7f7vs73d9bg5g-a/db_name_ehyv","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-d7sg9ln7f7vs73d9bg5g-a.oregon-postgres.render.com -p 5432 -U db_user db_name_ehyv"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:38:28 GMT
+                - Mon, 04 May 2026 20:43:49 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "371"
+                - "365"
             Ratelimit-Reset:
-                - "31"
+                - "10"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-009364
+                - api-67697cb9cc-7g8wf/qqOGxLHk0I-347933
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=5,cfOrigin;dur=229
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2420,9 +2549,9 @@ interactions:
                 - DENY
             X-Xss-Protection:
                 - 1; mode=block
-        status: 404 Not Found
-        code: 404
-        duration: 161.470708ms
+        status: 200 OK
+        code: 200
+        duration: 249.554333ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2441,7 +2570,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/projects/prj-csr7nebv2p9s739qqjig
+        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-d7sg9ln7f7vs73d9bg5g-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -2452,22 +2581,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"createdAt":"2024-11-14T22:37:45.702937Z","environmentIds":["evm-csr7nebv2p9s739qqjj0"],"id":"prj-csr7nebv2p9s739qqjig","name":"first","owner":{"email":"email@example.com","id":"some-owner-id","name":"Scott's Terraform","type":"team"},"updatedAt":"2024-11-14T22:37:45.702937Z"}
+            {"message":"not found: dpg-d7sg9ln7f7vs73d9bg5g-a"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:38:28 GMT
+                - Mon, 04 May 2026 20:43:49 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "370"
+                - "364"
             Ratelimit-Reset:
-                - "31"
+                - "10"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-009368
+                - api-67697cb9cc-8r4lj/bvH9OfgVXm-329323
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=145
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2476,9 +2608,9 @@ interactions:
                 - DENY
             X-Xss-Protection:
                 - 1; mode=block
-        status: 200 OK
-        code: 200
-        duration: 85.350083ms
+        status: 404 Not Found
+        code: 404
+        duration: 168.265792ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -2497,7 +2629,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/environments/evm-csr7nebv2p9s739qqjj0
+        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-d7sg9ln7f7vs73d9bg5g-b
         method: GET
       response:
         proto: HTTP/2.0
@@ -2508,22 +2640,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"databasesIds":null,"envGroupIds":null,"id":"evm-csr7nebv2p9s739qqjj0","name":"prod","projectId":"prj-csr7nebv2p9s739qqjig","protectedStatus":"protected","redisIds":null,"serviceIds":null}
+            {"message":"not found: dpg-d7sg9ln7f7vs73d9bg5g-b"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:38:28 GMT
+                - Mon, 04 May 2026 20:43:49 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "369"
+                - "363"
             Ratelimit-Reset:
-                - "31"
+                - "10"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-009372
+                - api-67697cb9cc-8r4lj/bvH9OfgVXm-329329
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=5,cfOrigin;dur=143
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2532,9 +2667,9 @@ interactions:
                 - DENY
             X-Xss-Protection:
                 - 1; mode=block
-        status: 200 OK
-        code: 200
-        duration: 75.422792ms
+        status: 404 Not Found
+        code: 404
+        duration: 167.790417ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -2553,7 +2688,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/projects/prj-csr7nerv2p9s739qqjl0
+        url: https://api.testing.render.com/v1/projects/prj-d7sg9l8k1i2s7381aj10
         method: GET
       response:
         proto: HTTP/2.0
@@ -2564,22 +2699,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"createdAt":"2024-11-14T22:37:47.431359Z","environmentIds":["evm-csr7nerv2p9s739qqjlg"],"id":"prj-csr7nerv2p9s739qqjl0","name":"second","owner":{"email":"email@example.com","id":"some-owner-id","name":"Scott's Terraform","type":"team"},"updatedAt":"2024-11-14T22:37:47.431359Z"}
+            {"createdAt":"2026-05-04T20:43:01.298824Z","environmentIds":["evm-d7sg9l8k1i2s7381aj20"],"id":"prj-d7sg9l8k1i2s7381aj10","name":"first","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"updatedAt":"2026-05-04T20:43:01.298824Z"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:38:28 GMT
+                - Mon, 04 May 2026 20:43:50 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "368"
+                - "362"
             Ratelimit-Reset:
-                - "31"
+                - "9"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-009374
+                - api-67697cb9cc-mj245/HwjA0atTkv-229019
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=120
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2590,7 +2728,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 103.3235ms
+        duration: 171.49775ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -2609,7 +2747,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/environments/evm-csr7nerv2p9s739qqjlg
+        url: https://api.testing.render.com/v1/environments/evm-d7sg9l8k1i2s7381aj20
         method: GET
       response:
         proto: HTTP/2.0
@@ -2620,22 +2758,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"databasesIds":["dpg-csr7nf3v2p9s739qqjq0-a","dpg-csr7nf3v2p9s739qqjq0-b"],"envGroupIds":null,"id":"evm-csr7nerv2p9s739qqjlg","name":"prod","projectId":"prj-csr7nerv2p9s739qqjl0","protectedStatus":"protected","redisIds":null,"serviceIds":null}
+            {"databasesIds":null,"envGroupIds":null,"id":"evm-d7sg9l8k1i2s7381aj20","ipAllowList":[{"cidrBlock":"0.0.0.0/0","description":"everywhere"}],"name":"prod","networkIsolationEnabled":false,"projectId":"prj-d7sg9l8k1i2s7381aj10","protectedStatus":"protected","redisIds":null,"serviceIds":null}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:38:29 GMT
+                - Mon, 04 May 2026 20:43:50 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "367"
+                - "361"
             Ratelimit-Reset:
-                - "30"
+                - "9"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-009379
+                - api-67697cb9cc-hlhmt/HnNQegxyNd-257479
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=89
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2646,7 +2787,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 55.552417ms
+        duration: 116.181666ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -2665,7 +2806,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-csr7nf3v2p9s739qqjq0-a
+        url: https://api.testing.render.com/v1/projects/prj-d7sg9lbeo5us73ahovo0
         method: GET
       response:
         proto: HTTP/2.0
@@ -2676,22 +2817,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"createdAt":"2024-11-14T22:37:48.153702Z","dashboardUrl":"https://dashboard.render.com/d/dpg-csr7nf3v2p9s739qqjq0-a","databaseName":"db_name_nui3","databaseUser":"db_user","diskSizeGB":25,"environmentId":"evm-csr7nerv2p9s739qqjlg","highAvailabilityEnabled":true,"id":"dpg-csr7nf3v2p9s739qqjq0-a","ipAllowList":null,"name":"new-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Scott's Terraform","type":"team"},"plan":"pro_4gb","readReplicas":[{"id":"dpg-csr7nf3v2p9s739qqjq0-b","name":"read-replica"}],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2024-11-14T22:38:26.662975Z","version":"15"}
+            {"createdAt":"2026-05-04T20:43:01.679555Z","environmentIds":["evm-d7sg9lbeo5us73ahovp0"],"id":"prj-d7sg9lbeo5us73ahovo0","name":"second","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"updatedAt":"2026-05-04T20:43:01.679555Z"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:38:29 GMT
+                - Mon, 04 May 2026 20:43:50 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "366"
+                - "360"
             Ratelimit-Reset:
-                - "30"
+                - "9"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-009385
+                - api-67697cb9cc-2x52t/rJPzHDiqR2-197508
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=5,cfOrigin;dur=129
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2702,7 +2846,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 81.384125ms
+        duration: 214.319333ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -2721,7 +2865,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-csr7nf3v2p9s739qqjq0-a/connection-info
+        url: https://api.testing.render.com/v1/environments/evm-d7sg9lbeo5us73ahovp0
         method: GET
       response:
         proto: HTTP/2.0
@@ -2732,22 +2876,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"externalConnectionString":"postgresql://db_user:IEE33ctjj8AfvV7yA4nJzNmfoBCGk3Jw@dpg-csr7nf3v2p9s739qqjq0-a.oregon-postgres.render.com:5432/db_name_nui3","internalConnectionString":"postgresql://db_user:IEE33ctjj8AfvV7yA4nJzNmfoBCGk3Jw@dpg-csr7nf3v2p9s739qqjq0-a/db_name_nui3","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-csr7nf3v2p9s739qqjq0-a.oregon-postgres.render.com -p 5432 -U db_user db_name_nui3"}
+            {"databasesIds":["dpg-d7sg9ln7f7vs73d9bg5g-b","dpg-d7sg9ln7f7vs73d9bg5g-a"],"envGroupIds":null,"id":"evm-d7sg9lbeo5us73ahovp0","ipAllowList":[{"cidrBlock":"0.0.0.0/0","description":"everywhere"}],"name":"prod","networkIsolationEnabled":false,"projectId":"prj-d7sg9lbeo5us73ahovo0","protectedStatus":"protected","redisIds":null,"serviceIds":null}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:38:29 GMT
+                - Mon, 04 May 2026 20:43:50 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "365"
+                - "359"
             Ratelimit-Reset:
-                - "30"
+                - "9"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-009389
+                - api-67697cb9cc-xcbhc/vgcYLi38GW-156458
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=79
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2758,7 +2905,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 69.710375ms
+        duration: 102.881667ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -2777,7 +2924,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-csr7nf3v2p9s739qqjq0-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sg9ln7f7vs73d9bg5g-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -2788,22 +2935,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"message":"not found: dpg-csr7nf3v2p9s739qqjq0-a"}
+            {"createdAt":"2026-05-04T20:43:02.842899Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sg9ln7f7vs73d9bg5g-a","databaseName":"db_name_ehyv","databaseUser":"db_user","diskAutoscalingEnabled":false,"diskSizeGB":25,"environmentId":"evm-d7sg9lbeo5us73ahovp0","highAvailabilityEnabled":true,"id":"dpg-d7sg9ln7f7vs73d9bg5g-a","ipAllowList":null,"name":"new-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"plan":"pro_4gb","readReplicas":[{"id":"dpg-d7sg9ln7f7vs73d9bg5g-b","name":"read-replica"}],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T20:43:47.760877Z","version":"15"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:38:29 GMT
+                - Mon, 04 May 2026 20:43:50 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "364"
+                - "358"
             Ratelimit-Reset:
-                - "30"
+                - "9"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-009390
+                - api-67697cb9cc-2th7z/x5t6h1CqqQ-269084
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=5,cfOrigin;dur=103
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2812,9 +2962,9 @@ interactions:
                 - DENY
             X-Xss-Protection:
                 - 1; mode=block
-        status: 404 Not Found
-        code: 404
-        duration: 96.851792ms
+        status: 200 OK
+        code: 200
+        duration: 129.561917ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -2833,7 +2983,1429 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-csr7nf3v2p9s739qqjq0-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sg9ln7f7vs73d9bg5g-a/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"externalConnectionString":"postgresql://db_user:kWnZFH3RCkyZCEvJX2zJfw6NneSC9qPs@dpg-d7sg9ln7f7vs73d9bg5g-a.oregon-postgres.render.com:5432/db_name_ehyv","internalConnectionString":"postgresql://db_user:kWnZFH3RCkyZCEvJX2zJfw6NneSC9qPs@dpg-d7sg9ln7f7vs73d9bg5g-a/db_name_ehyv","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-d7sg9ln7f7vs73d9bg5g-a.oregon-postgres.render.com -p 5432 -U db_user db_name_ehyv"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 20:43:50 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "357"
+            Ratelimit-Reset:
+                - "9"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-w5d8j/dGSnE3CKgI-284028
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=97
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 188.739917ms
+    - id: 51
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-d7sg9ln7f7vs73d9bg5g-a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"message":"not found: dpg-d7sg9ln7f7vs73d9bg5g-a"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 20:43:51 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "356"
+            Ratelimit-Reset:
+                - "8"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-xcbhc/vgcYLi38GW-156479
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=131
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 155.950792ms
+    - id: 52
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-d7sg9ln7f7vs73d9bg5g-b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"message":"not found: dpg-d7sg9ln7f7vs73d9bg5g-b"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 20:43:51 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "355"
+            Ratelimit-Reset:
+                - "8"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-n8qkv/lMOh2vXId9-328706
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=165
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 191.138333ms
+    - id: 53
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 140
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: '{"diskSizeGB":25,"enableHighAvailability":true,"ipAllowList":[],"name":"new-name","plan":"pro_4gb","readReplicas":[{"name":"read-replica"}]}'
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            Content-Type:
+                - application/json
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sg9ln7f7vs73d9bg5g-a
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"createdAt":"2026-05-04T20:43:02.842899Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sg9ln7f7vs73d9bg5g-a","databaseName":"db_name_ehyv","databaseUser":"db_user","diskAutoscalingEnabled":false,"diskSizeGB":25,"environmentId":"evm-d7sg9lbeo5us73ahovp0","highAvailabilityEnabled":true,"id":"dpg-d7sg9ln7f7vs73d9bg5g-a","ipAllowList":null,"name":"new-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"plan":"pro_4gb","readReplicas":[{"id":"dpg-d7sg9ln7f7vs73d9bg5g-b","name":"read-replica"}],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T20:43:51.651656Z","version":"15"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 20:43:51 GMT
+            Ratelimit-Limit:
+                - "100"
+            Ratelimit-Remaining:
+                - "92"
+            Ratelimit-Reset:
+                - "8"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-xcbhc/vgcYLi38GW-156503
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=8,cfOrigin;dur=183
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 242.950709ms
+    - id: 54
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sg9ln7f7vs73d9bg5g-a/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"externalConnectionString":"postgresql://db_user:kWnZFH3RCkyZCEvJX2zJfw6NneSC9qPs@dpg-d7sg9ln7f7vs73d9bg5g-a.oregon-postgres.render.com:5432/db_name_ehyv","internalConnectionString":"postgresql://db_user:kWnZFH3RCkyZCEvJX2zJfw6NneSC9qPs@dpg-d7sg9ln7f7vs73d9bg5g-a/db_name_ehyv","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-d7sg9ln7f7vs73d9bg5g-a.oregon-postgres.render.com -p 5432 -U db_user db_name_ehyv"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 20:43:51 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "354"
+            Ratelimit-Reset:
+                - "8"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-7g8wf/qqOGxLHk0I-348073
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=7,cfOrigin;dur=115
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 141.170083ms
+    - id: 55
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 18
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: '{"setting":"drop"}'
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            Content-Type:
+                - application/json
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-d7sg9ln7f7vs73d9bg5g-b
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"endpoint":"","resourceId":"dpg-d7sg9ln7f7vs73d9bg5g-b","setting":"drop"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 20:43:52 GMT
+            Ratelimit-Limit:
+                - "100"
+            Ratelimit-Remaining:
+                - "91"
+            Ratelimit-Reset:
+                - "8"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-8r4lj/bvH9OfgVXm-329457
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=5,cfOrigin;dur=86
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 150.132708ms
+    - id: 56
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/projects/prj-d7sg9l8k1i2s7381aj10
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"createdAt":"2026-05-04T20:43:01.298824Z","environmentIds":["evm-d7sg9l8k1i2s7381aj20"],"id":"prj-d7sg9l8k1i2s7381aj10","name":"first","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"updatedAt":"2026-05-04T20:43:01.298824Z"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 20:43:52 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "353"
+            Ratelimit-Reset:
+                - "7"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-2x52t/rJPzHDiqR2-197600
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=7,cfOrigin;dur=124
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 142.573958ms
+    - id: 57
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/environments/evm-d7sg9l8k1i2s7381aj20
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"databasesIds":null,"envGroupIds":null,"id":"evm-d7sg9l8k1i2s7381aj20","ipAllowList":[{"cidrBlock":"0.0.0.0/0","description":"everywhere"}],"name":"prod","networkIsolationEnabled":false,"projectId":"prj-d7sg9l8k1i2s7381aj10","protectedStatus":"protected","redisIds":null,"serviceIds":null}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 20:43:52 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "352"
+            Ratelimit-Reset:
+                - "7"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-mj245/HwjA0atTkv-229158
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=74
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 147.2245ms
+    - id: 58
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/projects/prj-d7sg9lbeo5us73ahovo0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"createdAt":"2026-05-04T20:43:01.679555Z","environmentIds":["evm-d7sg9lbeo5us73ahovp0"],"id":"prj-d7sg9lbeo5us73ahovo0","name":"second","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"updatedAt":"2026-05-04T20:43:01.679555Z"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 20:43:52 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "351"
+            Ratelimit-Reset:
+                - "7"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-txqml/nqfxnrpqwi-114509
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=5,cfOrigin;dur=132
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 152.55075ms
+    - id: 59
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/environments/evm-d7sg9lbeo5us73ahovp0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"databasesIds":["dpg-d7sg9ln7f7vs73d9bg5g-b","dpg-d7sg9ln7f7vs73d9bg5g-a"],"envGroupIds":null,"id":"evm-d7sg9lbeo5us73ahovp0","ipAllowList":[{"cidrBlock":"0.0.0.0/0","description":"everywhere"}],"name":"prod","networkIsolationEnabled":false,"projectId":"prj-d7sg9lbeo5us73ahovo0","protectedStatus":"protected","redisIds":null,"serviceIds":null}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 20:43:52 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "350"
+            Ratelimit-Reset:
+                - "7"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-2x52t/rJPzHDiqR2-197623
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=5,cfOrigin;dur=75
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 96.37275ms
+    - id: 60
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sg9ln7f7vs73d9bg5g-a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"createdAt":"2026-05-04T20:43:02.842899Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sg9ln7f7vs73d9bg5g-a","databaseName":"db_name_ehyv","databaseUser":"db_user","diskAutoscalingEnabled":false,"diskSizeGB":25,"environmentId":"evm-d7sg9lbeo5us73ahovp0","highAvailabilityEnabled":true,"id":"dpg-d7sg9ln7f7vs73d9bg5g-a","ipAllowList":null,"name":"new-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"plan":"pro_4gb","readReplicas":[{"id":"dpg-d7sg9ln7f7vs73d9bg5g-b","name":"read-replica"}],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T20:43:51.651656Z","version":"15"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 20:43:53 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "349"
+            Ratelimit-Reset:
+                - "7"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-xcbhc/vgcYLi38GW-156580
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=100
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 171.532417ms
+    - id: 61
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sg9ln7f7vs73d9bg5g-a/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"externalConnectionString":"postgresql://db_user:kWnZFH3RCkyZCEvJX2zJfw6NneSC9qPs@dpg-d7sg9ln7f7vs73d9bg5g-a.oregon-postgres.render.com:5432/db_name_ehyv","internalConnectionString":"postgresql://db_user:kWnZFH3RCkyZCEvJX2zJfw6NneSC9qPs@dpg-d7sg9ln7f7vs73d9bg5g-a/db_name_ehyv","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-d7sg9ln7f7vs73d9bg5g-a.oregon-postgres.render.com -p 5432 -U db_user db_name_ehyv"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 20:43:53 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "348"
+            Ratelimit-Reset:
+                - "6"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-w5d8j/dGSnE3CKgI-284179
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=103
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 126.979208ms
+    - id: 62
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-d7sg9ln7f7vs73d9bg5g-a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"message":"not found: dpg-d7sg9ln7f7vs73d9bg5g-a"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 20:43:53 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "347"
+            Ratelimit-Reset:
+                - "6"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-hlhmt/HnNQegxyNd-257624
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=8,cfOrigin;dur=148
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 173.906042ms
+    - id: 63
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-d7sg9ln7f7vs73d9bg5g-b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"endpoint":"","resourceId":"dpg-d7sg9ln7f7vs73d9bg5g-b","setting":"drop"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 20:43:53 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "346"
+            Ratelimit-Reset:
+                - "6"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-n8qkv/lMOh2vXId9-328830
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=5,cfOrigin;dur=171
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 191.300333ms
+    - id: 64
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/projects/prj-d7sg9l8k1i2s7381aj10
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"createdAt":"2026-05-04T20:43:01.298824Z","environmentIds":["evm-d7sg9l8k1i2s7381aj20"],"id":"prj-d7sg9l8k1i2s7381aj10","name":"first","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"updatedAt":"2026-05-04T20:43:01.298824Z"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 20:43:53 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "345"
+            Ratelimit-Reset:
+                - "6"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-xcbhc/vgcYLi38GW-156616
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=7,cfOrigin;dur=129
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 162.904958ms
+    - id: 65
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/environments/evm-d7sg9l8k1i2s7381aj20
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"databasesIds":null,"envGroupIds":null,"id":"evm-d7sg9l8k1i2s7381aj20","ipAllowList":[{"cidrBlock":"0.0.0.0/0","description":"everywhere"}],"name":"prod","networkIsolationEnabled":false,"projectId":"prj-d7sg9l8k1i2s7381aj10","protectedStatus":"protected","redisIds":null,"serviceIds":null}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 20:43:54 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "344"
+            Ratelimit-Reset:
+                - "6"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-8r4lj/bvH9OfgVXm-329592
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=83
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 103.71525ms
+    - id: 66
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/projects/prj-d7sg9lbeo5us73ahovo0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"createdAt":"2026-05-04T20:43:01.679555Z","environmentIds":["evm-d7sg9lbeo5us73ahovp0"],"id":"prj-d7sg9lbeo5us73ahovo0","name":"second","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"updatedAt":"2026-05-04T20:43:01.679555Z"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 20:43:54 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "343"
+            Ratelimit-Reset:
+                - "5"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-2x52t/rJPzHDiqR2-197678
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=5,cfOrigin;dur=123
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 222.29275ms
+    - id: 67
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/environments/evm-d7sg9lbeo5us73ahovp0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"databasesIds":["dpg-d7sg9ln7f7vs73d9bg5g-b","dpg-d7sg9ln7f7vs73d9bg5g-a"],"envGroupIds":null,"id":"evm-d7sg9lbeo5us73ahovp0","ipAllowList":[{"cidrBlock":"0.0.0.0/0","description":"everywhere"}],"name":"prod","networkIsolationEnabled":false,"projectId":"prj-d7sg9lbeo5us73ahovo0","protectedStatus":"protected","redisIds":null,"serviceIds":null}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 20:43:54 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "342"
+            Ratelimit-Reset:
+                - "5"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-2th7z/x5t6h1CqqQ-269277
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=77
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 95.915584ms
+    - id: 68
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sg9ln7f7vs73d9bg5g-a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"createdAt":"2026-05-04T20:43:02.842899Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sg9ln7f7vs73d9bg5g-a","databaseName":"db_name_ehyv","databaseUser":"db_user","diskAutoscalingEnabled":false,"diskSizeGB":25,"environmentId":"evm-d7sg9lbeo5us73ahovp0","highAvailabilityEnabled":true,"id":"dpg-d7sg9ln7f7vs73d9bg5g-a","ipAllowList":null,"name":"new-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"plan":"pro_4gb","readReplicas":[{"id":"dpg-d7sg9ln7f7vs73d9bg5g-b","name":"read-replica"}],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T20:43:51.651656Z","version":"15"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 20:43:54 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "341"
+            Ratelimit-Reset:
+                - "5"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-hlhmt/HnNQegxyNd-257676
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=7,cfOrigin;dur=112
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 218.299792ms
+    - id: 69
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sg9ln7f7vs73d9bg5g-a/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"externalConnectionString":"postgresql://db_user:kWnZFH3RCkyZCEvJX2zJfw6NneSC9qPs@dpg-d7sg9ln7f7vs73d9bg5g-a.oregon-postgres.render.com:5432/db_name_ehyv","internalConnectionString":"postgresql://db_user:kWnZFH3RCkyZCEvJX2zJfw6NneSC9qPs@dpg-d7sg9ln7f7vs73d9bg5g-a/db_name_ehyv","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-d7sg9ln7f7vs73d9bg5g-a.oregon-postgres.render.com -p 5432 -U db_user db_name_ehyv"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 20:43:54 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "340"
+            Ratelimit-Reset:
+                - "5"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-xcbhc/vgcYLi38GW-156660
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=98
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 121.2945ms
+    - id: 70
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-d7sg9ln7f7vs73d9bg5g-a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"message":"not found: dpg-d7sg9ln7f7vs73d9bg5g-a"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 20:43:55 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "339"
+            Ratelimit-Reset:
+                - "5"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-n8qkv/lMOh2vXId9-328902
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=163
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 182.746584ms
+    - id: 71
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-d7sg9ln7f7vs73d9bg5g-b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"endpoint":"","resourceId":"dpg-d7sg9ln7f7vs73d9bg5g-b","setting":"drop"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 20:43:55 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "338"
+            Ratelimit-Reset:
+                - "4"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-7g8wf/qqOGxLHk0I-348246
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=9,cfOrigin;dur=165
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 190.149167ms
+    - id: 72
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 140
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: '{"diskSizeGB":25,"enableHighAvailability":true,"ipAllowList":[],"name":"new-name","plan":"pro_4gb","readReplicas":[{"name":"read-replica"}]}'
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            Content-Type:
+                - application/json
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sg9ln7f7vs73d9bg5g-a
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"createdAt":"2026-05-04T20:43:02.842899Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sg9ln7f7vs73d9bg5g-a","databaseName":"db_name_ehyv","databaseUser":"db_user","diskAutoscalingEnabled":false,"diskSizeGB":25,"environmentId":"evm-d7sg9lbeo5us73ahovp0","highAvailabilityEnabled":true,"id":"dpg-d7sg9ln7f7vs73d9bg5g-a","ipAllowList":null,"name":"new-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"plan":"pro_4gb","readReplicas":[{"id":"dpg-d7sg9ln7f7vs73d9bg5g-b","name":"read-replica"}],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T20:43:55.516771Z","version":"15"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 20:43:55 GMT
+            Ratelimit-Limit:
+                - "100"
+            Ratelimit-Remaining:
+                - "90"
+            Ratelimit-Reset:
+                - "4"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-8r4lj/bvH9OfgVXm-329686
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=7,cfOrigin;dur=189
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 209.332542ms
+    - id: 73
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sg9ln7f7vs73d9bg5g-a/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"externalConnectionString":"postgresql://db_user:kWnZFH3RCkyZCEvJX2zJfw6NneSC9qPs@dpg-d7sg9ln7f7vs73d9bg5g-a.oregon-postgres.render.com:5432/db_name_ehyv","internalConnectionString":"postgresql://db_user:kWnZFH3RCkyZCEvJX2zJfw6NneSC9qPs@dpg-d7sg9ln7f7vs73d9bg5g-a/db_name_ehyv","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-d7sg9ln7f7vs73d9bg5g-a.oregon-postgres.render.com -p 5432 -U db_user db_name_ehyv"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 20:43:55 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "337"
+            Ratelimit-Reset:
+                - "4"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-8r4lj/bvH9OfgVXm-329697
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=110
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 134.862042ms
+    - id: 74
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-d7sg9ln7f7vs73d9bg5g-b
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2846,17 +4418,20 @@ interactions:
         body: ""
         headers:
             Date:
-                - Thu, 14 Nov 2024 22:38:29 GMT
+                - Mon, 04 May 2026 20:43:55 GMT
             Ratelimit-Limit:
                 - "100"
             Ratelimit-Remaining:
-                - "94"
+                - "89"
             Ratelimit-Reset:
-                - "30"
+                - "4"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-009394
+                - api-67697cb9cc-2x52t/rJPzHDiqR2-197741
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=9,cfOrigin;dur=80
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2867,8 +4442,1008 @@ interactions:
                 - 1; mode=block
         status: 204 No Content
         code: 204
-        duration: 156.379333ms
-    - id: 51
+        duration: 105.03075ms
+    - id: 75
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/projects/prj-d7sg9l8k1i2s7381aj10
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"createdAt":"2026-05-04T20:43:01.298824Z","environmentIds":["evm-d7sg9l8k1i2s7381aj20"],"id":"prj-d7sg9l8k1i2s7381aj10","name":"first","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"updatedAt":"2026-05-04T20:43:01.298824Z"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 20:43:56 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "336"
+            Ratelimit-Reset:
+                - "3"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-2x52t/rJPzHDiqR2-197765
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=5,cfOrigin;dur=118
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 143.534416ms
+    - id: 76
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/environments/evm-d7sg9l8k1i2s7381aj20
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"databasesIds":null,"envGroupIds":null,"id":"evm-d7sg9l8k1i2s7381aj20","ipAllowList":[{"cidrBlock":"0.0.0.0/0","description":"everywhere"}],"name":"prod","networkIsolationEnabled":false,"projectId":"prj-d7sg9l8k1i2s7381aj10","protectedStatus":"protected","redisIds":null,"serviceIds":null}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 20:43:56 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "335"
+            Ratelimit-Reset:
+                - "3"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-xcbhc/vgcYLi38GW-156728
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=75
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 94.951083ms
+    - id: 77
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/projects/prj-d7sg9lbeo5us73ahovo0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"createdAt":"2026-05-04T20:43:01.679555Z","environmentIds":["evm-d7sg9lbeo5us73ahovp0"],"id":"prj-d7sg9lbeo5us73ahovo0","name":"second","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"updatedAt":"2026-05-04T20:43:01.679555Z"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 20:43:56 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "334"
+            Ratelimit-Reset:
+                - "3"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-hlhmt/HnNQegxyNd-257767
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=5,cfOrigin;dur=137
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 183.153542ms
+    - id: 78
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/environments/evm-d7sg9lbeo5us73ahovp0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"databasesIds":["dpg-d7sg9ln7f7vs73d9bg5g-b","dpg-d7sg9ln7f7vs73d9bg5g-a"],"envGroupIds":null,"id":"evm-d7sg9lbeo5us73ahovp0","ipAllowList":[{"cidrBlock":"0.0.0.0/0","description":"everywhere"}],"name":"prod","networkIsolationEnabled":false,"projectId":"prj-d7sg9lbeo5us73ahovo0","protectedStatus":"protected","redisIds":null,"serviceIds":null}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 20:43:56 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "333"
+            Ratelimit-Reset:
+                - "3"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-2th7z/x5t6h1CqqQ-269381
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=5,cfOrigin;dur=75
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 96.340125ms
+    - id: 79
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sg9ln7f7vs73d9bg5g-a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"createdAt":"2026-05-04T20:43:02.842899Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sg9ln7f7vs73d9bg5g-a","databaseName":"db_name_ehyv","databaseUser":"db_user","diskAutoscalingEnabled":false,"diskSizeGB":25,"environmentId":"evm-d7sg9lbeo5us73ahovp0","highAvailabilityEnabled":true,"id":"dpg-d7sg9ln7f7vs73d9bg5g-a","ipAllowList":null,"name":"new-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"plan":"pro_4gb","readReplicas":[{"id":"dpg-d7sg9ln7f7vs73d9bg5g-b","name":"read-replica"}],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T20:43:55.516771Z","version":"15"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 20:43:57 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "332"
+            Ratelimit-Reset:
+                - "2"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-w5d8j/dGSnE3CKgI-284416
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=5,cfOrigin;dur=104
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 127.783375ms
+    - id: 80
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sg9ln7f7vs73d9bg5g-a/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"externalConnectionString":"postgresql://db_user:kWnZFH3RCkyZCEvJX2zJfw6NneSC9qPs@dpg-d7sg9ln7f7vs73d9bg5g-a.oregon-postgres.render.com:5432/db_name_ehyv","internalConnectionString":"postgresql://db_user:kWnZFH3RCkyZCEvJX2zJfw6NneSC9qPs@dpg-d7sg9ln7f7vs73d9bg5g-a/db_name_ehyv","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-d7sg9ln7f7vs73d9bg5g-a.oregon-postgres.render.com -p 5432 -U db_user db_name_ehyv"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 20:43:57 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "331"
+            Ratelimit-Reset:
+                - "2"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-rr9lz/iQKxXhmUkr-192221
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=97
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 190.21275ms
+    - id: 81
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-d7sg9ln7f7vs73d9bg5g-a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"message":"not found: dpg-d7sg9ln7f7vs73d9bg5g-a"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 20:43:57 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "330"
+            Ratelimit-Reset:
+                - "2"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-hlhmt/HnNQegxyNd-257806
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=142
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 162.037959ms
+    - id: 82
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-d7sg9ln7f7vs73d9bg5g-b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"message":"not found: dpg-d7sg9ln7f7vs73d9bg5g-b"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 20:43:57 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "329"
+            Ratelimit-Reset:
+                - "2"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-xcbhc/vgcYLi38GW-156780
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=130
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 148.481042ms
+    - id: 83
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/projects/prj-d7sg9l8k1i2s7381aj10
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"createdAt":"2026-05-04T20:43:01.298824Z","environmentIds":["evm-d7sg9l8k1i2s7381aj20"],"id":"prj-d7sg9l8k1i2s7381aj10","name":"first","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"updatedAt":"2026-05-04T20:43:01.298824Z"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 20:43:57 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "328"
+            Ratelimit-Reset:
+                - "2"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-n8qkv/lMOh2vXId9-329041
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=5,cfOrigin;dur=152
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 172.254916ms
+    - id: 84
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/environments/evm-d7sg9l8k1i2s7381aj20
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"databasesIds":null,"envGroupIds":null,"id":"evm-d7sg9l8k1i2s7381aj20","ipAllowList":[{"cidrBlock":"0.0.0.0/0","description":"everywhere"}],"name":"prod","networkIsolationEnabled":false,"projectId":"prj-d7sg9l8k1i2s7381aj10","protectedStatus":"protected","redisIds":null,"serviceIds":null}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 20:43:58 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "327"
+            Ratelimit-Reset:
+                - "2"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-7g8wf/qqOGxLHk0I-348379
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=86
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 107.502333ms
+    - id: 85
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/projects/prj-d7sg9lbeo5us73ahovo0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"createdAt":"2026-05-04T20:43:01.679555Z","environmentIds":["evm-d7sg9lbeo5us73ahovp0"],"id":"prj-d7sg9lbeo5us73ahovo0","name":"second","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"updatedAt":"2026-05-04T20:43:01.679555Z"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 20:43:58 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "326"
+            Ratelimit-Reset:
+                - "1"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-xcbhc/vgcYLi38GW-156810
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=7,cfOrigin;dur=130
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 154.946583ms
+    - id: 86
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/environments/evm-d7sg9lbeo5us73ahovp0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"databasesIds":["dpg-d7sg9ln7f7vs73d9bg5g-b","dpg-d7sg9ln7f7vs73d9bg5g-a"],"envGroupIds":null,"id":"evm-d7sg9lbeo5us73ahovp0","ipAllowList":[{"cidrBlock":"0.0.0.0/0","description":"everywhere"}],"name":"prod","networkIsolationEnabled":false,"projectId":"prj-d7sg9lbeo5us73ahovo0","protectedStatus":"protected","redisIds":null,"serviceIds":null}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 20:43:58 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "325"
+            Ratelimit-Reset:
+                - "1"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-8r4lj/bvH9OfgVXm-329880
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=78
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 133.594959ms
+    - id: 87
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sg9ln7f7vs73d9bg5g-a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"createdAt":"2026-05-04T20:43:02.842899Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sg9ln7f7vs73d9bg5g-a","databaseName":"db_name_ehyv","databaseUser":"db_user","diskAutoscalingEnabled":false,"diskSizeGB":25,"environmentId":"evm-d7sg9lbeo5us73ahovp0","highAvailabilityEnabled":true,"id":"dpg-d7sg9ln7f7vs73d9bg5g-a","ipAllowList":null,"name":"new-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"plan":"pro_4gb","readReplicas":[{"id":"dpg-d7sg9ln7f7vs73d9bg5g-b","name":"read-replica"}],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T20:43:55.516771Z","version":"15"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 20:43:58 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "324"
+            Ratelimit-Reset:
+                - "1"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-8r4lj/bvH9OfgVXm-329893
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=5,cfOrigin;dur=110
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 128.105167ms
+    - id: 88
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sg9ln7f7vs73d9bg5g-a/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"externalConnectionString":"postgresql://db_user:kWnZFH3RCkyZCEvJX2zJfw6NneSC9qPs@dpg-d7sg9ln7f7vs73d9bg5g-a.oregon-postgres.render.com:5432/db_name_ehyv","internalConnectionString":"postgresql://db_user:kWnZFH3RCkyZCEvJX2zJfw6NneSC9qPs@dpg-d7sg9ln7f7vs73d9bg5g-a/db_name_ehyv","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-d7sg9ln7f7vs73d9bg5g-a.oregon-postgres.render.com -p 5432 -U db_user db_name_ehyv"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 20:43:58 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "323"
+            Ratelimit-Reset:
+                - "1"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-2x52t/rJPzHDiqR2-197877
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=4,cfOrigin;dur=95
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 116.590708ms
+    - id: 89
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-d7sg9ln7f7vs73d9bg5g-a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"message":"not found: dpg-d7sg9ln7f7vs73d9bg5g-a"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 20:43:58 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "322"
+            Ratelimit-Reset:
+                - "1"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-2x52t/rJPzHDiqR2-197884
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=5,cfOrigin;dur=130
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 158.761917ms
+    - id: 90
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-d7sg9ln7f7vs73d9bg5g-b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"message":"not found: dpg-d7sg9ln7f7vs73d9bg5g-b"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 20:43:59 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "321"
+            Ratelimit-Reset:
+                - "1"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-xcbhc/vgcYLi38GW-156850
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=5,cfOrigin;dur=127
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 148.527209ms
+    - id: 91
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sg9ln7f7vs73d9bg5g-a
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Date:
+                - Mon, 04 May 2026 20:43:59 GMT
+            Ratelimit-Limit:
+                - "100"
+            Ratelimit-Remaining:
+                - "88"
+            Ratelimit-Reset:
+                - "0"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-w5d8j/dGSnE3CKgI-284569
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=448
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 204 No Content
+        code: 204
+        duration: 467.87025ms
+    - id: 92
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2896,27 +5471,30 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 601
+        content_length: 648
         uncompressed: false
         body: |
-            {"createdAt":"2024-11-14T22:38:30.012670268Z","dashboardUrl":"https://dashboard.render.com/d/dpg-csr7npjv2p9s739qqmp0-a","databaseName":"db_name2_qm7i","databaseUser":"db_user2","diskSizeGB":10,"highAvailabilityEnabled":false,"id":"dpg-csr7npjv2p9s739qqmp0-a","ipAllowList":null,"name":"new-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Scott's Terraform","type":"team"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"unknown","suspended":"not_suspended","suspenders":[],"updatedAt":"2024-11-14T22:38:30.012670268Z","version":"16"}
+            {"createdAt":"2026-05-04T20:44:00.199612047Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sga47avr4c73b59g10-a","databaseName":"db_name2_jmvr","databaseUser":"db_user2","diskAutoscalingEnabled":false,"diskSizeGB":10,"highAvailabilityEnabled":false,"id":"dpg-d7sga47avr4c73b59g10-a","ipAllowList":null,"name":"new-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"unknown","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T20:44:00.199612047Z","version":"16"}
         headers:
             Content-Length:
-                - "601"
+                - "648"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:38:30 GMT
+                - Mon, 04 May 2026 20:44:00 GMT
             Ratelimit-Limit:
                 - "20"
             Ratelimit-Remaining:
-                - "4"
+                - "17"
             Ratelimit-Reset:
-                - "1290"
+                - "960"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-009396
+                - api-67697cb9cc-rr9lz/iQKxXhmUkr-192340
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=9,cfOrigin;dur=744
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2927,8 +5505,8 @@ interactions:
                 - 1; mode=block
         status: 201 Created
         code: 201
-        duration: 383.758833ms
-    - id: 52
+        duration: 833.441625ms
+    - id: 93
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2946,7 +5524,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-csr7npjv2p9s739qqmp0-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sga47avr4c73b59g10-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -2957,348 +5535,12 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"createdAt":"2024-11-14T22:38:30.01267Z","dashboardUrl":"https://dashboard.render.com/d/dpg-csr7npjv2p9s739qqmp0-a","databaseName":"db_name2_qm7i","databaseUser":"db_user2","diskSizeGB":10,"highAvailabilityEnabled":false,"id":"dpg-csr7npjv2p9s739qqmp0-a","ipAllowList":null,"name":"new-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Scott's Terraform","type":"team"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2024-11-14T22:38:30.01267Z","version":"16"}
+            {"createdAt":"2026-05-04T20:44:00.199612Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sga47avr4c73b59g10-a","databaseName":"db_name2_jmvr","databaseUser":"db_user2","diskAutoscalingEnabled":false,"diskSizeGB":10,"highAvailabilityEnabled":false,"id":"dpg-d7sga47avr4c73b59g10-a","ipAllowList":null,"name":"new-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T20:44:00.199612Z","version":"16"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:38:30 GMT
-            Ratelimit-Limit:
-                - "400"
-            Ratelimit-Remaining:
-                - "363"
-            Ratelimit-Reset:
-                - "29"
-            Referrer-Policy:
-                - same-origin
-            Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-009404
-            Vary:
-                - Origin
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Xss-Protection:
-                - 1; mode=block
-        status: 200 OK
-        code: 200
-        duration: 79.006125ms
-    - id: 53
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: https://api.testing.render.com/v1
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Authorization:
-                - some-api-key
-            User-Agent:
-                - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-csr7npjv2p9s739qqmp0-a
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: |
-            {"createdAt":"2024-11-14T22:38:30.01267Z","dashboardUrl":"https://dashboard.render.com/d/dpg-csr7npjv2p9s739qqmp0-a","databaseName":"db_name2_qm7i","databaseUser":"db_user2","diskSizeGB":10,"highAvailabilityEnabled":false,"id":"dpg-csr7npjv2p9s739qqmp0-a","ipAllowList":null,"name":"new-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Scott's Terraform","type":"team"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2024-11-14T22:38:30.01267Z","version":"16"}
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-            Date:
-                - Thu, 14 Nov 2024 22:38:33 GMT
-            Ratelimit-Limit:
-                - "400"
-            Ratelimit-Remaining:
-                - "362"
-            Ratelimit-Reset:
-                - "26"
-            Referrer-Policy:
-                - same-origin
-            Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-009461
-            Vary:
-                - Origin
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Xss-Protection:
-                - 1; mode=block
-        status: 200 OK
-        code: 200
-        duration: 293.723042ms
-    - id: 54
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: https://api.testing.render.com/v1
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Authorization:
-                - some-api-key
-            User-Agent:
-                - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-csr7npjv2p9s739qqmp0-a
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: |
-            {"createdAt":"2024-11-14T22:38:30.01267Z","dashboardUrl":"https://dashboard.render.com/d/dpg-csr7npjv2p9s739qqmp0-a","databaseName":"db_name2_qm7i","databaseUser":"db_user2","diskSizeGB":10,"highAvailabilityEnabled":false,"id":"dpg-csr7npjv2p9s739qqmp0-a","ipAllowList":null,"name":"new-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Scott's Terraform","type":"team"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2024-11-14T22:38:30.01267Z","version":"16"}
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-            Date:
-                - Thu, 14 Nov 2024 22:38:37 GMT
-            Ratelimit-Limit:
-                - "400"
-            Ratelimit-Remaining:
-                - "361"
-            Ratelimit-Reset:
-                - "22"
-            Referrer-Policy:
-                - same-origin
-            Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-009533
-            Vary:
-                - Origin
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Xss-Protection:
-                - 1; mode=block
-        status: 200 OK
-        code: 200
-        duration: 74.51425ms
-    - id: 55
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: https://api.testing.render.com/v1
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Authorization:
-                - some-api-key
-            User-Agent:
-                - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-csr7npjv2p9s739qqmp0-a
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: |
-            {"createdAt":"2024-11-14T22:38:30.01267Z","dashboardUrl":"https://dashboard.render.com/d/dpg-csr7npjv2p9s739qqmp0-a","databaseName":"db_name2_qm7i","databaseUser":"db_user2","diskSizeGB":10,"highAvailabilityEnabled":false,"id":"dpg-csr7npjv2p9s739qqmp0-a","ipAllowList":null,"name":"new-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Scott's Terraform","type":"team"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2024-11-14T22:38:30.01267Z","version":"16"}
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-            Date:
-                - Thu, 14 Nov 2024 22:38:41 GMT
-            Ratelimit-Limit:
-                - "400"
-            Ratelimit-Remaining:
-                - "360"
-            Ratelimit-Reset:
-                - "18"
-            Referrer-Policy:
-                - same-origin
-            Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-009607
-            Vary:
-                - Origin
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Xss-Protection:
-                - 1; mode=block
-        status: 200 OK
-        code: 200
-        duration: 89.526042ms
-    - id: 56
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: https://api.testing.render.com/v1
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Authorization:
-                - some-api-key
-            User-Agent:
-                - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-csr7npjv2p9s739qqmp0-a
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: |
-            {"createdAt":"2024-11-14T22:38:30.01267Z","dashboardUrl":"https://dashboard.render.com/d/dpg-csr7npjv2p9s739qqmp0-a","databaseName":"db_name2_qm7i","databaseUser":"db_user2","diskSizeGB":10,"highAvailabilityEnabled":false,"id":"dpg-csr7npjv2p9s739qqmp0-a","ipAllowList":null,"name":"new-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Scott's Terraform","type":"team"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2024-11-14T22:38:30.01267Z","version":"16"}
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-            Date:
-                - Thu, 14 Nov 2024 22:38:46 GMT
-            Ratelimit-Limit:
-                - "400"
-            Ratelimit-Remaining:
-                - "359"
-            Ratelimit-Reset:
-                - "13"
-            Referrer-Policy:
-                - same-origin
-            Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-009708
-            Vary:
-                - Origin
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Xss-Protection:
-                - 1; mode=block
-        status: 200 OK
-        code: 200
-        duration: 75.558625ms
-    - id: 57
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: https://api.testing.render.com/v1
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Authorization:
-                - some-api-key
-            User-Agent:
-                - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-csr7npjv2p9s739qqmp0-a
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: |
-            {"createdAt":"2024-11-14T22:38:30.01267Z","dashboardUrl":"https://dashboard.render.com/d/dpg-csr7npjv2p9s739qqmp0-a","databaseName":"db_name2_qm7i","databaseUser":"db_user2","diskSizeGB":10,"highAvailabilityEnabled":false,"id":"dpg-csr7npjv2p9s739qqmp0-a","ipAllowList":null,"name":"new-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Scott's Terraform","type":"team"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2024-11-14T22:38:30.01267Z","version":"16"}
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-            Date:
-                - Thu, 14 Nov 2024 22:38:53 GMT
-            Ratelimit-Limit:
-                - "400"
-            Ratelimit-Remaining:
-                - "358"
-            Ratelimit-Reset:
-                - "6"
-            Referrer-Policy:
-                - same-origin
-            Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-009851
-            Vary:
-                - Origin
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Xss-Protection:
-                - 1; mode=block
-        status: 200 OK
-        code: 200
-        duration: 90.025834ms
-    - id: 58
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: https://api.testing.render.com/v1
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Authorization:
-                - some-api-key
-            User-Agent:
-                - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-csr7npjv2p9s739qqmp0-a
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: |
-            {"createdAt":"2024-11-14T22:38:30.01267Z","dashboardUrl":"https://dashboard.render.com/d/dpg-csr7npjv2p9s739qqmp0-a","databaseName":"db_name2_qm7i","databaseUser":"db_user2","diskSizeGB":10,"highAvailabilityEnabled":false,"id":"dpg-csr7npjv2p9s739qqmp0-a","ipAllowList":null,"name":"new-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Scott's Terraform","type":"team"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2024-11-14T22:38:30.01267Z","version":"16"}
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-            Date:
-                - Thu, 14 Nov 2024 22:39:00 GMT
+                - Mon, 04 May 2026 20:44:00 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
@@ -3308,7 +5550,10 @@ interactions:
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-009985
+                - api-67697cb9cc-xcbhc/vgcYLi38GW-156932
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=7,cfOrigin;dur=106
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -3319,8 +5564,8 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 74.98175ms
-    - id: 59
+        duration: 131.345209ms
+    - id: 94
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3338,7 +5583,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-csr7npjv2p9s739qqmp0-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sga47avr4c73b59g10-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -3349,22 +5594,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"createdAt":"2024-11-14T22:38:30.01267Z","dashboardUrl":"https://dashboard.render.com/d/dpg-csr7npjv2p9s739qqmp0-a","databaseName":"db_name2_qm7i","databaseUser":"db_user2","diskSizeGB":10,"highAvailabilityEnabled":false,"id":"dpg-csr7npjv2p9s739qqmp0-a","ipAllowList":null,"name":"new-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Scott's Terraform","type":"team"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"available","suspended":"not_suspended","suspenders":[],"updatedAt":"2024-11-14T22:38:30.01267Z","version":"16"}
+            {"createdAt":"2026-05-04T20:44:00.199612Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sga47avr4c73b59g10-a","databaseName":"db_name2_jmvr","databaseUser":"db_user2","diskAutoscalingEnabled":false,"diskSizeGB":10,"highAvailabilityEnabled":false,"id":"dpg-d7sga47avr4c73b59g10-a","ipAllowList":null,"name":"new-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T20:44:00.199612Z","version":"16"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:39:09 GMT
+                - Mon, 04 May 2026 20:44:03 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
                 - "398"
             Ratelimit-Reset:
-                - "50"
+                - "56"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-010167
+                - api-67697cb9cc-xcbhc/vgcYLi38GW-157086
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=96
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -3375,8 +5623,8 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 80.893417ms
-    - id: 60
+        duration: 129.621333ms
+    - id: 95
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3394,7 +5642,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-csr7npjv2p9s739qqmp0-a/connection-info
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sga47avr4c73b59g10-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -3405,22 +5653,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"externalConnectionString":"postgresql://db_user2:Sj68nzlzjOFnjj6pPaCzdRcYtGyZrk5m@dpg-csr7npjv2p9s739qqmp0-a.oregon-postgres.render.com:5432/db_name2_qm7i","internalConnectionString":"postgresql://db_user2:Sj68nzlzjOFnjj6pPaCzdRcYtGyZrk5m@dpg-csr7npjv2p9s739qqmp0-a/db_name2_qm7i","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-csr7npjv2p9s739qqmp0-a.oregon-postgres.render.com -p 5432 -U db_user2 db_name2_qm7i"}
+            {"createdAt":"2026-05-04T20:44:00.199612Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sga47avr4c73b59g10-a","databaseName":"db_name2_jmvr","databaseUser":"db_user2","diskAutoscalingEnabled":false,"diskSizeGB":10,"highAvailabilityEnabled":false,"id":"dpg-d7sga47avr4c73b59g10-a","ipAllowList":null,"name":"new-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T20:44:00.199612Z","version":"16"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:39:10 GMT
+                - Mon, 04 May 2026 20:44:07 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
                 - "397"
             Ratelimit-Reset:
-                - "50"
+                - "52"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-010169
+                - api-67697cb9cc-hlhmt/HnNQegxyNd-258310
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=7,cfOrigin;dur=101
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -3431,8 +5682,8 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 114.190375ms
-    - id: 61
+        duration: 124.944291ms
+    - id: 96
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3450,7 +5701,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/projects/prj-csr7nebv2p9s739qqjig
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sga47avr4c73b59g10-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -3461,22 +5712,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"createdAt":"2024-11-14T22:37:45.702937Z","environmentIds":["evm-csr7nebv2p9s739qqjj0"],"id":"prj-csr7nebv2p9s739qqjig","name":"first","owner":{"email":"email@example.com","id":"some-owner-id","name":"Scott's Terraform","type":"team"},"updatedAt":"2024-11-14T22:37:45.702937Z"}
+            {"createdAt":"2026-05-04T20:44:00.199612Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sga47avr4c73b59g10-a","databaseName":"db_name2_jmvr","databaseUser":"db_user2","diskAutoscalingEnabled":false,"diskSizeGB":10,"highAvailabilityEnabled":false,"id":"dpg-d7sga47avr4c73b59g10-a","ipAllowList":null,"name":"new-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T20:44:00.199612Z","version":"16"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:39:10 GMT
+                - Mon, 04 May 2026 20:44:11 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
                 - "396"
             Ratelimit-Reset:
-                - "49"
+                - "48"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-010178
+                - api-67697cb9cc-xcbhc/vgcYLi38GW-157494
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=7,cfOrigin;dur=95
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -3487,8 +5741,8 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 93.362708ms
-    - id: 62
+        duration: 120.492167ms
+    - id: 97
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3506,7 +5760,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/environments/evm-csr7nebv2p9s739qqjj0
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sga47avr4c73b59g10-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -3517,22 +5771,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"databasesIds":null,"envGroupIds":null,"id":"evm-csr7nebv2p9s739qqjj0","name":"prod","projectId":"prj-csr7nebv2p9s739qqjig","protectedStatus":"protected","redisIds":null,"serviceIds":null}
+            {"createdAt":"2026-05-04T20:44:00.199612Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sga47avr4c73b59g10-a","databaseName":"db_name2_jmvr","databaseUser":"db_user2","diskAutoscalingEnabled":false,"diskSizeGB":10,"highAvailabilityEnabled":false,"id":"dpg-d7sga47avr4c73b59g10-a","ipAllowList":null,"name":"new-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T20:44:00.199612Z","version":"16"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:39:10 GMT
+                - Mon, 04 May 2026 20:44:17 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
                 - "395"
             Ratelimit-Reset:
-                - "49"
+                - "42"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-010183
+                - api-67697cb9cc-2th7z/x5t6h1CqqQ-270576
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=95
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -3543,8 +5800,8 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 71.006708ms
-    - id: 63
+        duration: 162.242ms
+    - id: 98
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3562,7 +5819,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/projects/prj-csr7nerv2p9s739qqjl0
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sga47avr4c73b59g10-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -3573,22 +5830,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"createdAt":"2024-11-14T22:37:47.431359Z","environmentIds":["evm-csr7nerv2p9s739qqjlg"],"id":"prj-csr7nerv2p9s739qqjl0","name":"second","owner":{"email":"email@example.com","id":"some-owner-id","name":"Scott's Terraform","type":"team"},"updatedAt":"2024-11-14T22:37:47.431359Z"}
+            {"createdAt":"2026-05-04T20:44:00.199612Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sga47avr4c73b59g10-a","databaseName":"db_name2_jmvr","databaseUser":"db_user2","diskAutoscalingEnabled":false,"diskSizeGB":10,"highAvailabilityEnabled":false,"id":"dpg-d7sga47avr4c73b59g10-a","ipAllowList":null,"name":"new-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T20:44:00.199612Z","version":"16"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:39:10 GMT
+                - Mon, 04 May 2026 20:44:23 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
                 - "394"
             Ratelimit-Reset:
-                - "49"
+                - "36"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-010187
+                - api-67697cb9cc-8r4lj/bvH9OfgVXm-331640
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=94
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -3599,8 +5859,8 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 111.880291ms
-    - id: 64
+        duration: 186.293417ms
+    - id: 99
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3618,7 +5878,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/environments/evm-csr7nerv2p9s739qqjlg
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sga47avr4c73b59g10-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -3629,22 +5889,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"databasesIds":null,"envGroupIds":null,"id":"evm-csr7nerv2p9s739qqjlg","name":"prod","projectId":"prj-csr7nerv2p9s739qqjl0","protectedStatus":"protected","redisIds":null,"serviceIds":null}
+            {"createdAt":"2026-05-04T20:44:00.199612Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sga47avr4c73b59g10-a","databaseName":"db_name2_jmvr","databaseUser":"db_user2","diskAutoscalingEnabled":false,"diskSizeGB":10,"highAvailabilityEnabled":false,"id":"dpg-d7sga47avr4c73b59g10-a","ipAllowList":null,"name":"new-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T20:44:00.199612Z","version":"16"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:39:10 GMT
+                - Mon, 04 May 2026 20:44:31 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
                 - "393"
             Ratelimit-Reset:
-                - "49"
+                - "28"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-010190
+                - api-67697cb9cc-w5d8j/dGSnE3CKgI-286683
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=96
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -3655,8 +5918,8 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 117.215917ms
-    - id: 65
+        duration: 117.260333ms
+    - id: 100
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3674,7 +5937,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-csr7npjv2p9s739qqmp0-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sga47avr4c73b59g10-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -3685,22 +5948,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"createdAt":"2024-11-14T22:38:30.01267Z","dashboardUrl":"https://dashboard.render.com/d/dpg-csr7npjv2p9s739qqmp0-a","databaseName":"db_name2_qm7i","databaseUser":"db_user2","diskSizeGB":10,"highAvailabilityEnabled":false,"id":"dpg-csr7npjv2p9s739qqmp0-a","ipAllowList":null,"name":"new-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Scott's Terraform","type":"team"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"available","suspended":"not_suspended","suspenders":[],"updatedAt":"2024-11-14T22:38:30.01267Z","version":"16"}
+            {"createdAt":"2026-05-04T20:44:00.199612Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sga47avr4c73b59g10-a","databaseName":"db_name2_jmvr","databaseUser":"db_user2","diskAutoscalingEnabled":false,"diskSizeGB":10,"highAvailabilityEnabled":false,"id":"dpg-d7sga47avr4c73b59g10-a","ipAllowList":null,"name":"new-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"available","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T20:44:00.199612Z","version":"16"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:39:11 GMT
+                - Mon, 04 May 2026 20:44:40 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
                 - "392"
             Ratelimit-Reset:
-                - "48"
+                - "19"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-010193
+                - api-67697cb9cc-n8qkv/lMOh2vXId9-331457
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=99
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -3711,8 +5977,8 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 101.72925ms
-    - id: 66
+        duration: 127.091708ms
+    - id: 101
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3730,7 +5996,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-csr7npjv2p9s739qqmp0-a/connection-info
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sga47avr4c73b59g10-a/connection-info
         method: GET
       response:
         proto: HTTP/2.0
@@ -3741,22 +6007,25 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"externalConnectionString":"postgresql://db_user2:Sj68nzlzjOFnjj6pPaCzdRcYtGyZrk5m@dpg-csr7npjv2p9s739qqmp0-a.oregon-postgres.render.com:5432/db_name2_qm7i","internalConnectionString":"postgresql://db_user2:Sj68nzlzjOFnjj6pPaCzdRcYtGyZrk5m@dpg-csr7npjv2p9s739qqmp0-a/db_name2_qm7i","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-csr7npjv2p9s739qqmp0-a.oregon-postgres.render.com -p 5432 -U db_user2 db_name2_qm7i"}
+            {"externalConnectionString":"postgresql://db_user2:zGgjBnV5OAoBx3leIdeY2Ecd961MXvsl@dpg-d7sga47avr4c73b59g10-a.oregon-postgres.render.com:5432/db_name2_jmvr","internalConnectionString":"postgresql://db_user2:zGgjBnV5OAoBx3leIdeY2Ecd961MXvsl@dpg-d7sga47avr4c73b59g10-a/db_name2_jmvr","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-d7sga47avr4c73b59g10-a.oregon-postgres.render.com -p 5432 -U db_user2 db_name2_jmvr"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:39:11 GMT
+                - Mon, 04 May 2026 20:44:40 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
                 - "391"
             Ratelimit-Reset:
-                - "48"
+                - "19"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-010198
+                - api-67697cb9cc-hlhmt/HnNQegxyNd-259943
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=8,cfOrigin;dur=92
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -3767,8 +6036,8 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 71.254875ms
-    - id: 67
+        duration: 116.623958ms
+    - id: 102
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3786,7 +6055,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-csr7npjv2p9s739qqmp0-a
+        url: https://api.testing.render.com/v1/projects/prj-d7sg9l8k1i2s7381aj10
         method: GET
       response:
         proto: HTTP/2.0
@@ -3797,22 +6066,379 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"message":"not found: dpg-csr7npjv2p9s739qqmp0-a"}
+            {"createdAt":"2026-05-04T20:43:01.298824Z","environmentIds":["evm-d7sg9l8k1i2s7381aj20"],"id":"prj-d7sg9l8k1i2s7381aj10","name":"first","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"updatedAt":"2026-05-04T20:43:01.298824Z"}
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 14 Nov 2024 22:39:11 GMT
+                - Mon, 04 May 2026 20:44:40 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
                 - "390"
             Ratelimit-Reset:
-                - "48"
+                - "19"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-010202
+                - api-67697cb9cc-txqml/nqfxnrpqwi-116182
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=8,cfOrigin;dur=142
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 187.871375ms
+    - id: 103
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/environments/evm-d7sg9l8k1i2s7381aj20
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"databasesIds":null,"envGroupIds":null,"id":"evm-d7sg9l8k1i2s7381aj20","ipAllowList":[{"cidrBlock":"0.0.0.0/0","description":"everywhere"}],"name":"prod","networkIsolationEnabled":false,"projectId":"prj-d7sg9l8k1i2s7381aj10","protectedStatus":"protected","redisIds":null,"serviceIds":null}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 20:44:40 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "389"
+            Ratelimit-Reset:
+                - "19"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-2x52t/rJPzHDiqR2-199861
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=8,cfOrigin;dur=78
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 106.065875ms
+    - id: 104
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/projects/prj-d7sg9lbeo5us73ahovo0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"createdAt":"2026-05-04T20:43:01.679555Z","environmentIds":["evm-d7sg9lbeo5us73ahovp0"],"id":"prj-d7sg9lbeo5us73ahovo0","name":"second","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"updatedAt":"2026-05-04T20:43:01.679555Z"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 20:44:41 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "388"
+            Ratelimit-Reset:
+                - "18"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-mj245/HwjA0atTkv-231905
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=7,cfOrigin;dur=118
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 143.828584ms
+    - id: 105
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/environments/evm-d7sg9lbeo5us73ahovp0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"databasesIds":null,"envGroupIds":null,"id":"evm-d7sg9lbeo5us73ahovp0","ipAllowList":[{"cidrBlock":"0.0.0.0/0","description":"everywhere"}],"name":"prod","networkIsolationEnabled":false,"projectId":"prj-d7sg9lbeo5us73ahovo0","protectedStatus":"protected","redisIds":null,"serviceIds":null}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 20:44:41 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "387"
+            Ratelimit-Reset:
+                - "18"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-xcbhc/vgcYLi38GW-159020
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=7,cfOrigin;dur=76
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 175.842667ms
+    - id: 106
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sga47avr4c73b59g10-a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"createdAt":"2026-05-04T20:44:00.199612Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sga47avr4c73b59g10-a","databaseName":"db_name2_jmvr","databaseUser":"db_user2","diskAutoscalingEnabled":false,"diskSizeGB":10,"highAvailabilityEnabled":false,"id":"dpg-d7sga47avr4c73b59g10-a","ipAllowList":null,"name":"new-name","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"available","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T20:44:00.199612Z","version":"16"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 20:44:41 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "386"
+            Ratelimit-Reset:
+                - "18"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-w5d8j/dGSnE3CKgI-287351
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=7,cfOrigin;dur=134
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 167.278166ms
+    - id: 107
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sga47avr4c73b59g10-a/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"externalConnectionString":"postgresql://db_user2:zGgjBnV5OAoBx3leIdeY2Ecd961MXvsl@dpg-d7sga47avr4c73b59g10-a.oregon-postgres.render.com:5432/db_name2_jmvr","internalConnectionString":"postgresql://db_user2:zGgjBnV5OAoBx3leIdeY2Ecd961MXvsl@dpg-d7sga47avr4c73b59g10-a/db_name2_jmvr","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-d7sga47avr4c73b59g10-a.oregon-postgres.render.com -p 5432 -U db_user2 db_name2_jmvr"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 20:44:41 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "385"
+            Ratelimit-Reset:
+                - "18"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-xcbhc/vgcYLi38GW-159040
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=5,cfOrigin;dur=96
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 115.670292ms
+    - id: 108
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-d7sga47avr4c73b59g10-a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"message":"not found: dpg-d7sga47avr4c73b59g10-a"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 20:44:41 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "384"
+            Ratelimit-Reset:
+                - "18"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-hlhmt/HnNQegxyNd-260019
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=11,cfOrigin;dur=138
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -3823,8 +6449,8 @@ interactions:
                 - 1; mode=block
         status: 404 Not Found
         code: 404
-        duration: 80.288542ms
-    - id: 68
+        duration: 176.102708ms
+    - id: 109
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3842,7 +6468,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-csr7npjv2p9s739qqmp0-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sga47avr4c73b59g10-a
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -3855,17 +6481,20 @@ interactions:
         body: ""
         headers:
             Date:
-                - Thu, 14 Nov 2024 22:39:11 GMT
+                - Mon, 04 May 2026 20:44:42 GMT
             Ratelimit-Limit:
                 - "100"
             Ratelimit-Remaining:
                 - "99"
             Ratelimit-Reset:
-                - "48"
+                - "17"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-010205
+                - api-67697cb9cc-7g8wf/qqOGxLHk0I-350829
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=453
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -3876,8 +6505,8 @@ interactions:
                 - 1; mode=block
         status: 204 No Content
         code: 204
-        duration: 160.178584ms
-    - id: 69
+        duration: 474.832292ms
+    - id: 110
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3895,7 +6524,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/projects/prj-csr7nerv2p9s739qqjl0
+        url: https://api.testing.render.com/v1/projects/prj-d7sg9lbeo5us73ahovo0
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -3908,17 +6537,20 @@ interactions:
         body: ""
         headers:
             Date:
-                - Thu, 14 Nov 2024 22:39:11 GMT
+                - Mon, 04 May 2026 20:44:42 GMT
             Ratelimit-Limit:
                 - "100"
             Ratelimit-Remaining:
                 - "98"
             Ratelimit-Reset:
-                - "48"
+                - "17"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-010214
+                - api-67697cb9cc-hlhmt/HnNQegxyNd-260055
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=5,cfOrigin;dur=117
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -3929,8 +6561,8 @@ interactions:
                 - 1; mode=block
         status: 204 No Content
         code: 204
-        duration: 63.474667ms
-    - id: 70
+        duration: 138.028083ms
+    - id: 111
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3948,7 +6580,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/projects/prj-csr7nebv2p9s739qqjig
+        url: https://api.testing.render.com/v1/projects/prj-d7sg9l8k1i2s7381aj10
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -3961,17 +6593,20 @@ interactions:
         body: ""
         headers:
             Date:
-                - Thu, 14 Nov 2024 22:39:11 GMT
+                - Mon, 04 May 2026 20:44:42 GMT
             Ratelimit-Limit:
                 - "100"
             Ratelimit-Remaining:
                 - "97"
             Ratelimit-Reset:
-                - "48"
+                - "17"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-84fb959cf4-bscbk/zYuGxMIfWO-010218
+                - api-67697cb9cc-8r4lj/bvH9OfgVXm-332977
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=5,cfOrigin;dur=117
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -3982,4 +6617,4 @@ interactions:
                 - 1; mode=block
         status: 204 No Content
         code: 204
-        duration: 68.843542ms
+        duration: 137.256667ms

--- a/internal/provider/postgres/resource/testdata/postgres_parameter_overrides_cassette.yaml
+++ b/internal/provider/postgres/resource/testdata/postgres_parameter_overrides_cassette.yaml
@@ -29,27 +29,30 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 766
+        content_length: 771
         uncompressed: false
         body: |
-            {"createdAt":"2025-11-20T05:26:03.107234457Z","dashboardUrl":"http://dashboard.render.localhost:3000/d/dpg-d4facqrvbnoc73eic1vg-a","databaseName":"test_parameter_overrides_fb85","databaseUser":"test_parameter_overrides_fb85_user","diskAutoscalingEnabled":false,"diskSizeGB":100,"highAvailabilityEnabled":false,"id":"dpg-d4facqrvbnoc73eic1vg-a","ipAllowList":null,"name":"test-parameter-overrides","owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"parameterOverrides":{"max_connections":"100","work_mem":"4MB"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"unknown","suspended":"not_suspended","suspenders":[],"updatedAt":"2025-11-20T05:26:03.107234457Z","version":"16"}
+            {"createdAt":"2026-05-04T21:01:46.486849488Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sgiegsfn5c73fgpfl0-a","databaseName":"test_parameter_overrides_agfj","databaseUser":"test_parameter_overrides_agfj_user","diskAutoscalingEnabled":false,"diskSizeGB":100,"highAvailabilityEnabled":false,"id":"dpg-d7sgiegsfn5c73fgpfl0-a","ipAllowList":null,"name":"test-parameter-overrides","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"parameterOverrides":{"max_connections":"100","work_mem":"4MB"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"unknown","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T21:01:46.486849488Z","version":"16"}
         headers:
             Content-Length:
-                - "766"
+                - "771"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 20 Nov 2025 05:26:03 GMT
+                - Mon, 04 May 2026 21:01:46 GMT
             Ratelimit-Limit:
                 - "20"
             Ratelimit-Remaining:
-                - "11"
+                - "19"
             Ratelimit-Reset:
-                - "2036"
+                - "3494"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-6c86dcdf64-2v2rx/ttyxxPz4tl-000203
+                - api-67697cb9cc-swx5g/Htral3X5Am-260285
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=16,cfOrigin;dur=781
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -60,7 +63,7 @@ interactions:
                 - 1; mode=block
         status: 201 Created
         code: 201
-        duration: 260.934422ms
+        duration: 915.733625ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -79,7 +82,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-d4facqrvbnoc73eic1vg-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sgiegsfn5c73fgpfl0-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -87,27 +90,28 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 760
-        uncompressed: false
+        content_length: -1
+        uncompressed: true
         body: |
-            {"createdAt":"2025-11-20T05:26:03.107234Z","dashboardUrl":"http://dashboard.render.localhost:3000/d/dpg-d4facqrvbnoc73eic1vg-a","databaseName":"test_parameter_overrides_fb85","databaseUser":"test_parameter_overrides_fb85_user","diskAutoscalingEnabled":false,"diskSizeGB":100,"highAvailabilityEnabled":false,"id":"dpg-d4facqrvbnoc73eic1vg-a","ipAllowList":null,"name":"test-parameter-overrides","owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"parameterOverrides":{"max_connections":"100","work_mem":"4MB"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"unknown","suspended":"not_suspended","suspenders":[],"updatedAt":"2025-11-20T05:26:03.107234Z","version":"16"}
+            {"createdAt":"2026-05-04T21:01:46.486849Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sgiegsfn5c73fgpfl0-a","databaseName":"test_parameter_overrides_agfj","databaseUser":"test_parameter_overrides_agfj_user","diskAutoscalingEnabled":false,"diskSizeGB":100,"highAvailabilityEnabled":false,"id":"dpg-d7sgiegsfn5c73fgpfl0-a","ipAllowList":null,"name":"test-parameter-overrides","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"parameterOverrides":{"max_connections":"100","work_mem":"4MB"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T21:01:46.486849Z","version":"16"}
         headers:
-            Content-Length:
-                - "760"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 20 Nov 2025 05:26:03 GMT
+                - Mon, 04 May 2026 21:01:46 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
                 - "399"
             Ratelimit-Reset:
-                - "56"
+                - "13"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-6c86dcdf64-2v2rx/ttyxxPz4tl-000204
+                - api-67697cb9cc-nzjtj/tk2FBh0tKJ-363553
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=8,cfOrigin;dur=113
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -118,7 +122,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 45.934817ms
+        duration: 145.185417ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -137,7 +141,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-d4facqrvbnoc73eic1vg-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sgiegsfn5c73fgpfl0-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -145,27 +149,28 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 761
-        uncompressed: false
+        content_length: -1
+        uncompressed: true
         body: |
-            {"createdAt":"2025-11-20T05:26:03.107234Z","dashboardUrl":"http://dashboard.render.localhost:3000/d/dpg-d4facqrvbnoc73eic1vg-a","databaseName":"test_parameter_overrides_fb85","databaseUser":"test_parameter_overrides_fb85_user","diskAutoscalingEnabled":false,"diskSizeGB":100,"highAvailabilityEnabled":false,"id":"dpg-d4facqrvbnoc73eic1vg-a","ipAllowList":null,"name":"test-parameter-overrides","owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"parameterOverrides":{"max_connections":"100","work_mem":"4MB"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2025-11-20T05:26:03.107234Z","version":"16"}
+            {"createdAt":"2026-05-04T21:01:46.486849Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sgiegsfn5c73fgpfl0-a","databaseName":"test_parameter_overrides_agfj","databaseUser":"test_parameter_overrides_agfj_user","diskAutoscalingEnabled":false,"diskSizeGB":100,"highAvailabilityEnabled":false,"id":"dpg-d7sgiegsfn5c73fgpfl0-a","ipAllowList":null,"name":"test-parameter-overrides","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"parameterOverrides":{"max_connections":"100","work_mem":"4MB"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T21:01:46.486849Z","version":"16"}
         headers:
-            Content-Length:
-                - "761"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 20 Nov 2025 05:26:06 GMT
+                - Mon, 04 May 2026 21:01:49 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
                 - "398"
             Ratelimit-Reset:
-                - "53"
+                - "10"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-6c86dcdf64-2v2rx/ttyxxPz4tl-000205
+                - api-67697cb9cc-dxjk6/4C2QjVr1j7-404456
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=10,cfOrigin;dur=93
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -176,7 +181,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 50.820729ms
+        duration: 144.435667ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -195,7 +200,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-d4facqrvbnoc73eic1vg-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sgiegsfn5c73fgpfl0-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -203,27 +208,28 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 761
-        uncompressed: false
+        content_length: -1
+        uncompressed: true
         body: |
-            {"createdAt":"2025-11-20T05:26:03.107234Z","dashboardUrl":"http://dashboard.render.localhost:3000/d/dpg-d4facqrvbnoc73eic1vg-a","databaseName":"test_parameter_overrides_fb85","databaseUser":"test_parameter_overrides_fb85_user","diskAutoscalingEnabled":false,"diskSizeGB":100,"highAvailabilityEnabled":false,"id":"dpg-d4facqrvbnoc73eic1vg-a","ipAllowList":null,"name":"test-parameter-overrides","owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"parameterOverrides":{"max_connections":"100","work_mem":"4MB"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2025-11-20T05:26:03.107234Z","version":"16"}
+            {"createdAt":"2026-05-04T21:01:46.486849Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sgiegsfn5c73fgpfl0-a","databaseName":"test_parameter_overrides_agfj","databaseUser":"test_parameter_overrides_agfj_user","diskAutoscalingEnabled":false,"diskSizeGB":100,"highAvailabilityEnabled":false,"id":"dpg-d7sgiegsfn5c73fgpfl0-a","ipAllowList":null,"name":"test-parameter-overrides","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"parameterOverrides":{"max_connections":"100","work_mem":"4MB"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T21:01:46.486849Z","version":"16"}
         headers:
-            Content-Length:
-                - "761"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 20 Nov 2025 05:26:09 GMT
+                - Mon, 04 May 2026 21:01:53 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
                 - "397"
             Ratelimit-Reset:
-                - "50"
+                - "6"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-6c86dcdf64-2v2rx/ttyxxPz4tl-000206
+                - api-67697cb9cc-swx5g/Htral3X5Am-260672
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=173
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -234,7 +240,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 44.459885ms
+        duration: 263.598042ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -253,7 +259,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-d4facqrvbnoc73eic1vg-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sgiegsfn5c73fgpfl0-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -261,27 +267,28 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 761
-        uncompressed: false
+        content_length: -1
+        uncompressed: true
         body: |
-            {"createdAt":"2025-11-20T05:26:03.107234Z","dashboardUrl":"http://dashboard.render.localhost:3000/d/dpg-d4facqrvbnoc73eic1vg-a","databaseName":"test_parameter_overrides_fb85","databaseUser":"test_parameter_overrides_fb85_user","diskAutoscalingEnabled":false,"diskSizeGB":100,"highAvailabilityEnabled":false,"id":"dpg-d4facqrvbnoc73eic1vg-a","ipAllowList":null,"name":"test-parameter-overrides","owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"parameterOverrides":{"max_connections":"100","work_mem":"4MB"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2025-11-20T05:26:03.107234Z","version":"16"}
+            {"createdAt":"2026-05-04T21:01:46.486849Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sgiegsfn5c73fgpfl0-a","databaseName":"test_parameter_overrides_agfj","databaseUser":"test_parameter_overrides_agfj_user","diskAutoscalingEnabled":false,"diskSizeGB":100,"highAvailabilityEnabled":false,"id":"dpg-d7sgiegsfn5c73fgpfl0-a","ipAllowList":null,"name":"test-parameter-overrides","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"parameterOverrides":{"max_connections":"100","work_mem":"4MB"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T21:01:46.486849Z","version":"16"}
         headers:
-            Content-Length:
-                - "761"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 20 Nov 2025 05:26:14 GMT
+                - Mon, 04 May 2026 21:01:58 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
                 - "396"
             Ratelimit-Reset:
-                - "45"
+                - "1"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-6c86dcdf64-2v2rx/ttyxxPz4tl-000207
+                - api-67697cb9cc-nzjtj/tk2FBh0tKJ-364231
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=7,cfOrigin;dur=102
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -292,7 +299,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 47.039712ms
+        duration: 201.717334ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -311,7 +318,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-d4facqrvbnoc73eic1vg-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sgiegsfn5c73fgpfl0-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -319,27 +326,28 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 761
-        uncompressed: false
+        content_length: -1
+        uncompressed: true
         body: |
-            {"createdAt":"2025-11-20T05:26:03.107234Z","dashboardUrl":"http://dashboard.render.localhost:3000/d/dpg-d4facqrvbnoc73eic1vg-a","databaseName":"test_parameter_overrides_fb85","databaseUser":"test_parameter_overrides_fb85_user","diskAutoscalingEnabled":false,"diskSizeGB":100,"highAvailabilityEnabled":false,"id":"dpg-d4facqrvbnoc73eic1vg-a","ipAllowList":null,"name":"test-parameter-overrides","owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"parameterOverrides":{"max_connections":"100","work_mem":"4MB"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2025-11-20T05:26:03.107234Z","version":"16"}
+            {"createdAt":"2026-05-04T21:01:46.486849Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sgiegsfn5c73fgpfl0-a","databaseName":"test_parameter_overrides_agfj","databaseUser":"test_parameter_overrides_agfj_user","diskAutoscalingEnabled":false,"diskSizeGB":100,"highAvailabilityEnabled":false,"id":"dpg-d7sgiegsfn5c73fgpfl0-a","ipAllowList":null,"name":"test-parameter-overrides","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"parameterOverrides":{"max_connections":"100","work_mem":"4MB"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T21:01:46.486849Z","version":"16"}
         headers:
-            Content-Length:
-                - "761"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 20 Nov 2025 05:26:19 GMT
+                - Mon, 04 May 2026 21:02:03 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "395"
+                - "399"
             Ratelimit-Reset:
-                - "40"
+                - "56"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-6c86dcdf64-2v2rx/ttyxxPz4tl-000208
+                - api-67697cb9cc-hr98q/EEsGBcgj5Z-171064
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=8,cfOrigin;dur=93
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -350,7 +358,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 48.90555ms
+        duration: 173.786625ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -369,7 +377,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-d4facqrvbnoc73eic1vg-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sgiegsfn5c73fgpfl0-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -377,27 +385,28 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 761
-        uncompressed: false
+        content_length: -1
+        uncompressed: true
         body: |
-            {"createdAt":"2025-11-20T05:26:03.107234Z","dashboardUrl":"http://dashboard.render.localhost:3000/d/dpg-d4facqrvbnoc73eic1vg-a","databaseName":"test_parameter_overrides_fb85","databaseUser":"test_parameter_overrides_fb85_user","diskAutoscalingEnabled":false,"diskSizeGB":100,"highAvailabilityEnabled":false,"id":"dpg-d4facqrvbnoc73eic1vg-a","ipAllowList":null,"name":"test-parameter-overrides","owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"parameterOverrides":{"max_connections":"100","work_mem":"4MB"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2025-11-20T05:26:03.107234Z","version":"16"}
+            {"createdAt":"2026-05-04T21:01:46.486849Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sgiegsfn5c73fgpfl0-a","databaseName":"test_parameter_overrides_agfj","databaseUser":"test_parameter_overrides_agfj_user","diskAutoscalingEnabled":false,"diskSizeGB":100,"highAvailabilityEnabled":false,"id":"dpg-d7sgiegsfn5c73fgpfl0-a","ipAllowList":null,"name":"test-parameter-overrides","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"parameterOverrides":{"max_connections":"100","work_mem":"4MB"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T21:01:46.486849Z","version":"16"}
         headers:
-            Content-Length:
-                - "761"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 20 Nov 2025 05:26:25 GMT
+                - Mon, 04 May 2026 21:02:10 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "394"
+                - "398"
             Ratelimit-Reset:
-                - "34"
+                - "49"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-6c86dcdf64-2v2rx/ttyxxPz4tl-000209
+                - api-67697cb9cc-7hdlp/bSeT1VJf0a-289980
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=14,cfOrigin;dur=110
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -408,7 +417,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 57.097899ms
+        duration: 146.477625ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -427,7 +436,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-d4facqrvbnoc73eic1vg-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sgiegsfn5c73fgpfl0-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -435,27 +444,28 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 761
-        uncompressed: false
+        content_length: -1
+        uncompressed: true
         body: |
-            {"createdAt":"2025-11-20T05:26:03.107234Z","dashboardUrl":"http://dashboard.render.localhost:3000/d/dpg-d4facqrvbnoc73eic1vg-a","databaseName":"test_parameter_overrides_fb85","databaseUser":"test_parameter_overrides_fb85_user","diskAutoscalingEnabled":false,"diskSizeGB":100,"highAvailabilityEnabled":false,"id":"dpg-d4facqrvbnoc73eic1vg-a","ipAllowList":null,"name":"test-parameter-overrides","owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"parameterOverrides":{"max_connections":"100","work_mem":"4MB"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2025-11-20T05:26:03.107234Z","version":"16"}
+            {"createdAt":"2026-05-04T21:01:46.486849Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sgiegsfn5c73fgpfl0-a","databaseName":"test_parameter_overrides_agfj","databaseUser":"test_parameter_overrides_agfj_user","diskAutoscalingEnabled":false,"diskSizeGB":100,"highAvailabilityEnabled":false,"id":"dpg-d7sgiegsfn5c73fgpfl0-a","ipAllowList":null,"name":"test-parameter-overrides","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"parameterOverrides":{"max_connections":"100","work_mem":"4MB"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T21:01:46.486849Z","version":"16"}
         headers:
-            Content-Length:
-                - "761"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 20 Nov 2025 05:26:33 GMT
+                - Mon, 04 May 2026 21:02:17 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "393"
+                - "397"
             Ratelimit-Reset:
-                - "26"
+                - "42"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-6c86dcdf64-2v2rx/ttyxxPz4tl-000210
+                - api-67697cb9cc-rr9lz/iQKxXhmUkr-234386
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=8,cfOrigin;dur=89
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -466,7 +476,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 44.406888ms
+        duration: 204.431708ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -485,7 +495,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-d4facqrvbnoc73eic1vg-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sgiegsfn5c73fgpfl0-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -493,27 +503,28 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 762
-        uncompressed: false
+        content_length: -1
+        uncompressed: true
         body: |
-            {"createdAt":"2025-11-20T05:26:03.107234Z","dashboardUrl":"http://dashboard.render.localhost:3000/d/dpg-d4facqrvbnoc73eic1vg-a","databaseName":"test_parameter_overrides_fb85","databaseUser":"test_parameter_overrides_fb85_user","diskAutoscalingEnabled":false,"diskSizeGB":100,"highAvailabilityEnabled":false,"id":"dpg-d4facqrvbnoc73eic1vg-a","ipAllowList":null,"name":"test-parameter-overrides","owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"parameterOverrides":{"max_connections":"100","work_mem":"4MB"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"available","suspended":"not_suspended","suspenders":[],"updatedAt":"2025-11-20T05:26:03.107234Z","version":"16"}
+            {"createdAt":"2026-05-04T21:01:46.486849Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sgiegsfn5c73fgpfl0-a","databaseName":"test_parameter_overrides_agfj","databaseUser":"test_parameter_overrides_agfj_user","diskAutoscalingEnabled":false,"diskSizeGB":100,"highAvailabilityEnabled":false,"id":"dpg-d7sgiegsfn5c73fgpfl0-a","ipAllowList":null,"name":"test-parameter-overrides","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"parameterOverrides":{"max_connections":"100","work_mem":"4MB"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"creating","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T21:01:46.486849Z","version":"16"}
         headers:
-            Content-Length:
-                - "762"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 20 Nov 2025 05:26:42 GMT
+                - Mon, 04 May 2026 21:02:26 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "392"
+                - "396"
             Ratelimit-Reset:
-                - "17"
+                - "33"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-6c86dcdf64-2v2rx/ttyxxPz4tl-000211
+                - api-67697cb9cc-swx5g/Htral3X5Am-262152
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=105
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -524,7 +535,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 59.896389ms
+        duration: 128.469292ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -543,7 +554,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-d4facqrvbnoc73eic1vg-a/connection-info
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sgiegsfn5c73fgpfl0-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -551,27 +562,28 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 632
-        uncompressed: false
+        content_length: -1
+        uncompressed: true
         body: |
-            {"externalConnectionString":"postgresql://test_parameter_overrides_fb85_user:ORlThK7u7i7iYJZFl4OcfgEmxVTycts1@dpg-d4facqrvbnoc73eic1vg-a.oregon-postgres.localhost.render.com:5434/test_parameter_overrides_fb85","internalConnectionString":"postgresql://test_parameter_overrides_fb85_user:ORlThK7u7i7iYJZFl4OcfgEmxVTycts1@dpg-d4facqrvbnoc73eic1vg-a/test_parameter_overrides_fb85","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-d4facqrvbnoc73eic1vg-a.oregon-postgres.localhost.render.com -p 5434 -U test_parameter_overrides_fb85_user test_parameter_overrides_fb85"}
+            {"createdAt":"2026-05-04T21:01:46.486849Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sgiegsfn5c73fgpfl0-a","databaseName":"test_parameter_overrides_agfj","databaseUser":"test_parameter_overrides_agfj_user","diskAutoscalingEnabled":false,"diskSizeGB":100,"highAvailabilityEnabled":false,"id":"dpg-d7sgiegsfn5c73fgpfl0-a","ipAllowList":null,"name":"test-parameter-overrides","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"parameterOverrides":{"max_connections":"100","work_mem":"4MB"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"available","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T21:01:46.486849Z","version":"16"}
         headers:
-            Content-Length:
-                - "632"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 20 Nov 2025 05:26:42 GMT
+                - Mon, 04 May 2026 21:02:37 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "391"
+                - "395"
             Ratelimit-Reset:
-                - "17"
+                - "22"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-6c86dcdf64-2v2rx/ttyxxPz4tl-000212
+                - api-67697cb9cc-nzjtj/tk2FBh0tKJ-366579
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=5,cfOrigin;dur=102
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -582,7 +594,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 46.150996ms
+        duration: 208.70125ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -601,7 +613,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-d4facqrvbnoc73eic1vg-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sgiegsfn5c73fgpfl0-a/connection-info
         method: GET
       response:
         proto: HTTP/2.0
@@ -609,27 +621,28 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 762
-        uncompressed: false
+        content_length: -1
+        uncompressed: true
         body: |
-            {"createdAt":"2025-11-20T05:26:03.107234Z","dashboardUrl":"http://dashboard.render.localhost:3000/d/dpg-d4facqrvbnoc73eic1vg-a","databaseName":"test_parameter_overrides_fb85","databaseUser":"test_parameter_overrides_fb85_user","diskAutoscalingEnabled":false,"diskSizeGB":100,"highAvailabilityEnabled":false,"id":"dpg-d4facqrvbnoc73eic1vg-a","ipAllowList":null,"name":"test-parameter-overrides","owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"parameterOverrides":{"max_connections":"100","work_mem":"4MB"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"available","suspended":"not_suspended","suspenders":[],"updatedAt":"2025-11-20T05:26:03.107234Z","version":"16"}
+            {"externalConnectionString":"postgresql://test_parameter_overrides_agfj_user:mYvK8WNGV6hawuc6xHqeq4Rzlo9e8Tfv@dpg-d7sgiegsfn5c73fgpfl0-a.oregon-postgres.render.com:5432/test_parameter_overrides_agfj","internalConnectionString":"postgresql://test_parameter_overrides_agfj_user:mYvK8WNGV6hawuc6xHqeq4Rzlo9e8Tfv@dpg-d7sgiegsfn5c73fgpfl0-a/test_parameter_overrides_agfj","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-d7sgiegsfn5c73fgpfl0-a.oregon-postgres.render.com -p 5432 -U test_parameter_overrides_agfj_user test_parameter_overrides_agfj"}
         headers:
-            Content-Length:
-                - "762"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 20 Nov 2025 05:26:42 GMT
+                - Mon, 04 May 2026 21:02:37 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "390"
+                - "394"
             Ratelimit-Reset:
-                - "17"
+                - "22"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-6c86dcdf64-2v2rx/ttyxxPz4tl-000213
+                - api-67697cb9cc-dxjk6/4C2QjVr1j7-407352
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=10,cfOrigin;dur=106
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -640,7 +653,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 47.105856ms
+        duration: 135.738625ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -659,7 +672,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-d4facqrvbnoc73eic1vg-a/connection-info
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sgiegsfn5c73fgpfl0-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -667,27 +680,28 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 632
-        uncompressed: false
+        content_length: -1
+        uncompressed: true
         body: |
-            {"externalConnectionString":"postgresql://test_parameter_overrides_fb85_user:ORlThK7u7i7iYJZFl4OcfgEmxVTycts1@dpg-d4facqrvbnoc73eic1vg-a.oregon-postgres.localhost.render.com:5434/test_parameter_overrides_fb85","internalConnectionString":"postgresql://test_parameter_overrides_fb85_user:ORlThK7u7i7iYJZFl4OcfgEmxVTycts1@dpg-d4facqrvbnoc73eic1vg-a/test_parameter_overrides_fb85","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-d4facqrvbnoc73eic1vg-a.oregon-postgres.localhost.render.com -p 5434 -U test_parameter_overrides_fb85_user test_parameter_overrides_fb85"}
+            {"createdAt":"2026-05-04T21:01:46.486849Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sgiegsfn5c73fgpfl0-a","databaseName":"test_parameter_overrides_agfj","databaseUser":"test_parameter_overrides_agfj_user","diskAutoscalingEnabled":false,"diskSizeGB":100,"highAvailabilityEnabled":false,"id":"dpg-d7sgiegsfn5c73fgpfl0-a","ipAllowList":null,"name":"test-parameter-overrides","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"parameterOverrides":{"max_connections":"100","work_mem":"4MB"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"available","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T21:01:46.486849Z","version":"16"}
         headers:
-            Content-Length:
-                - "632"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 20 Nov 2025 05:26:42 GMT
+                - Mon, 04 May 2026 21:02:38 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "389"
+                - "393"
             Ratelimit-Reset:
-                - "17"
+                - "21"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-6c86dcdf64-2v2rx/ttyxxPz4tl-000214
+                - api-67697cb9cc-7g8wf/qqOGxLHk0I-413624
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=7,cfOrigin;dur=165
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -698,7 +712,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 47.512721ms
+        duration: 187.55725ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -717,7 +731,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-d4facqrvbnoc73eic1vg-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sgiegsfn5c73fgpfl0-a/connection-info
         method: GET
       response:
         proto: HTTP/2.0
@@ -725,27 +739,28 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 52
-        uncompressed: false
+        content_length: -1
+        uncompressed: true
         body: |
-            {"message":"not found: dpg-d4facqrvbnoc73eic1vg-a"}
+            {"externalConnectionString":"postgresql://test_parameter_overrides_agfj_user:mYvK8WNGV6hawuc6xHqeq4Rzlo9e8Tfv@dpg-d7sgiegsfn5c73fgpfl0-a.oregon-postgres.render.com:5432/test_parameter_overrides_agfj","internalConnectionString":"postgresql://test_parameter_overrides_agfj_user:mYvK8WNGV6hawuc6xHqeq4Rzlo9e8Tfv@dpg-d7sgiegsfn5c73fgpfl0-a/test_parameter_overrides_agfj","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-d7sgiegsfn5c73fgpfl0-a.oregon-postgres.render.com -p 5432 -U test_parameter_overrides_agfj_user test_parameter_overrides_agfj"}
         headers:
-            Content-Length:
-                - "52"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 20 Nov 2025 05:26:43 GMT
+                - Mon, 04 May 2026 21:02:38 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "388"
+                - "392"
             Ratelimit-Reset:
-                - "16"
+                - "21"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-6c86dcdf64-2v2rx/ttyxxPz4tl-000215
+                - api-67697cb9cc-hr98q/EEsGBcgj5Z-172394
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=102
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -754,9 +769,9 @@ interactions:
                 - DENY
             X-Xss-Protection:
                 - 1; mode=block
-        status: 404 Not Found
-        code: 404
-        duration: 31.236301ms
+        status: 200 OK
+        code: 200
+        duration: 149.609375ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -775,7 +790,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-d4facqrvbnoc73eic1vg-a
+        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-d7sgiegsfn5c73fgpfl0-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -783,27 +798,28 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 762
-        uncompressed: false
+        content_length: -1
+        uncompressed: true
         body: |
-            {"createdAt":"2025-11-20T05:26:03.107234Z","dashboardUrl":"http://dashboard.render.localhost:3000/d/dpg-d4facqrvbnoc73eic1vg-a","databaseName":"test_parameter_overrides_fb85","databaseUser":"test_parameter_overrides_fb85_user","diskAutoscalingEnabled":false,"diskSizeGB":100,"highAvailabilityEnabled":false,"id":"dpg-d4facqrvbnoc73eic1vg-a","ipAllowList":null,"name":"test-parameter-overrides","owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"parameterOverrides":{"max_connections":"100","work_mem":"4MB"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"available","suspended":"not_suspended","suspenders":[],"updatedAt":"2025-11-20T05:26:03.107234Z","version":"16"}
+            {"message":"not found: dpg-d7sgiegsfn5c73fgpfl0-a"}
         headers:
-            Content-Length:
-                - "762"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 20 Nov 2025 05:26:43 GMT
+                - Mon, 04 May 2026 21:02:38 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "387"
+                - "391"
             Ratelimit-Reset:
-                - "16"
+                - "21"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-6c86dcdf64-2v2rx/ttyxxPz4tl-000216
+                - api-67697cb9cc-8r4lj/bvH9OfgVXm-400909
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=12,cfOrigin;dur=138
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -812,9 +828,9 @@ interactions:
                 - DENY
             X-Xss-Protection:
                 - 1; mode=block
-        status: 200 OK
-        code: 200
-        duration: 46.689405ms
+        status: 404 Not Found
+        code: 404
+        duration: 168.700917ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -833,7 +849,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-d4facqrvbnoc73eic1vg-a/connection-info
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sgiegsfn5c73fgpfl0-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -841,27 +857,28 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 632
-        uncompressed: false
+        content_length: -1
+        uncompressed: true
         body: |
-            {"externalConnectionString":"postgresql://test_parameter_overrides_fb85_user:ORlThK7u7i7iYJZFl4OcfgEmxVTycts1@dpg-d4facqrvbnoc73eic1vg-a.oregon-postgres.localhost.render.com:5434/test_parameter_overrides_fb85","internalConnectionString":"postgresql://test_parameter_overrides_fb85_user:ORlThK7u7i7iYJZFl4OcfgEmxVTycts1@dpg-d4facqrvbnoc73eic1vg-a/test_parameter_overrides_fb85","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-d4facqrvbnoc73eic1vg-a.oregon-postgres.localhost.render.com -p 5434 -U test_parameter_overrides_fb85_user test_parameter_overrides_fb85"}
+            {"createdAt":"2026-05-04T21:01:46.486849Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sgiegsfn5c73fgpfl0-a","databaseName":"test_parameter_overrides_agfj","databaseUser":"test_parameter_overrides_agfj_user","diskAutoscalingEnabled":false,"diskSizeGB":100,"highAvailabilityEnabled":false,"id":"dpg-d7sgiegsfn5c73fgpfl0-a","ipAllowList":null,"name":"test-parameter-overrides","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"parameterOverrides":{"max_connections":"100","work_mem":"4MB"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"available","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T21:01:46.486849Z","version":"16"}
         headers:
-            Content-Length:
-                - "632"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 20 Nov 2025 05:26:43 GMT
+                - Mon, 04 May 2026 21:02:38 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "386"
+                - "390"
             Ratelimit-Reset:
-                - "16"
+                - "21"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-6c86dcdf64-2v2rx/ttyxxPz4tl-000217
+                - api-67697cb9cc-nzjtj/tk2FBh0tKJ-366642
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=7,cfOrigin;dur=103
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -872,7 +889,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 42.795061ms
+        duration: 159.771583ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -891,7 +908,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-d4facqrvbnoc73eic1vg-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sgiegsfn5c73fgpfl0-a/connection-info
         method: GET
       response:
         proto: HTTP/2.0
@@ -899,27 +916,87 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 52
-        uncompressed: false
+        content_length: -1
+        uncompressed: true
         body: |
-            {"message":"not found: dpg-d4facqrvbnoc73eic1vg-a"}
+            {"externalConnectionString":"postgresql://test_parameter_overrides_agfj_user:mYvK8WNGV6hawuc6xHqeq4Rzlo9e8Tfv@dpg-d7sgiegsfn5c73fgpfl0-a.oregon-postgres.render.com:5432/test_parameter_overrides_agfj","internalConnectionString":"postgresql://test_parameter_overrides_agfj_user:mYvK8WNGV6hawuc6xHqeq4Rzlo9e8Tfv@dpg-d7sgiegsfn5c73fgpfl0-a/test_parameter_overrides_agfj","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-d7sgiegsfn5c73fgpfl0-a.oregon-postgres.render.com -p 5432 -U test_parameter_overrides_agfj_user test_parameter_overrides_agfj"}
         headers:
-            Content-Length:
-                - "52"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 20 Nov 2025 05:26:43 GMT
+                - Mon, 04 May 2026 21:02:39 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "385"
+                - "389"
             Ratelimit-Reset:
-                - "16"
+                - "21"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-6c86dcdf64-2v2rx/ttyxxPz4tl-000218
+                - api-67697cb9cc-7hdlp/bSeT1VJf0a-291510
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=9,cfOrigin;dur=132
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 161.495125ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-d7sgiegsfn5c73fgpfl0-a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"message":"not found: dpg-d7sgiegsfn5c73fgpfl0-a"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 21:02:39 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "388"
+            Ratelimit-Reset:
+                - "20"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-dxjk6/4C2QjVr1j7-407422
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=7,cfOrigin;dur=141
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -930,8 +1007,8 @@ interactions:
                 - 1; mode=block
         status: 404 Not Found
         code: 404
-        duration: 27.288357ms
-    - id: 16
+        duration: 221.377333ms
+    - id: 17
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -951,7 +1028,7 @@ interactions:
                 - application/json
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-d4facqrvbnoc73eic1vg-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sgiegsfn5c73fgpfl0-a
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -959,27 +1036,28 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 769
-        uncompressed: false
+        content_length: -1
+        uncompressed: true
         body: |
-            {"createdAt":"2025-11-20T05:26:03.107234Z","dashboardUrl":"http://dashboard.render.localhost:3000/d/dpg-d4facqrvbnoc73eic1vg-a","databaseName":"test_parameter_overrides_fb85","databaseUser":"test_parameter_overrides_fb85_user","diskAutoscalingEnabled":false,"diskSizeGB":100,"highAvailabilityEnabled":false,"id":"dpg-d4facqrvbnoc73eic1vg-a","ipAllowList":null,"name":"test-parameter-overrides","owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"parameterOverrides":{"max_connections":"150","shared_buffers":"128MB"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"available","suspended":"not_suspended","suspenders":[],"updatedAt":"2025-11-20T05:26:43.67168Z","version":"16"}
+            {"createdAt":"2026-05-04T21:01:46.486849Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sgiegsfn5c73fgpfl0-a","databaseName":"test_parameter_overrides_agfj","databaseUser":"test_parameter_overrides_agfj_user","diskAutoscalingEnabled":false,"diskSizeGB":100,"highAvailabilityEnabled":false,"id":"dpg-d7sgiegsfn5c73fgpfl0-a","ipAllowList":null,"name":"test-parameter-overrides","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"parameterOverrides":{"max_connections":"150","shared_buffers":"128MB"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"available","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T21:02:39.486316Z","version":"16"}
         headers:
-            Content-Length:
-                - "769"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 20 Nov 2025 05:26:43 GMT
+                - Mon, 04 May 2026 21:02:39 GMT
             Ratelimit-Limit:
                 - "100"
             Ratelimit-Remaining:
                 - "99"
             Ratelimit-Reset:
-                - "16"
+                - "20"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-6c86dcdf64-2v2rx/ttyxxPz4tl-000219
+                - api-67697cb9cc-rr9lz/iQKxXhmUkr-235268
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=7,cfOrigin;dur=235
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -990,65 +1068,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 137.431895ms
-    - id: 17
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: https://api.testing.render.com/v1
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Authorization:
-                - some-api-key
-            User-Agent:
-                - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-d4facqrvbnoc73eic1vg-a/connection-info
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 632
-        uncompressed: false
-        body: |
-            {"externalConnectionString":"postgresql://test_parameter_overrides_fb85_user:ORlThK7u7i7iYJZFl4OcfgEmxVTycts1@dpg-d4facqrvbnoc73eic1vg-a.oregon-postgres.localhost.render.com:5434/test_parameter_overrides_fb85","internalConnectionString":"postgresql://test_parameter_overrides_fb85_user:ORlThK7u7i7iYJZFl4OcfgEmxVTycts1@dpg-d4facqrvbnoc73eic1vg-a/test_parameter_overrides_fb85","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-d4facqrvbnoc73eic1vg-a.oregon-postgres.localhost.render.com -p 5434 -U test_parameter_overrides_fb85_user test_parameter_overrides_fb85"}
-        headers:
-            Content-Length:
-                - "632"
-            Content-Type:
-                - application/json; charset=utf-8
-            Date:
-                - Thu, 20 Nov 2025 05:26:43 GMT
-            Ratelimit-Limit:
-                - "400"
-            Ratelimit-Remaining:
-                - "384"
-            Ratelimit-Reset:
-                - "16"
-            Referrer-Policy:
-                - same-origin
-            Render-Request-Id:
-                - api-6c86dcdf64-2v2rx/ttyxxPz4tl-000220
-            Vary:
-                - Origin
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Xss-Protection:
-                - 1; mode=block
-        status: 200 OK
-        code: 200
-        duration: 43.400716ms
+        duration: 261.519708ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -1067,7 +1087,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-d4facqrvbnoc73eic1vg-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sgiegsfn5c73fgpfl0-a/connection-info
         method: GET
       response:
         proto: HTTP/2.0
@@ -1075,27 +1095,28 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 769
-        uncompressed: false
+        content_length: -1
+        uncompressed: true
         body: |
-            {"createdAt":"2025-11-20T05:26:03.107234Z","dashboardUrl":"http://dashboard.render.localhost:3000/d/dpg-d4facqrvbnoc73eic1vg-a","databaseName":"test_parameter_overrides_fb85","databaseUser":"test_parameter_overrides_fb85_user","diskAutoscalingEnabled":false,"diskSizeGB":100,"highAvailabilityEnabled":false,"id":"dpg-d4facqrvbnoc73eic1vg-a","ipAllowList":null,"name":"test-parameter-overrides","owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"parameterOverrides":{"max_connections":"150","shared_buffers":"128MB"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"available","suspended":"not_suspended","suspenders":[],"updatedAt":"2025-11-20T05:26:43.67168Z","version":"16"}
+            {"externalConnectionString":"postgresql://test_parameter_overrides_agfj_user:mYvK8WNGV6hawuc6xHqeq4Rzlo9e8Tfv@dpg-d7sgiegsfn5c73fgpfl0-a.oregon-postgres.render.com:5432/test_parameter_overrides_agfj","internalConnectionString":"postgresql://test_parameter_overrides_agfj_user:mYvK8WNGV6hawuc6xHqeq4Rzlo9e8Tfv@dpg-d7sgiegsfn5c73fgpfl0-a/test_parameter_overrides_agfj","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-d7sgiegsfn5c73fgpfl0-a.oregon-postgres.render.com -p 5432 -U test_parameter_overrides_agfj_user test_parameter_overrides_agfj"}
         headers:
-            Content-Length:
-                - "769"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 20 Nov 2025 05:26:44 GMT
+                - Mon, 04 May 2026 21:02:39 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "383"
+                - "387"
             Ratelimit-Reset:
-                - "15"
+                - "20"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-6c86dcdf64-2v2rx/ttyxxPz4tl-000221
+                - api-67697cb9cc-8r4lj/bvH9OfgVXm-400981
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=7,cfOrigin;dur=103
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1106,7 +1127,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 45.330164ms
+        duration: 149.871625ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -1125,7 +1146,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-d4facqrvbnoc73eic1vg-a/connection-info
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sgiegsfn5c73fgpfl0-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1133,27 +1154,28 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 632
-        uncompressed: false
+        content_length: -1
+        uncompressed: true
         body: |
-            {"externalConnectionString":"postgresql://test_parameter_overrides_fb85_user:ORlThK7u7i7iYJZFl4OcfgEmxVTycts1@dpg-d4facqrvbnoc73eic1vg-a.oregon-postgres.localhost.render.com:5434/test_parameter_overrides_fb85","internalConnectionString":"postgresql://test_parameter_overrides_fb85_user:ORlThK7u7i7iYJZFl4OcfgEmxVTycts1@dpg-d4facqrvbnoc73eic1vg-a/test_parameter_overrides_fb85","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-d4facqrvbnoc73eic1vg-a.oregon-postgres.localhost.render.com -p 5434 -U test_parameter_overrides_fb85_user test_parameter_overrides_fb85"}
+            {"createdAt":"2026-05-04T21:01:46.486849Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sgiegsfn5c73fgpfl0-a","databaseName":"test_parameter_overrides_agfj","databaseUser":"test_parameter_overrides_agfj_user","diskAutoscalingEnabled":false,"diskSizeGB":100,"highAvailabilityEnabled":false,"id":"dpg-d7sgiegsfn5c73fgpfl0-a","ipAllowList":null,"name":"test-parameter-overrides","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"parameterOverrides":{"max_connections":"150","shared_buffers":"128MB"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"available","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T21:02:39.486316Z","version":"16"}
         headers:
-            Content-Length:
-                - "632"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 20 Nov 2025 05:26:44 GMT
+                - Mon, 04 May 2026 21:02:40 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "382"
+                - "386"
             Ratelimit-Reset:
-                - "15"
+                - "19"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-6c86dcdf64-2v2rx/ttyxxPz4tl-000222
+                - api-67697cb9cc-swx5g/Htral3X5Am-262797
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=8,cfOrigin;dur=109
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1164,7 +1186,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 43.291158ms
+        duration: 134.753292ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1183,7 +1205,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-d4facqrvbnoc73eic1vg-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sgiegsfn5c73fgpfl0-a/connection-info
         method: GET
       response:
         proto: HTTP/2.0
@@ -1191,27 +1213,28 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 52
-        uncompressed: false
+        content_length: -1
+        uncompressed: true
         body: |
-            {"message":"not found: dpg-d4facqrvbnoc73eic1vg-a"}
+            {"externalConnectionString":"postgresql://test_parameter_overrides_agfj_user:mYvK8WNGV6hawuc6xHqeq4Rzlo9e8Tfv@dpg-d7sgiegsfn5c73fgpfl0-a.oregon-postgres.render.com:5432/test_parameter_overrides_agfj","internalConnectionString":"postgresql://test_parameter_overrides_agfj_user:mYvK8WNGV6hawuc6xHqeq4Rzlo9e8Tfv@dpg-d7sgiegsfn5c73fgpfl0-a/test_parameter_overrides_agfj","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-d7sgiegsfn5c73fgpfl0-a.oregon-postgres.render.com -p 5432 -U test_parameter_overrides_agfj_user test_parameter_overrides_agfj"}
         headers:
-            Content-Length:
-                - "52"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 20 Nov 2025 05:26:44 GMT
+                - Mon, 04 May 2026 21:02:40 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "381"
+                - "385"
             Ratelimit-Reset:
-                - "15"
+                - "19"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-6c86dcdf64-2v2rx/ttyxxPz4tl-000223
+                - api-67697cb9cc-nzjtj/tk2FBh0tKJ-366747
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=112
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1220,9 +1243,9 @@ interactions:
                 - DENY
             X-Xss-Protection:
                 - 1; mode=block
-        status: 404 Not Found
-        code: 404
-        duration: 31.297385ms
+        status: 200 OK
+        code: 200
+        duration: 201.714ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1241,7 +1264,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-d4facqrvbnoc73eic1vg-a
+        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-d7sgiegsfn5c73fgpfl0-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1249,27 +1272,28 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 769
-        uncompressed: false
+        content_length: -1
+        uncompressed: true
         body: |
-            {"createdAt":"2025-11-20T05:26:03.107234Z","dashboardUrl":"http://dashboard.render.localhost:3000/d/dpg-d4facqrvbnoc73eic1vg-a","databaseName":"test_parameter_overrides_fb85","databaseUser":"test_parameter_overrides_fb85_user","diskAutoscalingEnabled":false,"diskSizeGB":100,"highAvailabilityEnabled":false,"id":"dpg-d4facqrvbnoc73eic1vg-a","ipAllowList":null,"name":"test-parameter-overrides","owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"parameterOverrides":{"max_connections":"150","shared_buffers":"128MB"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"available","suspended":"not_suspended","suspenders":[],"updatedAt":"2025-11-20T05:26:43.67168Z","version":"16"}
+            {"message":"not found: dpg-d7sgiegsfn5c73fgpfl0-a"}
         headers:
-            Content-Length:
-                - "769"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 20 Nov 2025 05:26:44 GMT
+                - Mon, 04 May 2026 21:02:40 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "380"
+                - "384"
             Ratelimit-Reset:
-                - "15"
+                - "19"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-6c86dcdf64-2v2rx/ttyxxPz4tl-000224
+                - api-67697cb9cc-2x52t/rJPzHDiqR2-244259
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=10,cfOrigin;dur=133
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1278,9 +1302,9 @@ interactions:
                 - DENY
             X-Xss-Protection:
                 - 1; mode=block
-        status: 200 OK
-        code: 200
-        duration: 50.132082ms
+        status: 404 Not Found
+        code: 404
+        duration: 170.287042ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1299,7 +1323,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-d4facqrvbnoc73eic1vg-a/connection-info
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sgiegsfn5c73fgpfl0-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1307,27 +1331,28 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 632
-        uncompressed: false
+        content_length: -1
+        uncompressed: true
         body: |
-            {"externalConnectionString":"postgresql://test_parameter_overrides_fb85_user:ORlThK7u7i7iYJZFl4OcfgEmxVTycts1@dpg-d4facqrvbnoc73eic1vg-a.oregon-postgres.localhost.render.com:5434/test_parameter_overrides_fb85","internalConnectionString":"postgresql://test_parameter_overrides_fb85_user:ORlThK7u7i7iYJZFl4OcfgEmxVTycts1@dpg-d4facqrvbnoc73eic1vg-a/test_parameter_overrides_fb85","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-d4facqrvbnoc73eic1vg-a.oregon-postgres.localhost.render.com -p 5434 -U test_parameter_overrides_fb85_user test_parameter_overrides_fb85"}
+            {"createdAt":"2026-05-04T21:01:46.486849Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sgiegsfn5c73fgpfl0-a","databaseName":"test_parameter_overrides_agfj","databaseUser":"test_parameter_overrides_agfj_user","diskAutoscalingEnabled":false,"diskSizeGB":100,"highAvailabilityEnabled":false,"id":"dpg-d7sgiegsfn5c73fgpfl0-a","ipAllowList":null,"name":"test-parameter-overrides","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"parameterOverrides":{"max_connections":"150","shared_buffers":"128MB"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"available","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T21:02:39.486316Z","version":"16"}
         headers:
-            Content-Length:
-                - "632"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 20 Nov 2025 05:26:44 GMT
+                - Mon, 04 May 2026 21:02:40 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "379"
+                - "383"
             Ratelimit-Reset:
-                - "15"
+                - "19"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-6c86dcdf64-2v2rx/ttyxxPz4tl-000225
+                - api-67697cb9cc-dxjk6/4C2QjVr1j7-407541
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=9,cfOrigin;dur=103
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1338,7 +1363,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 43.287957ms
+        duration: 135.039417ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1357,7 +1382,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-d4facqrvbnoc73eic1vg-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sgiegsfn5c73fgpfl0-a/connection-info
         method: GET
       response:
         proto: HTTP/2.0
@@ -1365,27 +1390,87 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 52
-        uncompressed: false
+        content_length: -1
+        uncompressed: true
         body: |
-            {"message":"not found: dpg-d4facqrvbnoc73eic1vg-a"}
+            {"externalConnectionString":"postgresql://test_parameter_overrides_agfj_user:mYvK8WNGV6hawuc6xHqeq4Rzlo9e8Tfv@dpg-d7sgiegsfn5c73fgpfl0-a.oregon-postgres.render.com:5432/test_parameter_overrides_agfj","internalConnectionString":"postgresql://test_parameter_overrides_agfj_user:mYvK8WNGV6hawuc6xHqeq4Rzlo9e8Tfv@dpg-d7sgiegsfn5c73fgpfl0-a/test_parameter_overrides_agfj","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-d7sgiegsfn5c73fgpfl0-a.oregon-postgres.render.com -p 5432 -U test_parameter_overrides_agfj_user test_parameter_overrides_agfj"}
         headers:
-            Content-Length:
-                - "52"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 20 Nov 2025 05:26:44 GMT
+                - Mon, 04 May 2026 21:02:40 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "378"
+                - "382"
             Ratelimit-Reset:
-                - "15"
+                - "19"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-6c86dcdf64-2v2rx/ttyxxPz4tl-000226
+                - api-67697cb9cc-nzjtj/tk2FBh0tKJ-366785
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=107
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 152.479542ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-d7sgiegsfn5c73fgpfl0-a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"message":"not found: dpg-d7sgiegsfn5c73fgpfl0-a"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 21:02:41 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "381"
+            Ratelimit-Reset:
+                - "19"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-swx5g/Htral3X5Am-262845
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=7,cfOrigin;dur=134
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1396,8 +1481,8 @@ interactions:
                 - 1; mode=block
         status: 404 Not Found
         code: 404
-        duration: 27.678169ms
-    - id: 24
+        duration: 166.671792ms
+    - id: 25
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1417,7 +1502,7 @@ interactions:
                 - application/json
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-d4facqrvbnoc73eic1vg-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sgiegsfn5c73fgpfl0-a
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -1425,27 +1510,28 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 698
-        uncompressed: false
+        content_length: -1
+        uncompressed: true
         body: |
-            {"createdAt":"2025-11-20T05:26:03.107234Z","dashboardUrl":"http://dashboard.render.localhost:3000/d/dpg-d4facqrvbnoc73eic1vg-a","databaseName":"test_parameter_overrides_fb85","databaseUser":"test_parameter_overrides_fb85_user","diskAutoscalingEnabled":false,"diskSizeGB":100,"highAvailabilityEnabled":false,"id":"dpg-d4facqrvbnoc73eic1vg-a","ipAllowList":null,"name":"test-parameter-overrides","owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"available","suspended":"not_suspended","suspenders":[],"updatedAt":"2025-11-20T05:26:44.970844Z","version":"16"}
+            {"createdAt":"2026-05-04T21:01:46.486849Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sgiegsfn5c73fgpfl0-a","databaseName":"test_parameter_overrides_agfj","databaseUser":"test_parameter_overrides_agfj_user","diskAutoscalingEnabled":false,"diskSizeGB":100,"highAvailabilityEnabled":false,"id":"dpg-d7sgiegsfn5c73fgpfl0-a","ipAllowList":null,"name":"test-parameter-overrides","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"available","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T21:02:41.296649Z","version":"16"}
         headers:
-            Content-Length:
-                - "698"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 20 Nov 2025 05:26:45 GMT
+                - Mon, 04 May 2026 21:02:41 GMT
             Ratelimit-Limit:
                 - "100"
             Ratelimit-Remaining:
                 - "98"
             Ratelimit-Reset:
-                - "15"
+                - "18"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-6c86dcdf64-2v2rx/ttyxxPz4tl-000227
+                - api-67697cb9cc-hr98q/EEsGBcgj5Z-172516
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=16,cfOrigin;dur=244
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1456,65 +1542,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 272.530057ms
-    - id: 25
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: https://api.testing.render.com/v1
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Authorization:
-                - some-api-key
-            User-Agent:
-                - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-d4facqrvbnoc73eic1vg-a/connection-info
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 632
-        uncompressed: false
-        body: |
-            {"externalConnectionString":"postgresql://test_parameter_overrides_fb85_user:ORlThK7u7i7iYJZFl4OcfgEmxVTycts1@dpg-d4facqrvbnoc73eic1vg-a.oregon-postgres.localhost.render.com:5434/test_parameter_overrides_fb85","internalConnectionString":"postgresql://test_parameter_overrides_fb85_user:ORlThK7u7i7iYJZFl4OcfgEmxVTycts1@dpg-d4facqrvbnoc73eic1vg-a/test_parameter_overrides_fb85","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-d4facqrvbnoc73eic1vg-a.oregon-postgres.localhost.render.com -p 5434 -U test_parameter_overrides_fb85_user test_parameter_overrides_fb85"}
-        headers:
-            Content-Length:
-                - "632"
-            Content-Type:
-                - application/json; charset=utf-8
-            Date:
-                - Thu, 20 Nov 2025 05:26:45 GMT
-            Ratelimit-Limit:
-                - "400"
-            Ratelimit-Remaining:
-                - "377"
-            Ratelimit-Reset:
-                - "14"
-            Referrer-Policy:
-                - same-origin
-            Render-Request-Id:
-                - api-6c86dcdf64-2v2rx/ttyxxPz4tl-000228
-            Vary:
-                - Origin
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Xss-Protection:
-                - 1; mode=block
-        status: 200 OK
-        code: 200
-        duration: 55.526632ms
+        duration: 278.801042ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1533,7 +1561,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-d4facqrvbnoc73eic1vg-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sgiegsfn5c73fgpfl0-a/connection-info
         method: GET
       response:
         proto: HTTP/2.0
@@ -1541,27 +1569,28 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 698
-        uncompressed: false
+        content_length: -1
+        uncompressed: true
         body: |
-            {"createdAt":"2025-11-20T05:26:03.107234Z","dashboardUrl":"http://dashboard.render.localhost:3000/d/dpg-d4facqrvbnoc73eic1vg-a","databaseName":"test_parameter_overrides_fb85","databaseUser":"test_parameter_overrides_fb85_user","diskAutoscalingEnabled":false,"diskSizeGB":100,"highAvailabilityEnabled":false,"id":"dpg-d4facqrvbnoc73eic1vg-a","ipAllowList":null,"name":"test-parameter-overrides","owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"available","suspended":"not_suspended","suspenders":[],"updatedAt":"2025-11-20T05:26:44.970844Z","version":"16"}
+            {"externalConnectionString":"postgresql://test_parameter_overrides_agfj_user:mYvK8WNGV6hawuc6xHqeq4Rzlo9e8Tfv@dpg-d7sgiegsfn5c73fgpfl0-a.oregon-postgres.render.com:5432/test_parameter_overrides_agfj","internalConnectionString":"postgresql://test_parameter_overrides_agfj_user:mYvK8WNGV6hawuc6xHqeq4Rzlo9e8Tfv@dpg-d7sgiegsfn5c73fgpfl0-a/test_parameter_overrides_agfj","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-d7sgiegsfn5c73fgpfl0-a.oregon-postgres.render.com -p 5432 -U test_parameter_overrides_agfj_user test_parameter_overrides_agfj"}
         headers:
-            Content-Length:
-                - "698"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 20 Nov 2025 05:26:45 GMT
+                - Mon, 04 May 2026 21:02:41 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "376"
+                - "380"
             Ratelimit-Reset:
-                - "14"
+                - "18"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-6c86dcdf64-2v2rx/ttyxxPz4tl-000229
+                - api-67697cb9cc-dxjk6/4C2QjVr1j7-407600
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=107
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1572,7 +1601,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 43.12291ms
+        duration: 137.851042ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1591,7 +1620,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-d4facqrvbnoc73eic1vg-a/connection-info
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sgiegsfn5c73fgpfl0-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1599,27 +1628,28 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 632
-        uncompressed: false
+        content_length: -1
+        uncompressed: true
         body: |
-            {"externalConnectionString":"postgresql://test_parameter_overrides_fb85_user:ORlThK7u7i7iYJZFl4OcfgEmxVTycts1@dpg-d4facqrvbnoc73eic1vg-a.oregon-postgres.localhost.render.com:5434/test_parameter_overrides_fb85","internalConnectionString":"postgresql://test_parameter_overrides_fb85_user:ORlThK7u7i7iYJZFl4OcfgEmxVTycts1@dpg-d4facqrvbnoc73eic1vg-a/test_parameter_overrides_fb85","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-d4facqrvbnoc73eic1vg-a.oregon-postgres.localhost.render.com -p 5434 -U test_parameter_overrides_fb85_user test_parameter_overrides_fb85"}
+            {"createdAt":"2026-05-04T21:01:46.486849Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sgiegsfn5c73fgpfl0-a","databaseName":"test_parameter_overrides_agfj","databaseUser":"test_parameter_overrides_agfj_user","diskAutoscalingEnabled":false,"diskSizeGB":100,"highAvailabilityEnabled":false,"id":"dpg-d7sgiegsfn5c73fgpfl0-a","ipAllowList":null,"name":"test-parameter-overrides","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"available","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T21:02:41.296649Z","version":"16"}
         headers:
-            Content-Length:
-                - "632"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 20 Nov 2025 05:26:45 GMT
+                - Mon, 04 May 2026 21:02:41 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "375"
+                - "379"
             Ratelimit-Reset:
-                - "14"
+                - "18"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-6c86dcdf64-2v2rx/ttyxxPz4tl-000230
+                - api-67697cb9cc-7g8wf/qqOGxLHk0I-413866
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=100
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1630,7 +1660,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 47.537897ms
+        duration: 133.958834ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1649,7 +1679,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-d4facqrvbnoc73eic1vg-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sgiegsfn5c73fgpfl0-a/connection-info
         method: GET
       response:
         proto: HTTP/2.0
@@ -1657,27 +1687,28 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 52
-        uncompressed: false
+        content_length: -1
+        uncompressed: true
         body: |
-            {"message":"not found: dpg-d4facqrvbnoc73eic1vg-a"}
+            {"externalConnectionString":"postgresql://test_parameter_overrides_agfj_user:mYvK8WNGV6hawuc6xHqeq4Rzlo9e8Tfv@dpg-d7sgiegsfn5c73fgpfl0-a.oregon-postgres.render.com:5432/test_parameter_overrides_agfj","internalConnectionString":"postgresql://test_parameter_overrides_agfj_user:mYvK8WNGV6hawuc6xHqeq4Rzlo9e8Tfv@dpg-d7sgiegsfn5c73fgpfl0-a/test_parameter_overrides_agfj","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-d7sgiegsfn5c73fgpfl0-a.oregon-postgres.render.com -p 5432 -U test_parameter_overrides_agfj_user test_parameter_overrides_agfj"}
         headers:
-            Content-Length:
-                - "52"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 20 Nov 2025 05:26:45 GMT
+                - Mon, 04 May 2026 21:02:42 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "374"
+                - "378"
             Ratelimit-Reset:
-                - "14"
+                - "18"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-6c86dcdf64-2v2rx/ttyxxPz4tl-000231
+                - api-67697cb9cc-hr98q/EEsGBcgj5Z-172548
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=6,cfOrigin;dur=106
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1686,9 +1717,9 @@ interactions:
                 - DENY
             X-Xss-Protection:
                 - 1; mode=block
-        status: 404 Not Found
-        code: 404
-        duration: 29.737195ms
+        status: 200 OK
+        code: 200
+        duration: 126.881542ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1707,7 +1738,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-d4facqrvbnoc73eic1vg-a
+        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-d7sgiegsfn5c73fgpfl0-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1715,27 +1746,28 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 698
-        uncompressed: false
+        content_length: -1
+        uncompressed: true
         body: |
-            {"createdAt":"2025-11-20T05:26:03.107234Z","dashboardUrl":"http://dashboard.render.localhost:3000/d/dpg-d4facqrvbnoc73eic1vg-a","databaseName":"test_parameter_overrides_fb85","databaseUser":"test_parameter_overrides_fb85_user","diskAutoscalingEnabled":false,"diskSizeGB":100,"highAvailabilityEnabled":false,"id":"dpg-d4facqrvbnoc73eic1vg-a","ipAllowList":null,"name":"test-parameter-overrides","owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"available","suspended":"not_suspended","suspenders":[],"updatedAt":"2025-11-20T05:26:44.970844Z","version":"16"}
+            {"message":"not found: dpg-d7sgiegsfn5c73fgpfl0-a"}
         headers:
-            Content-Length:
-                - "698"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 20 Nov 2025 05:26:45 GMT
+                - Mon, 04 May 2026 21:02:42 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "373"
+                - "377"
             Ratelimit-Reset:
-                - "14"
+                - "17"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-6c86dcdf64-2v2rx/ttyxxPz4tl-000232
+                - api-67697cb9cc-8r4lj/bvH9OfgVXm-401131
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=7,cfOrigin;dur=159
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1744,9 +1776,9 @@ interactions:
                 - DENY
             X-Xss-Protection:
                 - 1; mode=block
-        status: 200 OK
-        code: 200
-        duration: 43.981053ms
+        status: 404 Not Found
+        code: 404
+        duration: 182.098958ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1765,7 +1797,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-d4facqrvbnoc73eic1vg-a/connection-info
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sgiegsfn5c73fgpfl0-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1773,27 +1805,28 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 632
-        uncompressed: false
+        content_length: -1
+        uncompressed: true
         body: |
-            {"externalConnectionString":"postgresql://test_parameter_overrides_fb85_user:ORlThK7u7i7iYJZFl4OcfgEmxVTycts1@dpg-d4facqrvbnoc73eic1vg-a.oregon-postgres.localhost.render.com:5434/test_parameter_overrides_fb85","internalConnectionString":"postgresql://test_parameter_overrides_fb85_user:ORlThK7u7i7iYJZFl4OcfgEmxVTycts1@dpg-d4facqrvbnoc73eic1vg-a/test_parameter_overrides_fb85","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-d4facqrvbnoc73eic1vg-a.oregon-postgres.localhost.render.com -p 5434 -U test_parameter_overrides_fb85_user test_parameter_overrides_fb85"}
+            {"createdAt":"2026-05-04T21:01:46.486849Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sgiegsfn5c73fgpfl0-a","databaseName":"test_parameter_overrides_agfj","databaseUser":"test_parameter_overrides_agfj_user","diskAutoscalingEnabled":false,"diskSizeGB":100,"highAvailabilityEnabled":false,"id":"dpg-d7sgiegsfn5c73fgpfl0-a","ipAllowList":null,"name":"test-parameter-overrides","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"plan":"pro_4gb","readReplicas":[],"region":"oregon","role":"primary","status":"available","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T21:02:41.296649Z","version":"16"}
         headers:
-            Content-Length:
-                - "632"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 20 Nov 2025 05:26:46 GMT
+                - Mon, 04 May 2026 21:02:42 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "372"
+                - "376"
             Ratelimit-Reset:
-                - "13"
+                - "17"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-6c86dcdf64-2v2rx/ttyxxPz4tl-000233
+                - api-67697cb9cc-nzjtj/tk2FBh0tKJ-366884
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=8,cfOrigin;dur=103
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1804,7 +1837,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 46.507478ms
+        duration: 191.993125ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1823,7 +1856,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-d4facqrvbnoc73eic1vg-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sgiegsfn5c73fgpfl0-a/connection-info
         method: GET
       response:
         proto: HTTP/2.0
@@ -1831,27 +1864,87 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 52
-        uncompressed: false
+        content_length: -1
+        uncompressed: true
         body: |
-            {"message":"not found: dpg-d4facqrvbnoc73eic1vg-a"}
+            {"externalConnectionString":"postgresql://test_parameter_overrides_agfj_user:mYvK8WNGV6hawuc6xHqeq4Rzlo9e8Tfv@dpg-d7sgiegsfn5c73fgpfl0-a.oregon-postgres.render.com:5432/test_parameter_overrides_agfj","internalConnectionString":"postgresql://test_parameter_overrides_agfj_user:mYvK8WNGV6hawuc6xHqeq4Rzlo9e8Tfv@dpg-d7sgiegsfn5c73fgpfl0-a/test_parameter_overrides_agfj","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-d7sgiegsfn5c73fgpfl0-a.oregon-postgres.render.com -p 5432 -U test_parameter_overrides_agfj_user test_parameter_overrides_agfj"}
         headers:
-            Content-Length:
-                - "52"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 20 Nov 2025 05:26:46 GMT
+                - Mon, 04 May 2026 21:02:42 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "371"
+                - "375"
             Ratelimit-Reset:
-                - "13"
+                - "17"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-6c86dcdf64-2v2rx/ttyxxPz4tl-000234
+                - api-67697cb9cc-7hdlp/bSeT1VJf0a-291701
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=9,cfOrigin;dur=109
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 137.709125ms
+    - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-d7sgiegsfn5c73fgpfl0-a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"message":"not found: dpg-d7sgiegsfn5c73fgpfl0-a"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 21:02:42 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "374"
+            Ratelimit-Reset:
+                - "17"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-rr9lz/iQKxXhmUkr-235413
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=7,cfOrigin;dur=122
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1862,8 +1955,8 @@ interactions:
                 - 1; mode=block
         status: 404 Not Found
         code: 404
-        duration: 27.882337ms
-    - id: 32
+        duration: 230.844417ms
+    - id: 33
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1883,7 +1976,7 @@ interactions:
                 - application/json
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-d4facqrvbnoc73eic1vg-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sgiegsfn5c73fgpfl0-a
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -1891,27 +1984,28 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 853
-        uncompressed: false
+        content_length: -1
+        uncompressed: true
         body: |
-            {"createdAt":"2025-11-20T05:26:03.107234Z","dashboardUrl":"http://dashboard.render.localhost:3000/d/dpg-d4facqrvbnoc73eic1vg-a","databaseName":"test_parameter_overrides_fb85","databaseUser":"test_parameter_overrides_fb85_user","diskAutoscalingEnabled":false,"diskSizeGB":100,"highAvailabilityEnabled":false,"id":"dpg-d4facqrvbnoc73eic1vg-a","ipAllowList":null,"name":"test-parameter-overrides","owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"parameterOverrides":{"max_connections":"100"},"plan":"pro_4gb","readReplicas":[{"id":"dpg-d4facqrvbnoc73eic1vg-b","name":"read-replica","parameterOverrides":{"statement_timeout":"30000"}}],"region":"oregon","role":"primary","status":"available","suspended":"not_suspended","suspenders":[],"updatedAt":"2025-11-20T05:26:46.405827Z","version":"16"}
+            {"createdAt":"2026-05-04T21:01:46.486849Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sgiegsfn5c73fgpfl0-a","databaseName":"test_parameter_overrides_agfj","databaseUser":"test_parameter_overrides_agfj_user","diskAutoscalingEnabled":false,"diskSizeGB":100,"highAvailabilityEnabled":false,"id":"dpg-d7sgiegsfn5c73fgpfl0-a","ipAllowList":null,"name":"test-parameter-overrides","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"parameterOverrides":{"max_connections":"100"},"plan":"pro_4gb","readReplicas":[{"id":"dpg-d7sgiegsfn5c73fgpfl0-b","name":"read-replica","parameterOverrides":{"statement_timeout":"30000"}}],"region":"oregon","role":"primary","status":"available","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T21:02:43.210896Z","version":"16"}
         headers:
-            Content-Length:
-                - "853"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 20 Nov 2025 05:26:46 GMT
+                - Mon, 04 May 2026 21:02:43 GMT
             Ratelimit-Limit:
                 - "100"
             Ratelimit-Remaining:
                 - "97"
             Ratelimit-Reset:
-                - "13"
+                - "16"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-6c86dcdf64-2v2rx/ttyxxPz4tl-000235
+                - api-67697cb9cc-8r4lj/bvH9OfgVXm-401188
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=5,cfOrigin;dur=496
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1922,65 +2016,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 332.637458ms
-    - id: 33
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: https://api.testing.render.com/v1
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Authorization:
-                - some-api-key
-            User-Agent:
-                - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-d4facqrvbnoc73eic1vg-a/connection-info
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 632
-        uncompressed: false
-        body: |
-            {"externalConnectionString":"postgresql://test_parameter_overrides_fb85_user:ORlThK7u7i7iYJZFl4OcfgEmxVTycts1@dpg-d4facqrvbnoc73eic1vg-a.oregon-postgres.localhost.render.com:5434/test_parameter_overrides_fb85","internalConnectionString":"postgresql://test_parameter_overrides_fb85_user:ORlThK7u7i7iYJZFl4OcfgEmxVTycts1@dpg-d4facqrvbnoc73eic1vg-a/test_parameter_overrides_fb85","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-d4facqrvbnoc73eic1vg-a.oregon-postgres.localhost.render.com -p 5434 -U test_parameter_overrides_fb85_user test_parameter_overrides_fb85"}
-        headers:
-            Content-Length:
-                - "632"
-            Content-Type:
-                - application/json; charset=utf-8
-            Date:
-                - Thu, 20 Nov 2025 05:26:46 GMT
-            Ratelimit-Limit:
-                - "400"
-            Ratelimit-Remaining:
-                - "370"
-            Ratelimit-Reset:
-                - "13"
-            Referrer-Policy:
-                - same-origin
-            Render-Request-Id:
-                - api-6c86dcdf64-2v2rx/ttyxxPz4tl-000236
-            Vary:
-                - Origin
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Xss-Protection:
-                - 1; mode=block
-        status: 200 OK
-        code: 200
-        duration: 43.142642ms
+        duration: 520.111959ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1999,7 +2035,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-d4facqrvbnoc73eic1vg-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sgiegsfn5c73fgpfl0-a/connection-info
         method: GET
       response:
         proto: HTTP/2.0
@@ -2007,27 +2043,28 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 853
-        uncompressed: false
+        content_length: -1
+        uncompressed: true
         body: |
-            {"createdAt":"2025-11-20T05:26:03.107234Z","dashboardUrl":"http://dashboard.render.localhost:3000/d/dpg-d4facqrvbnoc73eic1vg-a","databaseName":"test_parameter_overrides_fb85","databaseUser":"test_parameter_overrides_fb85_user","diskAutoscalingEnabled":false,"diskSizeGB":100,"highAvailabilityEnabled":false,"id":"dpg-d4facqrvbnoc73eic1vg-a","ipAllowList":null,"name":"test-parameter-overrides","owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"parameterOverrides":{"max_connections":"100"},"plan":"pro_4gb","readReplicas":[{"id":"dpg-d4facqrvbnoc73eic1vg-b","name":"read-replica","parameterOverrides":{"statement_timeout":"30000"}}],"region":"oregon","role":"primary","status":"available","suspended":"not_suspended","suspenders":[],"updatedAt":"2025-11-20T05:26:46.405827Z","version":"16"}
+            {"externalConnectionString":"postgresql://test_parameter_overrides_agfj_user:mYvK8WNGV6hawuc6xHqeq4Rzlo9e8Tfv@dpg-d7sgiegsfn5c73fgpfl0-a.oregon-postgres.render.com:5432/test_parameter_overrides_agfj","internalConnectionString":"postgresql://test_parameter_overrides_agfj_user:mYvK8WNGV6hawuc6xHqeq4Rzlo9e8Tfv@dpg-d7sgiegsfn5c73fgpfl0-a/test_parameter_overrides_agfj","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-d7sgiegsfn5c73fgpfl0-a.oregon-postgres.render.com -p 5432 -U test_parameter_overrides_agfj_user test_parameter_overrides_agfj"}
         headers:
-            Content-Length:
-                - "853"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 20 Nov 2025 05:26:46 GMT
+                - Mon, 04 May 2026 21:02:43 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "369"
+                - "373"
             Ratelimit-Reset:
-                - "13"
+                - "16"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-6c86dcdf64-2v2rx/ttyxxPz4tl-000237
+                - api-67697cb9cc-swx5g/Htral3X5Am-262976
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=9,cfOrigin;dur=122
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2038,7 +2075,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 48.171927ms
+        duration: 155.917375ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -2057,7 +2094,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-d4facqrvbnoc73eic1vg-a/connection-info
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sgiegsfn5c73fgpfl0-a
         method: GET
       response:
         proto: HTTP/2.0
@@ -2065,27 +2102,28 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 632
-        uncompressed: false
+        content_length: -1
+        uncompressed: true
         body: |
-            {"externalConnectionString":"postgresql://test_parameter_overrides_fb85_user:ORlThK7u7i7iYJZFl4OcfgEmxVTycts1@dpg-d4facqrvbnoc73eic1vg-a.oregon-postgres.localhost.render.com:5434/test_parameter_overrides_fb85","internalConnectionString":"postgresql://test_parameter_overrides_fb85_user:ORlThK7u7i7iYJZFl4OcfgEmxVTycts1@dpg-d4facqrvbnoc73eic1vg-a/test_parameter_overrides_fb85","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-d4facqrvbnoc73eic1vg-a.oregon-postgres.localhost.render.com -p 5434 -U test_parameter_overrides_fb85_user test_parameter_overrides_fb85"}
+            {"createdAt":"2026-05-04T21:01:46.486849Z","dashboardUrl":"https://dashboard.render.com/d/dpg-d7sgiegsfn5c73fgpfl0-a","databaseName":"test_parameter_overrides_agfj","databaseUser":"test_parameter_overrides_agfj_user","diskAutoscalingEnabled":false,"diskSizeGB":100,"highAvailabilityEnabled":false,"id":"dpg-d7sgiegsfn5c73fgpfl0-a","ipAllowList":null,"name":"test-parameter-overrides","owner":{"email":"email@example.com","id":"some-owner-id","name":"Tucker's Terraform Cassette Test","type":"team"},"parameterOverrides":{"max_connections":"100"},"plan":"pro_4gb","readReplicas":[{"id":"dpg-d7sgiegsfn5c73fgpfl0-b","name":"read-replica","parameterOverrides":{"statement_timeout":"30000"}}],"region":"oregon","role":"primary","status":"available","suspended":"not_suspended","suspenders":[],"updatedAt":"2026-05-04T21:02:43.210896Z","version":"16"}
         headers:
-            Content-Length:
-                - "632"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 20 Nov 2025 05:26:47 GMT
+                - Mon, 04 May 2026 21:02:44 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "368"
+                - "372"
             Ratelimit-Reset:
-                - "12"
+                - "15"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-6c86dcdf64-2v2rx/ttyxxPz4tl-000238
+                - api-67697cb9cc-nzjtj/tk2FBh0tKJ-366982
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=8,cfOrigin;dur=99
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2096,7 +2134,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 43.679974ms
+        duration: 243.34375ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -2115,7 +2153,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-d4facqrvbnoc73eic1vg-a
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sgiegsfn5c73fgpfl0-a/connection-info
         method: GET
       response:
         proto: HTTP/2.0
@@ -2123,27 +2161,28 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 52
-        uncompressed: false
+        content_length: -1
+        uncompressed: true
         body: |
-            {"message":"not found: dpg-d4facqrvbnoc73eic1vg-a"}
+            {"externalConnectionString":"postgresql://test_parameter_overrides_agfj_user:mYvK8WNGV6hawuc6xHqeq4Rzlo9e8Tfv@dpg-d7sgiegsfn5c73fgpfl0-a.oregon-postgres.render.com:5432/test_parameter_overrides_agfj","internalConnectionString":"postgresql://test_parameter_overrides_agfj_user:mYvK8WNGV6hawuc6xHqeq4Rzlo9e8Tfv@dpg-d7sgiegsfn5c73fgpfl0-a/test_parameter_overrides_agfj","password":"thirtytwocharacterpasswooooooord","psqlCommand":"PGPASSWORD=thirtytwocharacterpasswooooooord psql -h dpg-d7sgiegsfn5c73fgpfl0-a.oregon-postgres.render.com -p 5432 -U test_parameter_overrides_agfj_user test_parameter_overrides_agfj"}
         headers:
-            Content-Length:
-                - "52"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 20 Nov 2025 05:26:47 GMT
+                - Mon, 04 May 2026 21:02:44 GMT
             Ratelimit-Limit:
                 - "400"
             Ratelimit-Remaining:
-                - "367"
+                - "371"
             Ratelimit-Reset:
-                - "12"
+                - "15"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-6c86dcdf64-2v2rx/ttyxxPz4tl-000239
+                - api-67697cb9cc-2x52t/rJPzHDiqR2-244413
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=7,cfOrigin;dur=103
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2152,9 +2191,9 @@ interactions:
                 - DENY
             X-Xss-Protection:
                 - 1; mode=block
-        status: 404 Not Found
-        code: 404
-        duration: 26.388909ms
+        status: 200 OK
+        code: 200
+        duration: 125.803333ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -2173,7 +2212,125 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/postgres/dpg-d4facqrvbnoc73eic1vg-a
+        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-d7sgiegsfn5c73fgpfl0-a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"message":"not found: dpg-d7sgiegsfn5c73fgpfl0-a"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 21:02:44 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "370"
+            Ratelimit-Reset:
+                - "15"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-dxjk6/4C2QjVr1j7-407772
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=9,cfOrigin;dur=140
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 220.397333ms
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/dpg-d7sgiegsfn5c73fgpfl0-b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {"message":"not found: dpg-d7sgiegsfn5c73fgpfl0-b"}
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 04 May 2026 21:02:44 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "369"
+            Ratelimit-Reset:
+                - "15"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-67697cb9cc-nzjtj/tk2FBh0tKJ-367022
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=7,cfOrigin;dur=134
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 173.550916ms
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/postgres/dpg-d7sgiegsfn5c73fgpfl0-a
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2186,17 +2343,20 @@ interactions:
         body: ""
         headers:
             Date:
-                - Thu, 20 Nov 2025 05:26:47 GMT
+                - Mon, 04 May 2026 21:02:45 GMT
             Ratelimit-Limit:
                 - "100"
             Ratelimit-Remaining:
                 - "96"
             Ratelimit-Reset:
-                - "12"
+                - "15"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-6c86dcdf64-2v2rx/ttyxxPz4tl-000240
+                - api-67697cb9cc-swx5g/Htral3X5Am-263031
+            Server-Timing:
+                - cfCacheStatus;desc="DYNAMIC"
+                - cfEdge;dur=8,cfOrigin;dur=466
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2207,4 +2367,4 @@ interactions:
                 - 1; mode=block
         status: 204 No Content
         code: 204
-        duration: 91.358589ms
+        duration: 494.865ms

--- a/internal/provider/types/datasource/logstreamoverride.go
+++ b/internal/provider/types/datasource/logstreamoverride.go
@@ -34,9 +34,6 @@ var LogStreamOverride = schema.SingleNestedAttribute{
 	Description: "Configure the [log stream override settings](https://render.com/docs/log-streams#overriding-defaults) for this service. These will override the global log stream settings of the user or team.",
 }
 
-// ReplicaLogStreamOverride is the read-only variant used inside the datasource
-// read_replicas SetNestedAttribute. All sub-attributes are Computed only since
-// users can't write attributes on a datasource.
 var ReplicaLogStreamOverride = schema.SingleNestedAttribute{
 	Attributes: map[string]schema.Attribute{
 		"setting": schema.StringAttribute{

--- a/internal/provider/types/datasource/logstreamoverride.go
+++ b/internal/provider/types/datasource/logstreamoverride.go
@@ -33,3 +33,29 @@ var LogStreamOverride = schema.SingleNestedAttribute{
 	Computed:    true,
 	Description: "Configure the [log stream override settings](https://render.com/docs/log-streams#overriding-defaults) for this service. These will override the global log stream settings of the user or team.",
 }
+
+// ReplicaLogStreamOverride is the read-only variant used inside the datasource
+// read_replicas SetNestedAttribute. All sub-attributes are Computed only since
+// users can't write attributes on a datasource.
+var ReplicaLogStreamOverride = schema.SingleNestedAttribute{
+	Attributes: map[string]schema.Attribute{
+		"setting": schema.StringAttribute{
+			Computed:            true,
+			Description:         "Whether to send or drop logs for this replica.",
+			MarkdownDescription: "Whether to send or drop logs for this replica.",
+		},
+		"endpoint": schema.StringAttribute{
+			Computed:            true,
+			Description:         "The endpoint logs are sent to.",
+			MarkdownDescription: "The endpoint logs are sent to.",
+		},
+		"token": schema.StringAttribute{
+			Computed:            true,
+			Sensitive:           true,
+			Description:         "The token used when sending logs.",
+			MarkdownDescription: "The token used when sending logs.",
+		},
+	},
+	Computed:    true,
+	Description: "The [log stream override settings](https://render.com/docs/log-streams#overriding-defaults) for this replica.",
+}

--- a/internal/provider/types/resource/logstreamoverride.go
+++ b/internal/provider/types/resource/logstreamoverride.go
@@ -33,3 +33,35 @@ var LogStreamOverride = schema.SingleNestedAttribute{
 	Computed:    true,
 	Description: "Configure the [log stream override settings](https://render.com/docs/log-streams#overriding-defaults) for this service. These will override the global log stream settings of the user or team.",
 }
+
+// ReplicaLogStreamOverride is the variant used inside a SetNestedAttribute (e.g.
+// render_postgres.read_replicas[*].log_stream_override). Compared to
+// LogStreamOverride, the outer object and the `endpoint` sub-attribute drop
+// `Computed` so plan-time values are always known. This avoids set-element
+// identity instability when `endpoint` would otherwise transition unknown→""
+// during apply, which the framework can't reconcile inside a Set.
+var ReplicaLogStreamOverride = schema.SingleNestedAttribute{
+	Attributes: map[string]schema.Attribute{
+		"setting": schema.StringAttribute{
+			Required:            true,
+			Description:         "Whether to send or drop logs for this replica. Must be one of `send` or `drop`.",
+			MarkdownDescription: "Whether to send or drop logs for this replica. Must be one of `send` or `drop`.",
+			Validators: []validator.String{
+				stringvalidator.OneOf("send", "drop"),
+			},
+		},
+		"endpoint": schema.StringAttribute{
+			Optional:            true,
+			Description:         "The endpoint to send logs to.",
+			MarkdownDescription: "The endpoint to send logs to.",
+		},
+		"token": schema.StringAttribute{
+			Optional:            true,
+			Sensitive:           true,
+			Description:         "The token to use when sending logs.",
+			MarkdownDescription: "The token to use when sending logs.",
+		},
+	},
+	Optional:    true,
+	Description: "Configure the [log stream override settings](https://render.com/docs/log-streams#overriding-defaults) for this replica. These take precedence over the workspace's default log stream and any setting on the primary.",
+}


### PR DESCRIPTION
Already supported elsewhere, but not exposed in our terraform provider yet. This adds support for log stream overrides on replicas.

The biggest change here is switching `read_replicas` from `Set` to `List`. It appears that a Set breaks at apply with "inconsistent values for sensitive attribute" when the Computed value transitions unknown→`""`. The alternatives to this seemed overly cumbersome: replica-specific schemas, making the override in a parallel list and trying to map. This change is still a noop and should only surface as a positional diff if a user reorders their replicas (why?).

Also random little docs fix.