### PR TITLE
Update GHA to fix CI tests

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -23,6 +23,10 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.26.0'
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
       - name: Run tests
         run: TF_ACC=1 go test ./...
 


### PR DESCRIPTION
Apparently tests have been failing (e.g. [runs/25346229300/job/74315681102](https://github.com/render-oss/terraform-provider-render/actions/runs/25346229300/job/74315681102)) since there was an update to the signing key for TF releases. This updates our install pattern so we shouldn't see that.