### PR TITLE
[KEYS-910] Add support for persistence mode to Key Value

### DIFF
--- a/docs/data-sources/keyvalue.md
+++ b/docs/data-sources/keyvalue.md
@@ -30,6 +30,7 @@ Provides information about a Render Key Value instance.
 - `ip_allow_list` (Attributes Set) List of IP addresses that are allowed to connect to the Redis instance. If no IP addresses are provided, only connections via the private network will be allowed. (see [below for nested schema](#nestedatt--ip_allow_list))
 - `max_memory_policy` (String) Policy for evicting keys when the maxmemory limit is reached
 - `name` (String) Name of the service
+- `persistence_mode` (String) The type of persistence to use for saving data
 - `plan` (String) Plan for the Key Value instance
 - `region` (String) Region to deploy the service
 

--- a/docs/data-sources/redis.md
+++ b/docs/data-sources/redis.md
@@ -30,6 +30,7 @@ Provides information about a Render Redis instance.
 - `ip_allow_list` (Attributes Set) List of IP addresses that are allowed to connect to the Redis instance. If no IP addresses are provided, only connections via the private network will be allowed. (see [below for nested schema](#nestedatt--ip_allow_list))
 - `max_memory_policy` (String) Policy for evicting keys when the maxmemory limit is reached
 - `name` (String) Name of the service
+- `persistence_mode` (String) The type of persistence to use for saving data
 - `plan` (String) Plan for the Redis instance
 - `region` (String) Region to deploy the service
 

--- a/docs/resources/keyvalue.md
+++ b/docs/resources/keyvalue.md
@@ -26,6 +26,7 @@ Provides a Render Key Value resource.
 - `environment_id` (String) ID of the [project environment](https://render.com/docs/projects) that the resource belongs to
 - `ip_allow_list` (Attributes Set) List of IP addresses that are allowed to connect to the instance. If no IP addresses are provided, only connections via the private network will be allowed. (see [below for nested schema](#nestedatt--ip_allow_list))
 - `log_stream_override` (Attributes) Configure the [log stream override settings](https://render.com/docs/log-streams#overriding-defaults) for this service. These will override the global log stream settings of the user or team. (see [below for nested schema](#nestedatt--log_stream_override))
+- `persistence_mode` (String) The type of persistence to use for saving data. Value values are `journal_snapshot`, `snapshot`, `off`.
 - `plan` (String) Plan for the Key Value instance. Must be one of `free`, `starter`, `standard`, `pro`, `pro_plus`, or a custom plan.
 
 ### Read-Only

--- a/docs/resources/redis.md
+++ b/docs/resources/redis.md
@@ -18,6 +18,7 @@ resource "render_redis" "example" {
   region            = "ohio"
   plan              = "starter"
   max_memory_policy = "noeviction"
+  persistence_mode  = "journal_snapshot"
 
   ip_allow_list = [
     {
@@ -42,6 +43,7 @@ resource "render_redis" "example" {
 - `environment_id` (String) ID of the [project environment](https://render.com/docs/projects) that the resource belongs to
 - `ip_allow_list` (Attributes Set) List of IP addresses that are allowed to connect to the instance. If no IP addresses are provided, only connections via the private network will be allowed. (see [below for nested schema](#nestedatt--ip_allow_list))
 - `log_stream_override` (Attributes) Configure the [log stream override settings](https://render.com/docs/log-streams#overriding-defaults) for this service. These will override the global log stream settings of the user or team. (see [below for nested schema](#nestedatt--log_stream_override))
+- `persistence_mode` (String) The type of persistence to use for saving data. Value values are `journal_snapshot`, `snapshot`, `off`.
 - `plan` (String) Plan for the Redis instance. Must be one of `free`, `starter`, `standard`, `pro`, `pro_plus`, or a custom plan.
 
 ### Read-Only

--- a/examples/resources/render_redis/resource.tf
+++ b/examples/resources/render_redis/resource.tf
@@ -3,6 +3,7 @@ resource "render_redis" "example" {
   region            = "ohio"
   plan              = "starter"
   max_memory_policy = "noeviction"
+  persistence_mode  = "journal_snapshot"
 
   ip_allow_list = [
     {

--- a/internal/provider/keyvalue/datasource/datasource_test.go
+++ b/internal/provider/keyvalue/datasource/datasource_test.go
@@ -1,0 +1,67 @@
+package datasource_test
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	th "terraform-provider-render/internal/provider/testhelpers"
+)
+
+func TestAccKeyvalueDataSource(t *testing.T) {
+	resourceName := "data.render_keyvalue.test"
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: th.SetupRecordingProvider(t, "keyvalue_datasource_cassette"),
+		Steps: []resource.TestStep{
+			{
+				ConfigFile: config.StaticFile("./testdata/keyvalue.tf"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrWith(resourceName, "id", func(value string) error {
+						if !strings.HasPrefix(value, "red-") {
+							return fmt.Errorf("expected id to start with red-, got: %s", value)
+						}
+						return nil
+					}),
+					resource.TestCheckResourceAttr(resourceName, "name", "some-keyvalue"),
+					resource.TestCheckResourceAttr(resourceName, "plan", "starter"),
+					resource.TestCheckResourceAttr(resourceName, "region", "oregon"),
+					resource.TestCheckResourceAttr(resourceName, "max_memory_policy", "noeviction"),
+					resource.TestCheckResourceAttr(resourceName, "persistence_mode", "snapshot"),
+
+					resource.TestCheckResourceAttr(resourceName, "ip_allow_list.0.cidr_block", "1.1.1.1/32"),
+					resource.TestCheckResourceAttr(resourceName, "ip_allow_list.0.description", "one"),
+					resource.TestCheckResourceAttr(resourceName, "ip_allow_list.1.cidr_block", "2.2.2.2/32"),
+					resource.TestCheckResourceAttr(resourceName, "ip_allow_list.1.description", "two"),
+
+					resource.TestCheckResourceAttrWith(resourceName, "connection_info.external_connection_string", func(value string) error {
+						if !regexp.MustCompile(`^rediss://red-.*:.{32}@oregon-keyvalue\..*:637[7,9]$`).MatchString(value) {
+							return fmt.Errorf("expected external_connection_string: %s to match regex", value)
+						}
+
+						return nil
+					}),
+
+					resource.TestCheckResourceAttrWith(resourceName, "connection_info.internal_connection_string", func(value string) error {
+						if !regexp.MustCompile(`^redis://red-.*:637[7,9]$`).MatchString(value) {
+							return fmt.Errorf("expected internal_connection_string: %s to match regex", value)
+						}
+
+						return nil
+					}),
+
+					resource.TestCheckResourceAttrWith(resourceName, "connection_info.cli_command", func(value string) error {
+						if !regexp.MustCompile(`^ REDISCLI_AUTH=.{32} valkey-cli --user red-.* -h oregon-keyvalue\..* -p 637[7,9] --tls$`).MatchString(value) {
+							return fmt.Errorf("expected cli_command: %s to match regex", value)
+						}
+
+						return nil
+					}),
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/keyvalue/datasource/schema.go
+++ b/internal/provider/keyvalue/datasource/schema.go
@@ -17,6 +17,7 @@ func Schema(ctx context.Context) schema.Schema {
 			"environment_id":      datasource.ResourceEnvironmentID,
 			"ip_allow_list":       datasource.IPAllowList,
 			"max_memory_policy":   datasource.MaxMemoryPolicy,
+			"persistence_mode":    datasource.PersistenceMode,
 			"name":                datasource.ServiceName,
 			"plan":                datasource.KeyValuePlan,
 			"region":              datasource.Region,

--- a/internal/provider/keyvalue/datasource/testdata/keyvalue.tf
+++ b/internal/provider/keyvalue/datasource/testdata/keyvalue.tf
@@ -1,0 +1,22 @@
+resource "render_keyvalue" "test" {
+  name              = "some-keyvalue"
+  plan              = "starter"
+  region            = "oregon"
+  max_memory_policy = "noeviction"
+  persistence_mode  = "snapshot"
+
+  ip_allow_list = [
+    {
+      cidr_block  = "1.1.1.1/32"
+      description = "one"
+    },
+    {
+      cidr_block  = "2.2.2.2/32"
+      description = "two"
+    }
+  ]
+}
+
+data "render_keyvalue" "test" {
+  id = render_keyvalue.test.id
+}

--- a/internal/provider/keyvalue/datasource/testdata/keyvalue_datasource_cassette.yaml
+++ b/internal/provider/keyvalue/datasource/testdata/keyvalue_datasource_cassette.yaml
@@ -1,0 +1,870 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 266
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: '{"ipAllowList":[{"cidrBlock":"1.1.1.1/32","description":"one"},{"cidrBlock":"2.2.2.2/32","description":"two"}],"maxmemoryPolicy":"noeviction","name":"some-keyvalue","ownerId":"some-owner-id","persistenceMode":"snapshot","plan":"starter","region":"oregon"}'
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            Content-Type:
+                - application/json
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 504
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-08T20:02:02.497912963Z","id":"red-d8jhvelkf5hc73agg2l0","ipAllowList":[{"cidrBlock":"1.1.1.1/32","description":"one"},{"cidrBlock":"2.2.2.2/32","description":"two"}],"name":"some-keyvalue","options":{"maxmemoryPolicy":"noeviction","persistenceMode":"snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"starter","region":"oregon","status":"unknown","updatedAt":"2026-06-08T20:02:02.497912963Z","version":"8.1.4"}
+        headers:
+            Content-Length:
+                - "504"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 08 Jun 2026 20:02:02 GMT
+            Ratelimit-Limit:
+                - "20"
+            Ratelimit-Remaining:
+                - "19"
+            Ratelimit-Reset:
+                - "3477"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-5b97655559-4vdk6/fVFYqEVdRW-000062
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 201 Created
+        code: 201
+        duration: 370.223833ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value/red-d8jhvelkf5hc73agg2l0/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 367
+        uncompressed: false
+        body: |
+            {"cliCommand":" REDISCLI_AUTH=PoTIpQigl6DFvF6AU5i14fEBoG5pupKO valkey-cli --user red-d8jhvelkf5hc73agg2l0 -h oregon-keyvalue.localhost.render.com -p 6377 --tls","externalConnectionString":"rediss://red-d8jhvelkf5hc73agg2l0:PoTIpQigl6DFvF6AU5i14fEBoG5pupKO@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8jhvelkf5hc73agg2l0:6379"}
+        headers:
+            Content-Length:
+                - "367"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 08 Jun 2026 20:02:02 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "399"
+            Ratelimit-Reset:
+                - "57"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-5b97655559-4vdk6/fVFYqEVdRW-000063
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 65.879667ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value/red-d8jhvelkf5hc73agg2l0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 499
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-08T20:02:02.497913Z","id":"red-d8jhvelkf5hc73agg2l0","ipAllowList":[{"cidrBlock":"1.1.1.1/32","description":"one"},{"cidrBlock":"2.2.2.2/32","description":"two"}],"name":"some-keyvalue","options":{"maxmemoryPolicy":"noeviction","persistenceMode":"snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"starter","region":"oregon","status":"creating","updatedAt":"2026-06-08T20:02:02.497913Z","version":"8.1.4"}
+        headers:
+            Content-Length:
+                - "499"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 08 Jun 2026 20:02:02 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "398"
+            Ratelimit-Reset:
+                - "57"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-5b97655559-4vdk6/fVFYqEVdRW-000064
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 96.592958ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value/red-d8jhvelkf5hc73agg2l0/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 367
+        uncompressed: false
+        body: |
+            {"cliCommand":" REDISCLI_AUTH=PoTIpQigl6DFvF6AU5i14fEBoG5pupKO valkey-cli --user red-d8jhvelkf5hc73agg2l0 -h oregon-keyvalue.localhost.render.com -p 6377 --tls","externalConnectionString":"rediss://red-d8jhvelkf5hc73agg2l0:PoTIpQigl6DFvF6AU5i14fEBoG5pupKO@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8jhvelkf5hc73agg2l0:6379"}
+        headers:
+            Content-Length:
+                - "367"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 08 Jun 2026 20:02:03 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "397"
+            Ratelimit-Reset:
+                - "56"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-5b97655559-4vdk6/fVFYqEVdRW-000065
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 74.131917ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8jhvelkf5hc73agg2l0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: red-d8jhvelkf5hc73agg2l0"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 08 Jun 2026 20:02:03 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "396"
+            Ratelimit-Reset:
+                - "56"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-5b97655559-4vdk6/fVFYqEVdRW-000066
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 61.174125ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value/red-d8jhvelkf5hc73agg2l0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 499
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-08T20:02:02.497913Z","id":"red-d8jhvelkf5hc73agg2l0","ipAllowList":[{"cidrBlock":"1.1.1.1/32","description":"one"},{"cidrBlock":"2.2.2.2/32","description":"two"}],"name":"some-keyvalue","options":{"maxmemoryPolicy":"noeviction","persistenceMode":"snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"starter","region":"oregon","status":"creating","updatedAt":"2026-06-08T20:02:02.497913Z","version":"8.1.4"}
+        headers:
+            Content-Length:
+                - "499"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 08 Jun 2026 20:02:03 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "395"
+            Ratelimit-Reset:
+                - "56"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-5b97655559-4vdk6/fVFYqEVdRW-000067
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 86.602167ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value/red-d8jhvelkf5hc73agg2l0/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 367
+        uncompressed: false
+        body: |
+            {"cliCommand":" REDISCLI_AUTH=PoTIpQigl6DFvF6AU5i14fEBoG5pupKO valkey-cli --user red-d8jhvelkf5hc73agg2l0 -h oregon-keyvalue.localhost.render.com -p 6377 --tls","externalConnectionString":"rediss://red-d8jhvelkf5hc73agg2l0:PoTIpQigl6DFvF6AU5i14fEBoG5pupKO@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8jhvelkf5hc73agg2l0:6379"}
+        headers:
+            Content-Length:
+                - "367"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 08 Jun 2026 20:02:03 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "394"
+            Ratelimit-Reset:
+                - "56"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-5b97655559-4vdk6/fVFYqEVdRW-000068
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 61.437542ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8jhvelkf5hc73agg2l0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: red-d8jhvelkf5hc73agg2l0"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 08 Jun 2026 20:02:03 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "393"
+            Ratelimit-Reset:
+                - "56"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-5b97655559-4vdk6/fVFYqEVdRW-000069
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 61.748625ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value/red-d8jhvelkf5hc73agg2l0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 499
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-08T20:02:02.497913Z","id":"red-d8jhvelkf5hc73agg2l0","ipAllowList":[{"cidrBlock":"1.1.1.1/32","description":"one"},{"cidrBlock":"2.2.2.2/32","description":"two"}],"name":"some-keyvalue","options":{"maxmemoryPolicy":"noeviction","persistenceMode":"snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"starter","region":"oregon","status":"creating","updatedAt":"2026-06-08T20:02:02.497913Z","version":"8.1.4"}
+        headers:
+            Content-Length:
+                - "499"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 08 Jun 2026 20:02:03 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "392"
+            Ratelimit-Reset:
+                - "56"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-5b97655559-4vdk6/fVFYqEVdRW-000070
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 86.655417ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value/red-d8jhvelkf5hc73agg2l0/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 367
+        uncompressed: false
+        body: |
+            {"cliCommand":" REDISCLI_AUTH=PoTIpQigl6DFvF6AU5i14fEBoG5pupKO valkey-cli --user red-d8jhvelkf5hc73agg2l0 -h oregon-keyvalue.localhost.render.com -p 6377 --tls","externalConnectionString":"rediss://red-d8jhvelkf5hc73agg2l0:PoTIpQigl6DFvF6AU5i14fEBoG5pupKO@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8jhvelkf5hc73agg2l0:6379"}
+        headers:
+            Content-Length:
+                - "367"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 08 Jun 2026 20:02:04 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "391"
+            Ratelimit-Reset:
+                - "55"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-5b97655559-4vdk6/fVFYqEVdRW-000071
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 65.741ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8jhvelkf5hc73agg2l0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: red-d8jhvelkf5hc73agg2l0"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 08 Jun 2026 20:02:04 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "390"
+            Ratelimit-Reset:
+                - "55"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-5b97655559-4vdk6/fVFYqEVdRW-000072
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 65.014875ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value/red-d8jhvelkf5hc73agg2l0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 499
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-08T20:02:02.497913Z","id":"red-d8jhvelkf5hc73agg2l0","ipAllowList":[{"cidrBlock":"1.1.1.1/32","description":"one"},{"cidrBlock":"2.2.2.2/32","description":"two"}],"name":"some-keyvalue","options":{"maxmemoryPolicy":"noeviction","persistenceMode":"snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"starter","region":"oregon","status":"creating","updatedAt":"2026-06-08T20:02:02.497913Z","version":"8.1.4"}
+        headers:
+            Content-Length:
+                - "499"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 08 Jun 2026 20:02:04 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "389"
+            Ratelimit-Reset:
+                - "55"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-5b97655559-4vdk6/fVFYqEVdRW-000073
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 89.687958ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value/red-d8jhvelkf5hc73agg2l0/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 367
+        uncompressed: false
+        body: |
+            {"cliCommand":" REDISCLI_AUTH=PoTIpQigl6DFvF6AU5i14fEBoG5pupKO valkey-cli --user red-d8jhvelkf5hc73agg2l0 -h oregon-keyvalue.localhost.render.com -p 6377 --tls","externalConnectionString":"rediss://red-d8jhvelkf5hc73agg2l0:PoTIpQigl6DFvF6AU5i14fEBoG5pupKO@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8jhvelkf5hc73agg2l0:6379"}
+        headers:
+            Content-Length:
+                - "367"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 08 Jun 2026 20:02:04 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "388"
+            Ratelimit-Reset:
+                - "55"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-5b97655559-4vdk6/fVFYqEVdRW-000074
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 65.979583ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8jhvelkf5hc73agg2l0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: red-d8jhvelkf5hc73agg2l0"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 08 Jun 2026 20:02:04 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "387"
+            Ratelimit-Reset:
+                - "55"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-5b97655559-4vdk6/fVFYqEVdRW-000075
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 59.481041ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value/red-d8jhvelkf5hc73agg2l0
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Date:
+                - Mon, 08 Jun 2026 20:02:04 GMT
+            Ratelimit-Limit:
+                - "100"
+            Ratelimit-Remaining:
+                - "99"
+            Ratelimit-Reset:
+                - "55"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-5b97655559-4vdk6/fVFYqEVdRW-000076
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 204 No Content
+        code: 204
+        duration: 188.579709ms

--- a/internal/provider/keyvalue/models.go
+++ b/internal/provider/keyvalue/models.go
@@ -16,6 +16,7 @@ type KeyValueModel struct {
 	EnvironmentID     types.String `tfsdk:"environment_id"`
 	IPAllowList       types.Set    `tfsdk:"ip_allow_list"`
 	MaxMemoryPolicy   types.String `tfsdk:"max_memory_policy"`
+	PersistenceMode   types.String `tfsdk:"persistence_mode"`
 	Name              types.String `tfsdk:"name"`
 	Plan              types.String `tfsdk:"plan"`
 	Region            types.String `tfsdk:"region"`
@@ -54,6 +55,7 @@ func ModelForKeyValueResult(kv *client.KeyValue, plan *KeyValueModel, connection
 		EnvironmentID:     types.StringPointerValue(kv.EnvironmentId),
 		IPAllowList:       common.IPAllowListFromClient(kv.IpAllowList, diags),
 		MaxMemoryPolicy:   types.StringValue(*kv.Options.MaxmemoryPolicy),
+		PersistenceMode:   types.StringValue(string(*kv.Options.PersistenceMode)),
 		Name:              types.StringValue(kv.Name),
 		Plan:              types.StringValue(string(kv.Plan)),
 		Region:            types.StringValue(string(kv.Region)),

--- a/internal/provider/keyvalue/resource/internal/create.go
+++ b/internal/provider/keyvalue/resource/internal/create.go
@@ -17,10 +17,16 @@ func CreateKeyValueRequestFromModel(ownerID string, plan keyvalue.KeyValueModel)
 		maxMemoryPolicy = client.MaxmemoryPolicy(plan.MaxMemoryPolicy.ValueString())
 	}
 
+	var persistenceMode *client.PersistenceMode
+	if plan.PersistenceMode.ValueString() != "" {
+		persistenceMode = (*client.PersistenceMode)(plan.PersistenceMode.ValueStringPointer())
+	}
+
 	var createKeyValueBody = client.CreateKeyValueJSONRequestBody{
 		EnvironmentId:   plan.EnvironmentID.ValueStringPointer(),
 		IpAllowList:     &ipAllowList,
 		MaxmemoryPolicy: &maxMemoryPolicy,
+		PersistenceMode: persistenceMode,
 		Name:            plan.Name.ValueString(),
 		OwnerId:         ownerID,
 		Plan:            client.KeyValuePlan(plan.Plan.ValueString()),

--- a/internal/provider/keyvalue/resource/internal/update.go
+++ b/internal/provider/keyvalue/resource/internal/update.go
@@ -17,6 +17,11 @@ func UpdateServiceRequestFromModel(plan keyvalue.KeyValueModel) (client.UpdateKe
 		maxMemoryPolicy = client.MaxmemoryPolicy(plan.MaxMemoryPolicy.ValueString())
 	}
 
+	var persistenceMode *client.PersistenceMode
+	if plan.PersistenceMode.ValueString() != "" {
+		persistenceMode = (*client.PersistenceMode)(plan.PersistenceMode.ValueStringPointer())
+	}
+
 	var keyValuePlan client.KeyValuePlan
 	if plan.Plan.ValueString() != "" {
 		keyValuePlan = client.KeyValuePlan(plan.Plan.ValueString())
@@ -25,6 +30,7 @@ func UpdateServiceRequestFromModel(plan keyvalue.KeyValueModel) (client.UpdateKe
 	updateKeyValueRequest := client.UpdateKeyValueJSONRequestBody{
 		IpAllowList:     &ipAllowList,
 		MaxmemoryPolicy: &maxMemoryPolicy,
+		PersistenceMode: persistenceMode,
 		Name:            plan.Name.ValueStringPointer(),
 		Plan:            &keyValuePlan,
 	}

--- a/internal/provider/keyvalue/resource/resource_test.go
+++ b/internal/provider/keyvalue/resource/resource_test.go
@@ -29,6 +29,7 @@ func TestKeyValueResource(t *testing.T) {
 					"environment_name":       config.StringVariable("first"),
 					"has_allow_list":         config.BoolVariable(true),
 					"max_memory_policy":      config.StringVariable("allkeys_lfu"),
+					"persistence_mode":       config.StringVariable("journal_snapshot"),
 					"name":                   config.StringVariable("test-keyvalue"),
 					"plan":                   config.StringVariable("starter"),
 					"has_log_stream_setting": config.BoolVariable(true),
@@ -44,6 +45,7 @@ func TestKeyValueResource(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "plan", "starter"),
 					resource.TestCheckResourceAttr(resourceName, "region", "oregon"),
 					resource.TestCheckResourceAttr(resourceName, "max_memory_policy", "allkeys_lfu"),
+					resource.TestCheckResourceAttr(resourceName, "persistence_mode", "journal_snapshot"),
 
 					resource.TestCheckResourceAttrWith(resourceName, "environment_id", func(value string) error {
 						if !strings.HasPrefix(value, "evm-") {
@@ -85,6 +87,9 @@ func TestKeyValueResource(t *testing.T) {
 
 						return nil
 					}),
+
+					// Check the default persistence mode of paid Key Value
+					resource.TestCheckResourceAttr("render_keyvalue.test-keyvalue-paid", "persistence_mode", "journal_snapshot"),
 				),
 			},
 			{
@@ -98,6 +103,7 @@ func TestKeyValueResource(t *testing.T) {
 					"environment_name":       config.StringVariable("first"),
 					"has_allow_list":         config.BoolVariable(true),
 					"max_memory_policy":      config.StringVariable("allkeys_lfu"),
+					"persistence_mode":       config.StringVariable("journal_snapshot"),
 					"name":                   config.StringVariable("test-keyvalue"),
 					"plan":                   config.StringVariable("starter"),
 					"has_log_stream_setting": config.BoolVariable(true),
@@ -111,6 +117,7 @@ func TestKeyValueResource(t *testing.T) {
 					"environment_name":       config.StringVariable("second"),
 					"has_allow_list":         config.BoolVariable(false),
 					"max_memory_policy":      config.StringVariable("noeviction"),
+					"persistence_mode":       config.StringVariable("snapshot"),
 					"name":                   config.StringVariable("test-keyvalue-new"),
 					"plan":                   config.StringVariable("standard"),
 					"has_log_stream_setting": config.BoolVariable(false),
@@ -125,6 +132,7 @@ func TestKeyValueResource(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "plan", "standard"),
 					resource.TestCheckResourceAttr(resourceName, "region", "oregon"),
 					resource.TestCheckResourceAttr(resourceName, "max_memory_policy", "noeviction"),
+					resource.TestCheckResourceAttr(resourceName, "persistence_mode", "snapshot"),
 					resource.TestCheckNoResourceAttr(resourceName, "log_stream_override.setting"),
 
 					resource.TestCheckResourceAttrWith(resourceName, "environment_id", func(value string) error {
@@ -151,6 +159,7 @@ func TestKeyValueResource(t *testing.T) {
 					"environment_name":       config.StringVariable("second"),
 					"has_allow_list":         config.BoolVariable(true),
 					"max_memory_policy":      config.StringVariable("noeviction"),
+					"persistence_mode":       config.StringVariable("snapshot"),
 					"name":                   config.StringVariable("test-keyvalue-new"),
 					"plan":                   config.StringVariable("standard"),
 					"has_log_stream_setting": config.BoolVariable(false),
@@ -166,6 +175,70 @@ func TestKeyValueResource(t *testing.T) {
 
 					resource.TestCheckResourceAttr(resourceName, "ip_allow_list.1.cidr_block", "2.0.0.0/8"),
 					resource.TestCheckResourceAttr(resourceName, "ip_allow_list.1.description", "test-2"),
+				),
+			},
+			// Test the upgrade path from free Key Value to paid to make sure the default persistence mode behaves as expected
+			{
+				ResourceName: "render_keyvalue.test-keyvalue-upgrade",
+				ConfigFile:   config.StaticFile("./testdata/keyvalue_upgrade.tf"),
+				ConfigVariables: config.Variables{
+					"plan": config.StringVariable("free"),
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						checks.ExpectNoReplace(),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("render_keyvalue.test-keyvalue-upgrade", "persistence_mode", "off"),
+				),
+			},
+			{
+				ResourceName: "render_keyvalue.test-keyvalue-upgrade",
+				ConfigFile:   config.StaticFile("./testdata/keyvalue_upgrade.tf"),
+				ConfigVariables: config.Variables{
+					"plan": config.StringVariable("starter"),
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						checks.ExpectNoReplace(),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("render_keyvalue.test-keyvalue-upgrade", "persistence_mode", "journal_snapshot"),
+				),
+			},
+			// Test the upgrade path from free Key Value to paid to make sure the specified persistence mode behaves as expected
+			{
+				ResourceName: "render_keyvalue.test-keyvalue-upgrade2",
+				ConfigFile:   config.StaticFile("./testdata/keyvalue_upgrade2.tf"),
+				ConfigVariables: config.Variables{
+					"plan":             config.StringVariable("free"),
+					"persistence_mode": config.StringVariable("off"),
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						checks.ExpectNoReplace(),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("render_keyvalue.test-keyvalue-upgrade2", "persistence_mode", "off"),
+				),
+			},
+			{
+				ResourceName: "render_keyvalue.test-keyvalue-upgrade2",
+				ConfigFile:   config.StaticFile("./testdata/keyvalue_upgrade2.tf"),
+				ConfigVariables: config.Variables{
+					"plan":             config.StringVariable("starter"),
+					"persistence_mode": config.StringVariable("snapshot"),
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						checks.ExpectNoReplace(),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("render_keyvalue.test-keyvalue-upgrade2", "persistence_mode", "snapshot"),
 				),
 			},
 		},

--- a/internal/provider/keyvalue/resource/schema.go
+++ b/internal/provider/keyvalue/resource/schema.go
@@ -16,6 +16,7 @@ func Schema(ctx context.Context) schema.Schema {
 			"environment_id":      resource.ResourceEnvironmentID,
 			"ip_allow_list":       resource.IPAllowList,
 			"max_memory_policy":   resource.MaxMemoryPolicy,
+			"persistence_mode":    resource.PersistenceMode,
 			"name":                resource.ServiceName,
 			"plan":                resource.KeyValuePlan,
 			"region":              resource.Region,

--- a/internal/provider/keyvalue/resource/testdata/keyvalue.tf
+++ b/internal/provider/keyvalue/resource/testdata/keyvalue.tf
@@ -7,6 +7,9 @@ variable "has_allow_list" {
 variable "max_memory_policy" {
   type = string
 }
+variable "persistence_mode" {
+  type = string
+}
 variable "name" {
   type = string
 }
@@ -19,33 +22,34 @@ variable "has_log_stream_setting" {
 
 locals {
   environment_map = {
-    "first" = render_project.first.environments,
+    "first"  = render_project.first.environments,
     "second" = render_project.second.environments,
   }
 }
 
-resource "render_project" "first"  {
+resource "render_project" "first" {
   name = "first"
   environments = {
     "prod" : { name : "prod", protected_status : "protected" },
   }
 }
 
-resource "render_project" "second"  {
+resource "render_project" "second" {
   name = "second"
   environments = {
     "prod" : { name : "prod", protected_status : "protected" },
   }
   # Ensure there is always an order to creating these
-  depends_on = [    render_project.first  ]
+  depends_on = [render_project.first]
 }
 
 resource "render_keyvalue" "test-keyvalue" {
-  environment_id = var.environment_name != null ? local.environment_map[var.environment_name]["prod"].id : null
+  environment_id    = var.environment_name != null ? local.environment_map[var.environment_name]["prod"].id : null
   max_memory_policy = var.max_memory_policy
-  name = var.name
-  plan = var.plan
-  region = "oregon"
+  persistence_mode  = var.persistence_mode
+  name              = var.name
+  plan              = var.plan
+  region            = "oregon"
   ip_allow_list = var.has_allow_list ? [
     {
       cidr_block  = "1.1.1.1/32"
@@ -61,4 +65,11 @@ resource "render_keyvalue" "test-keyvalue" {
   } : null
 
   depends_on = [render_project.first, render_project.second]
+}
+
+resource "render_keyvalue" "test-keyvalue-paid" {
+  name              = "test-keyvalue-paid"
+  plan              = "starter"
+  region            = "oregon"
+  max_memory_policy = "allkeys_lfu"
 }

--- a/internal/provider/keyvalue/resource/testdata/keyvalue_cassette.yaml
+++ b/internal/provider/keyvalue/resource/testdata/keyvalue_cassette.yaml
@@ -6,13 +6,13 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 116
+        content_length: 148
         transfer_encoding: []
         trailer: {}
         host: https://api.testing.render.com/v1
         remote_addr: ""
         request_uri: ""
-        body: '{"environments":[{"name":"prod","protectedStatus":"protected"}],"name":"first","ownerId":"some-owner-id"}'
+        body: '{"environments":[{"name":"prod","networkIsolationEnabled":false,"protectedStatus":"protected"}],"name":"first","ownerId":"some-owner-id"}'
         form: {}
         headers:
             Authorization:
@@ -29,27 +29,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 285
+        content_length: 282
         uncompressed: false
         body: |
-            {"createdAt":"2024-09-09T16:35:27.305482Z","environmentIds":["evm-crfi7js8m55c703hl2fg"],"id":"prj-crfi7js8m55c703hl2f0","name":"first","owner":{"email":"email@example.com","id":"some-owner-id","name":"Test Terraform","type":"team"},"updatedAt":"2024-09-09T16:35:27.305482Z"}
+            {"createdAt":"2026-06-09T16:25:25.533574Z","environmentIds":["evm-d8k3stdodlmc73btr2s0"],"id":"prj-d8k3stdodlmc73btr2r0","name":"first","owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"updatedAt":"2026-06-09T16:25:25.533574Z"}
         headers:
             Content-Length:
-                - "285"
+                - "282"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:27 GMT
+                - Tue, 09 Jun 2026 16:25:25 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "100"
             Ratelimit-Remaining:
-                - "9998"
+                - "99"
             Ratelimit-Reset:
-                - "32"
+                - "34"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000143
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000750
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -60,8 +60,68 @@ interactions:
                 - 1; mode=block
         status: 201 Created
         code: 201
-        duration: 145.171ms
+        duration: 133.481209ms
     - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 150
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: '{"ipAllowList":[],"maxmemoryPolicy":"allkeys_lfu","name":"test-keyvalue-paid","ownerId":"some-owner-id","plan":"starter","region":"oregon"}'
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            Content-Type:
+                - application/json
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 425
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T16:25:25.48944232Z","id":"red-d8k3stdodlmc73btr2q0","ipAllowList":null,"name":"test-keyvalue-paid","options":{"maxmemoryPolicy":"allkeys_lfu","persistenceMode":"journal_snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"starter","region":"oregon","status":"unknown","updatedAt":"2026-06-09T16:25:25.48944232Z","version":"8.1.4"}
+        headers:
+            Content-Length:
+                - "425"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:25 GMT
+            Ratelimit-Limit:
+                - "20"
+            Ratelimit-Remaining:
+                - "11"
+            Ratelimit-Reset:
+                - "2074"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000749
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 201 Created
+        code: 201
+        duration: 348.888583ms
+    - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -79,7 +139,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/environments/evm-crfi7js8m55c703hl2fg
+        url: https://api.testing.render.com/v1/environments/evm-d8k3stdodlmc73btr2s0
         method: GET
       response:
         proto: HTTP/2.0
@@ -87,27 +147,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 190
+        content_length: 222
         uncompressed: false
         body: |
-            {"databasesIds":null,"envGroupIds":null,"id":"evm-crfi7js8m55c703hl2fg","name":"prod","projectId":"prj-crfi7js8m55c703hl2f0","protectedStatus":"protected","redisIds":null,"serviceIds":null}
+            {"databasesIds":null,"envGroupIds":null,"id":"evm-d8k3stdodlmc73btr2s0","name":"prod","networkIsolationEnabled":false,"projectId":"prj-d8k3stdodlmc73btr2r0","protectedStatus":"protected","redisIds":null,"serviceIds":null}
         headers:
             Content-Length:
-                - "190"
+                - "222"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:27 GMT
+                - Tue, 09 Jun 2026 16:25:25 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9987"
+                - "399"
             Ratelimit-Reset:
-                - "32"
+                - "34"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000144
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000751
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -118,67 +178,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 41.325375ms
-    - id: 2
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 117
-        transfer_encoding: []
-        trailer: {}
-        host: https://api.testing.render.com/v1
-        remote_addr: ""
-        request_uri: ""
-        body: '{"environments":[{"name":"prod","protectedStatus":"protected"}],"name":"second","ownerId":"some-owner-id"}'
-        form: {}
-        headers:
-            Authorization:
-                - some-api-key
-            Content-Type:
-                - application/json
-            User-Agent:
-                - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/projects
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 286
-        uncompressed: false
-        body: |
-            {"createdAt":"2024-09-09T16:35:27.450645Z","environmentIds":["evm-crfi7js8m55c703hl2gg"],"id":"prj-crfi7js8m55c703hl2g0","name":"second","owner":{"email":"email@example.com","id":"some-owner-id","name":"Test Terraform","type":"team"},"updatedAt":"2024-09-09T16:35:27.450645Z"}
-        headers:
-            Content-Length:
-                - "286"
-            Content-Type:
-                - application/json; charset=utf-8
-            Date:
-                - Mon, 09 Sep 2024 16:35:27 GMT
-            Ratelimit-Limit:
-                - "10000"
-            Ratelimit-Remaining:
-                - "9997"
-            Ratelimit-Reset:
-                - "32"
-            Referrer-Policy:
-                - same-origin
-            Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000145
-            Vary:
-                - Origin
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Xss-Protection:
-                - 1; mode=block
-        status: 201 Created
-        code: 201
-        duration: 81.226083ms
+        duration: 65.890208ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -197,7 +197,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/environments/evm-crfi7js8m55c703hl2gg
+        url: https://api.testing.render.com/v1/key-value/red-d8k3stdodlmc73btr2q0/connection-info
         method: GET
       response:
         proto: HTTP/2.0
@@ -205,27 +205,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 190
+        content_length: 367
         uncompressed: false
         body: |
-            {"databasesIds":null,"envGroupIds":null,"id":"evm-crfi7js8m55c703hl2gg","name":"prod","projectId":"prj-crfi7js8m55c703hl2g0","protectedStatus":"protected","redisIds":null,"serviceIds":null}
+            {"cliCommand":" REDISCLI_AUTH=WaE4JEDy7ygZu0tOR8v73BR6mghAr1rG valkey-cli --user red-d8k3stdodlmc73btr2q0 -h oregon-keyvalue.localhost.render.com -p 6377 --tls","externalConnectionString":"rediss://red-d8k3stdodlmc73btr2q0:WaE4JEDy7ygZu0tOR8v73BR6mghAr1rG@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k3stdodlmc73btr2q0:6379"}
         headers:
             Content-Length:
-                - "190"
+                - "367"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:27 GMT
+                - Tue, 09 Jun 2026 16:25:25 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9986"
+                - "398"
             Ratelimit-Reset:
-                - "32"
+                - "34"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000146
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000752
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -236,19 +236,19 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 40.835125ms
+        duration: 73.083333ms
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 281
+        content_length: 149
         transfer_encoding: []
         trailer: {}
         host: https://api.testing.render.com/v1
         remote_addr: ""
         request_uri: ""
-        body: '{"environmentId":"evm-crfi7js8m55c703hl2fg","ipAllowList":[{"cidrBlock":"1.1.1.1/32","description":"test"},{"cidrBlock":"2.0.0.0/8","description":"test-2"}],"maxmemoryPolicy":"allkeys_lfu","name":"test-keyvalue","ownerId":"some-owner-id","plan":"starter","region":"oregon"}'
+        body: '{"environments":[{"name":"prod","networkIsolationEnabled":false,"protectedStatus":"protected"}],"name":"second","ownerId":"some-owner-id"}'
         form: {}
         headers:
             Authorization:
@@ -257,7 +257,7 @@ interactions:
                 - application/json
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/key-value
+        url: https://api.testing.render.com/v1/projects
         method: POST
       response:
         proto: HTTP/2.0
@@ -265,27 +265,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 524
+        content_length: 281
         uncompressed: false
         body: |
-            {"createdAt":"2024-09-09T16:35:27.643669961Z","environmentId":"evm-crfi7js8m55c703hl2fg","id":"red-crfi7js8m55c703hl2h0","ipAllowList":[{"cidrBlock":"1.1.1.1/32","description":"test"},{"cidrBlock":"2.0.0.0/8","description":"test-2"}],"name":"test-keyvalue","options":{"maxmemoryPolicy":"allkeys_lfu"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"Test Terraform","type":"team"},"plan":"starter","region":"oregon","status":"creating","updatedAt":"2024-09-09T16:35:27.643669961Z","version":"6.2.14"}
+            {"createdAt":"2026-06-09T16:25:26.03239Z","environmentIds":["evm-d8k3stlodlmc73btr2ug"],"id":"prj-d8k3stlodlmc73btr2tg","name":"second","owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"updatedAt":"2026-06-09T16:25:26.03239Z"}
         headers:
             Content-Length:
-                - "524"
+                - "281"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:27 GMT
+                - Tue, 09 Jun 2026 16:25:26 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "100"
             Ratelimit-Remaining:
-                - "9999"
+                - "98"
             Ratelimit-Reset:
-                - "32"
+                - "33"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000147
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000753
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -296,7 +296,7 @@ interactions:
                 - 1; mode=block
         status: 201 Created
         code: 201
-        duration: 223.503667ms
+        duration: 128.450291ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -315,7 +315,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/key-value/red-crfi7js8m55c703hl2h0/connection-info
+        url: https://api.testing.render.com/v1/environments/evm-d8k3stlodlmc73btr2ug
         method: GET
       response:
         proto: HTTP/2.0
@@ -323,27 +323,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 365
+        content_length: 222
         uncompressed: false
         body: |
-            {"externalConnectionString":"rediss://red-crfi7js8m55c703hl2h0:gIRSGDdOQriMcOCPQHj1durmcXvsgVqm@oregon-redis.localhost.render.com:6377","internalConnectionString":"redis://red-crfi7js8m55c703hl2h0:6379","cliCommand":" REDISCLI_AUTH=gIRSGDdOQriMcOCPQHj1durmcXvsgVqm valkey-cli --user red-crfi7js8m55c703hl2h0 -h oregon-redis.localhost.render.com -p 6377 --tls"}
+            {"databasesIds":null,"envGroupIds":null,"id":"evm-d8k3stlodlmc73btr2ug","name":"prod","networkIsolationEnabled":false,"projectId":"prj-d8k3stlodlmc73btr2tg","protectedStatus":"protected","redisIds":null,"serviceIds":null}
         headers:
             Content-Length:
-                - "365"
+                - "222"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:27 GMT
+                - Tue, 09 Jun 2026 16:25:26 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9985"
+                - "397"
             Ratelimit-Reset:
-                - "32"
+                - "33"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000148
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000754
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -354,8 +354,126 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 51.036208ms
+        duration: 69.270541ms
     - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 321
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: '{"environmentId":"evm-d8k3stdodlmc73btr2s0","ipAllowList":[{"cidrBlock":"1.1.1.1/32","description":"test"},{"cidrBlock":"2.0.0.0/8","description":"test-2"}],"maxmemoryPolicy":"allkeys_lfu","name":"test-keyvalue","ownerId":"some-owner-id","persistenceMode":"journal_snapshot","plan":"starter","region":"oregon"}'
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            Content-Type:
+                - application/json
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 559
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T16:25:26.405394083Z","environmentId":"evm-d8k3stdodlmc73btr2s0","id":"red-d8k3stlodlmc73btr2vg","ipAllowList":[{"cidrBlock":"1.1.1.1/32","description":"test"},{"cidrBlock":"2.0.0.0/8","description":"test-2"}],"name":"test-keyvalue","options":{"maxmemoryPolicy":"allkeys_lfu","persistenceMode":"journal_snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"starter","region":"oregon","status":"unknown","updatedAt":"2026-06-09T16:25:26.405394083Z","version":"8.1.4"}
+        headers:
+            Content-Length:
+                - "559"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:26 GMT
+            Ratelimit-Limit:
+                - "20"
+            Ratelimit-Remaining:
+                - "10"
+            Ratelimit-Reset:
+                - "2073"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000755
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 201 Created
+        code: 201
+        duration: 290.903542ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value/red-d8k3stlodlmc73btr2vg/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 367
+        uncompressed: false
+        body: |
+            {"cliCommand":" REDISCLI_AUTH=J1Nn3zNY0GwZ2Pspo6Tno4kVBYanCegk valkey-cli --user red-d8k3stlodlmc73btr2vg -h oregon-keyvalue.localhost.render.com -p 6377 --tls","externalConnectionString":"rediss://red-d8k3stlodlmc73btr2vg:J1Nn3zNY0GwZ2Pspo6Tno4kVBYanCegk@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k3stlodlmc73btr2vg:6379"}
+        headers:
+            Content-Length:
+                - "367"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:26 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "396"
+            Ratelimit-Reset:
+                - "33"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000756
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 79.486416ms
+    - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -375,7 +493,7 @@ interactions:
                 - application/json
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/logs/streams/resource/red-crfi7js8m55c703hl2h0
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8k3stlodlmc73btr2vg
         method: PUT
       response:
         proto: HTTP/2.0
@@ -386,24 +504,24 @@ interactions:
         content_length: 73
         uncompressed: false
         body: |
-            {"endpoint":"","resourceId":"red-crfi7js8m55c703hl2h0","setting":"drop"}
+            {"endpoint":"","resourceId":"red-d8k3stlodlmc73btr2vg","setting":"drop"}
         headers:
             Content-Length:
                 - "73"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:27 GMT
+                - Tue, 09 Jun 2026 16:25:26 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "100"
             Ratelimit-Remaining:
-                - "9996"
+                - "97"
             Ratelimit-Reset:
-                - "32"
+                - "33"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000149
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000757
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -414,123 +532,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 46.927083ms
-    - id: 7
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: https://api.testing.render.com/v1
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Authorization:
-                - some-api-key
-            User-Agent:
-                - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/projects/prj-crfi7js8m55c703hl2f0
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 285
-        uncompressed: false
-        body: |
-            {"createdAt":"2024-09-09T16:35:27.305482Z","environmentIds":["evm-crfi7js8m55c703hl2fg"],"id":"prj-crfi7js8m55c703hl2f0","name":"first","owner":{"email":"email@example.com","id":"some-owner-id","name":"Test Terraform","type":"team"},"updatedAt":"2024-09-09T16:35:27.305482Z"}
-        headers:
-            Content-Length:
-                - "285"
-            Content-Type:
-                - application/json; charset=utf-8
-            Date:
-                - Mon, 09 Sep 2024 16:35:28 GMT
-            Ratelimit-Limit:
-                - "10000"
-            Ratelimit-Remaining:
-                - "9984"
-            Ratelimit-Reset:
-                - "31"
-            Referrer-Policy:
-                - same-origin
-            Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000150
-            Vary:
-                - Origin
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Xss-Protection:
-                - 1; mode=block
-        status: 200 OK
-        code: 200
-        duration: 62.751583ms
-    - id: 8
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: https://api.testing.render.com/v1
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Authorization:
-                - some-api-key
-            User-Agent:
-                - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/environments/evm-crfi7js8m55c703hl2fg
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 214
-        uncompressed: false
-        body: |
-            {"databasesIds":null,"envGroupIds":null,"id":"evm-crfi7js8m55c703hl2fg","name":"prod","projectId":"prj-crfi7js8m55c703hl2f0","protectedStatus":"protected","redisIds":["red-crfi7js8m55c703hl2h0"],"serviceIds":null}
-        headers:
-            Content-Length:
-                - "214"
-            Content-Type:
-                - application/json; charset=utf-8
-            Date:
-                - Mon, 09 Sep 2024 16:35:28 GMT
-            Ratelimit-Limit:
-                - "10000"
-            Ratelimit-Remaining:
-                - "9983"
-            Ratelimit-Reset:
-                - "31"
-            Referrer-Policy:
-                - same-origin
-            Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000151
-            Vary:
-                - Origin
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Xss-Protection:
-                - 1; mode=block
-        status: 200 OK
-        code: 200
-        duration: 37.430167ms
+        duration: 74.621375ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -549,7 +551,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/projects/prj-crfi7js8m55c703hl2g0
+        url: https://api.testing.render.com/v1/projects/prj-d8k3stdodlmc73btr2r0
         method: GET
       response:
         proto: HTTP/2.0
@@ -557,27 +559,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 286
+        content_length: 282
         uncompressed: false
         body: |
-            {"createdAt":"2024-09-09T16:35:27.450645Z","environmentIds":["evm-crfi7js8m55c703hl2gg"],"id":"prj-crfi7js8m55c703hl2g0","name":"second","owner":{"email":"email@example.com","id":"some-owner-id","name":"Test Terraform","type":"team"},"updatedAt":"2024-09-09T16:35:27.450645Z"}
+            {"createdAt":"2026-06-09T16:25:25.533574Z","environmentIds":["evm-d8k3stdodlmc73btr2s0"],"id":"prj-d8k3stdodlmc73btr2r0","name":"first","owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"updatedAt":"2026-06-09T16:25:25.533574Z"}
         headers:
             Content-Length:
-                - "286"
+                - "282"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:28 GMT
+                - Tue, 09 Jun 2026 16:25:27 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9982"
+                - "395"
             Ratelimit-Reset:
-                - "31"
+                - "32"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000152
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000758
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -588,7 +590,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 57.957209ms
+        duration: 94.565375ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -607,7 +609,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/environments/evm-crfi7js8m55c703hl2gg
+        url: https://api.testing.render.com/v1/key-value/red-d8k3stdodlmc73btr2q0
         method: GET
       response:
         proto: HTTP/2.0
@@ -615,27 +617,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 190
+        content_length: 422
         uncompressed: false
         body: |
-            {"databasesIds":null,"envGroupIds":null,"id":"evm-crfi7js8m55c703hl2gg","name":"prod","projectId":"prj-crfi7js8m55c703hl2g0","protectedStatus":"protected","redisIds":null,"serviceIds":null}
+            {"createdAt":"2026-06-09T16:25:25.489442Z","id":"red-d8k3stdodlmc73btr2q0","ipAllowList":null,"name":"test-keyvalue-paid","options":{"maxmemoryPolicy":"allkeys_lfu","persistenceMode":"journal_snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"starter","region":"oregon","status":"creating","updatedAt":"2026-06-09T16:25:25.489442Z","version":"8.1.4"}
         headers:
             Content-Length:
-                - "190"
+                - "422"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:28 GMT
+                - Tue, 09 Jun 2026 16:25:27 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9981"
+                - "394"
             Ratelimit-Reset:
-                - "31"
+                - "32"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000153
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000759
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -646,7 +648,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 39.032458ms
+        duration: 85.379375ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -665,7 +667,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/key-value/red-crfi7js8m55c703hl2h0
+        url: https://api.testing.render.com/v1/environments/evm-d8k3stdodlmc73btr2s0
         method: GET
       response:
         proto: HTTP/2.0
@@ -673,27 +675,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 516
+        content_length: 246
         uncompressed: false
         body: |
-            {"createdAt":"2024-09-09T16:35:27.64367Z","environmentId":"evm-crfi7js8m55c703hl2fg","id":"red-crfi7js8m55c703hl2h0","ipAllowList":[{"cidrBlock":"1.1.1.1/32","description":"test"},{"cidrBlock":"2.0.0.0/8","description":"test-2"}],"name":"test-keyvalue","options":{"maxmemoryPolicy":"allkeys_lfu"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"Test Terraform","type":"team"},"plan":"starter","region":"oregon","status":"creating","updatedAt":"2024-09-09T16:35:27.64367Z","version":"6.2.14"}
+            {"databasesIds":null,"envGroupIds":null,"id":"evm-d8k3stdodlmc73btr2s0","name":"prod","networkIsolationEnabled":false,"projectId":"prj-d8k3stdodlmc73btr2r0","protectedStatus":"protected","redisIds":["red-d8k3stlodlmc73btr2vg"],"serviceIds":null}
         headers:
             Content-Length:
-                - "516"
+                - "246"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:28 GMT
+                - Tue, 09 Jun 2026 16:25:27 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9980"
+                - "393"
             Ratelimit-Reset:
-                - "31"
+                - "32"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000154
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000760
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -704,7 +706,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 55.451416ms
+        duration: 66.027083ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -723,7 +725,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/key-value/red-crfi7js8m55c703hl2h0/connection-info
+        url: https://api.testing.render.com/v1/key-value/red-d8k3stdodlmc73btr2q0/connection-info
         method: GET
       response:
         proto: HTTP/2.0
@@ -731,27 +733,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 365
+        content_length: 367
         uncompressed: false
         body: |
-            {"externalConnectionString":"rediss://red-crfi7js8m55c703hl2h0:gIRSGDdOQriMcOCPQHj1durmcXvsgVqm@oregon-redis.localhost.render.com:6377","internalConnectionString":"redis://red-crfi7js8m55c703hl2h0:6379","cliCommand":" REDISCLI_AUTH=gIRSGDdOQriMcOCPQHj1durmcXvsgVqm valkey-cli --user red-crfi7js8m55c703hl2h0 -h oregon-redis.localhost.render.com -p 6377 --tls"}
+            {"cliCommand":" REDISCLI_AUTH=WaE4JEDy7ygZu0tOR8v73BR6mghAr1rG valkey-cli --user red-d8k3stdodlmc73btr2q0 -h oregon-keyvalue.localhost.render.com -p 6377 --tls","externalConnectionString":"rediss://red-d8k3stdodlmc73btr2q0:WaE4JEDy7ygZu0tOR8v73BR6mghAr1rG@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k3stdodlmc73btr2q0:6379"}
         headers:
             Content-Length:
-                - "365"
+                - "367"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:28 GMT
+                - Tue, 09 Jun 2026 16:25:27 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9979"
+                - "392"
             Ratelimit-Reset:
-                - "31"
+                - "32"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000155
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000761
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -762,7 +764,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 54.70275ms
+        duration: 66.119083ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -781,7 +783,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/logs/streams/resource/red-crfi7js8m55c703hl2h0
+        url: https://api.testing.render.com/v1/projects/prj-d8k3stlodlmc73btr2tg
         method: GET
       response:
         proto: HTTP/2.0
@@ -789,27 +791,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 73
+        content_length: 281
         uncompressed: false
         body: |
-            {"endpoint":"","resourceId":"red-crfi7js8m55c703hl2h0","setting":"drop"}
+            {"createdAt":"2026-06-09T16:25:26.03239Z","environmentIds":["evm-d8k3stlodlmc73btr2ug"],"id":"prj-d8k3stlodlmc73btr2tg","name":"second","owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"updatedAt":"2026-06-09T16:25:26.03239Z"}
         headers:
             Content-Length:
-                - "73"
+                - "281"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:28 GMT
+                - Tue, 09 Jun 2026 16:25:27 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9978"
+                - "391"
             Ratelimit-Reset:
-                - "31"
+                - "32"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000156
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000762
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -820,7 +822,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 52.137375ms
+        duration: 99.388625ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -839,7 +841,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/key-value/red-crfi7js8m55c703hl2h0
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8k3stdodlmc73btr2q0
         method: GET
       response:
         proto: HTTP/2.0
@@ -847,27 +849,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 516
+        content_length: 50
         uncompressed: false
         body: |
-            {"createdAt":"2024-09-09T16:35:27.64367Z","environmentId":"evm-crfi7js8m55c703hl2fg","id":"red-crfi7js8m55c703hl2h0","ipAllowList":[{"cidrBlock":"1.1.1.1/32","description":"test"},{"cidrBlock":"2.0.0.0/8","description":"test-2"}],"name":"test-keyvalue","options":{"maxmemoryPolicy":"allkeys_lfu"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"Test Terraform","type":"team"},"plan":"starter","region":"oregon","status":"creating","updatedAt":"2024-09-09T16:35:27.64367Z","version":"6.2.14"}
+            {"message":"not found: red-d8k3stdodlmc73btr2q0"}
         headers:
             Content-Length:
-                - "516"
+                - "50"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:28 GMT
+                - Tue, 09 Jun 2026 16:25:27 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9977"
+                - "390"
             Ratelimit-Reset:
-                - "31"
+                - "32"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000157
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000763
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -876,9 +878,9 @@ interactions:
                 - DENY
             X-Xss-Protection:
                 - 1; mode=block
-        status: 200 OK
-        code: 200
-        duration: 59.175ms
+        status: 404 Not Found
+        code: 404
+        duration: 52.054708ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -897,7 +899,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/key-value/red-crfi7js8m55c703hl2h0/connection-info
+        url: https://api.testing.render.com/v1/environments/evm-d8k3stlodlmc73btr2ug
         method: GET
       response:
         proto: HTTP/2.0
@@ -905,27 +907,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 365
+        content_length: 222
         uncompressed: false
         body: |
-            {"externalConnectionString":"rediss://red-crfi7js8m55c703hl2h0:gIRSGDdOQriMcOCPQHj1durmcXvsgVqm@oregon-redis.localhost.render.com:6377","internalConnectionString":"redis://red-crfi7js8m55c703hl2h0:6379","cliCommand":" REDISCLI_AUTH=gIRSGDdOQriMcOCPQHj1durmcXvsgVqm valkey-cli --user red-crfi7js8m55c703hl2h0 -h oregon-redis.localhost.render.com -p 6377 --tls"}
+            {"databasesIds":null,"envGroupIds":null,"id":"evm-d8k3stlodlmc73btr2ug","name":"prod","networkIsolationEnabled":false,"projectId":"prj-d8k3stlodlmc73btr2tg","protectedStatus":"protected","redisIds":null,"serviceIds":null}
         headers:
             Content-Length:
-                - "365"
+                - "222"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:28 GMT
+                - Tue, 09 Jun 2026 16:25:28 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9976"
+                - "389"
             Ratelimit-Reset:
                 - "31"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000158
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000764
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -936,7 +938,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 52.420791ms
+        duration: 67.556625ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -955,7 +957,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/logs/streams/resource/red-crfi7js8m55c703hl2h0
+        url: https://api.testing.render.com/v1/key-value/red-d8k3stlodlmc73btr2vg
         method: GET
       response:
         proto: HTTP/2.0
@@ -963,27 +965,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 73
+        content_length: 554
         uncompressed: false
         body: |
-            {"endpoint":"","resourceId":"red-crfi7js8m55c703hl2h0","setting":"drop"}
+            {"createdAt":"2026-06-09T16:25:26.405394Z","environmentId":"evm-d8k3stdodlmc73btr2s0","id":"red-d8k3stlodlmc73btr2vg","ipAllowList":[{"cidrBlock":"1.1.1.1/32","description":"test"},{"cidrBlock":"2.0.0.0/8","description":"test-2"}],"name":"test-keyvalue","options":{"maxmemoryPolicy":"allkeys_lfu","persistenceMode":"journal_snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"starter","region":"oregon","status":"creating","updatedAt":"2026-06-09T16:25:26.405394Z","version":"8.1.4"}
         headers:
             Content-Length:
-                - "73"
+                - "554"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:28 GMT
+                - Tue, 09 Jun 2026 16:25:28 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9975"
+                - "388"
             Ratelimit-Reset:
                 - "31"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000159
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000765
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -994,7 +996,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 48.333083ms
+        duration: 111.700958ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -1013,7 +1015,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/projects/prj-crfi7js8m55c703hl2f0
+        url: https://api.testing.render.com/v1/key-value/red-d8k3stlodlmc73btr2vg/connection-info
         method: GET
       response:
         proto: HTTP/2.0
@@ -1021,27 +1023,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 285
+        content_length: 367
         uncompressed: false
         body: |
-            {"createdAt":"2024-09-09T16:35:27.305482Z","environmentIds":["evm-crfi7js8m55c703hl2fg"],"id":"prj-crfi7js8m55c703hl2f0","name":"first","owner":{"email":"email@example.com","id":"some-owner-id","name":"Test Terraform","type":"team"},"updatedAt":"2024-09-09T16:35:27.305482Z"}
+            {"cliCommand":" REDISCLI_AUTH=J1Nn3zNY0GwZ2Pspo6Tno4kVBYanCegk valkey-cli --user red-d8k3stlodlmc73btr2vg -h oregon-keyvalue.localhost.render.com -p 6377 --tls","externalConnectionString":"rediss://red-d8k3stlodlmc73btr2vg:J1Nn3zNY0GwZ2Pspo6Tno4kVBYanCegk@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k3stlodlmc73btr2vg:6379"}
         headers:
             Content-Length:
-                - "285"
+                - "367"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:29 GMT
+                - Tue, 09 Jun 2026 16:25:28 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9974"
+                - "387"
             Ratelimit-Reset:
-                - "30"
+                - "31"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000160
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000766
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1052,7 +1054,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 57.213625ms
+        duration: 85.934667ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -1071,7 +1073,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/environments/evm-crfi7js8m55c703hl2fg
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8k3stlodlmc73btr2vg
         method: GET
       response:
         proto: HTTP/2.0
@@ -1079,27 +1081,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 214
+        content_length: 73
         uncompressed: false
         body: |
-            {"databasesIds":null,"envGroupIds":null,"id":"evm-crfi7js8m55c703hl2fg","name":"prod","projectId":"prj-crfi7js8m55c703hl2f0","protectedStatus":"protected","redisIds":["red-crfi7js8m55c703hl2h0"],"serviceIds":null}
+            {"endpoint":"","resourceId":"red-d8k3stlodlmc73btr2vg","setting":"drop"}
         headers:
             Content-Length:
-                - "214"
+                - "73"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:29 GMT
+                - Tue, 09 Jun 2026 16:25:28 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9973"
+                - "386"
             Ratelimit-Reset:
-                - "30"
+                - "31"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000161
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000767
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1110,7 +1112,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 35.155291ms
+        duration: 87.082958ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -1129,7 +1131,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/projects/prj-crfi7js8m55c703hl2g0
+        url: https://api.testing.render.com/v1/key-value/red-d8k3stlodlmc73btr2vg
         method: GET
       response:
         proto: HTTP/2.0
@@ -1137,27 +1139,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 286
+        content_length: 554
         uncompressed: false
         body: |
-            {"createdAt":"2024-09-09T16:35:27.450645Z","environmentIds":["evm-crfi7js8m55c703hl2gg"],"id":"prj-crfi7js8m55c703hl2g0","name":"second","owner":{"email":"email@example.com","id":"some-owner-id","name":"Test Terraform","type":"team"},"updatedAt":"2024-09-09T16:35:27.450645Z"}
+            {"createdAt":"2026-06-09T16:25:26.405394Z","environmentId":"evm-d8k3stdodlmc73btr2s0","id":"red-d8k3stlodlmc73btr2vg","ipAllowList":[{"cidrBlock":"1.1.1.1/32","description":"test"},{"cidrBlock":"2.0.0.0/8","description":"test-2"}],"name":"test-keyvalue","options":{"maxmemoryPolicy":"allkeys_lfu","persistenceMode":"journal_snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"starter","region":"oregon","status":"creating","updatedAt":"2026-06-09T16:25:26.405394Z","version":"8.1.4"}
         headers:
             Content-Length:
-                - "286"
+                - "554"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:29 GMT
+                - Tue, 09 Jun 2026 16:25:28 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9972"
+                - "385"
             Ratelimit-Reset:
-                - "30"
+                - "31"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000162
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000768
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1168,7 +1170,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 52.636792ms
+        duration: 111.453208ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1187,7 +1189,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/environments/evm-crfi7js8m55c703hl2gg
+        url: https://api.testing.render.com/v1/key-value/red-d8k3stlodlmc73btr2vg/connection-info
         method: GET
       response:
         proto: HTTP/2.0
@@ -1195,27 +1197,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 190
+        content_length: 367
         uncompressed: false
         body: |
-            {"databasesIds":null,"envGroupIds":null,"id":"evm-crfi7js8m55c703hl2gg","name":"prod","projectId":"prj-crfi7js8m55c703hl2g0","protectedStatus":"protected","redisIds":null,"serviceIds":null}
+            {"cliCommand":" REDISCLI_AUTH=J1Nn3zNY0GwZ2Pspo6Tno4kVBYanCegk valkey-cli --user red-d8k3stlodlmc73btr2vg -h oregon-keyvalue.localhost.render.com -p 6377 --tls","externalConnectionString":"rediss://red-d8k3stlodlmc73btr2vg:J1Nn3zNY0GwZ2Pspo6Tno4kVBYanCegk@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k3stlodlmc73btr2vg:6379"}
         headers:
             Content-Length:
-                - "190"
+                - "367"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:29 GMT
+                - Tue, 09 Jun 2026 16:25:29 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9971"
+                - "384"
             Ratelimit-Reset:
-                - "30"
+                - "31"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000163
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000769
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1226,7 +1228,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 37.055417ms
+        duration: 90.046375ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1245,7 +1247,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/key-value/red-crfi7js8m55c703hl2h0
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8k3stlodlmc73btr2vg
         method: GET
       response:
         proto: HTTP/2.0
@@ -1253,27 +1255,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 516
+        content_length: 73
         uncompressed: false
         body: |
-            {"createdAt":"2024-09-09T16:35:27.64367Z","environmentId":"evm-crfi7js8m55c703hl2fg","id":"red-crfi7js8m55c703hl2h0","ipAllowList":[{"cidrBlock":"1.1.1.1/32","description":"test"},{"cidrBlock":"2.0.0.0/8","description":"test-2"}],"name":"test-keyvalue","options":{"maxmemoryPolicy":"allkeys_lfu"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"Test Terraform","type":"team"},"plan":"starter","region":"oregon","status":"creating","updatedAt":"2024-09-09T16:35:27.64367Z","version":"6.2.14"}
+            {"endpoint":"","resourceId":"red-d8k3stlodlmc73btr2vg","setting":"drop"}
         headers:
             Content-Length:
-                - "516"
+                - "73"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:29 GMT
+                - Tue, 09 Jun 2026 16:25:29 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9970"
+                - "383"
             Ratelimit-Reset:
                 - "30"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000164
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000770
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1284,7 +1286,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 74.7005ms
+        duration: 86.779041ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1303,7 +1305,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/key-value/red-crfi7js8m55c703hl2h0/connection-info
+        url: https://api.testing.render.com/v1/projects/prj-d8k3stdodlmc73btr2r0
         method: GET
       response:
         proto: HTTP/2.0
@@ -1311,27 +1313,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 365
+        content_length: 282
         uncompressed: false
         body: |
-            {"externalConnectionString":"rediss://red-crfi7js8m55c703hl2h0:gIRSGDdOQriMcOCPQHj1durmcXvsgVqm@oregon-redis.localhost.render.com:6377","internalConnectionString":"redis://red-crfi7js8m55c703hl2h0:6379","cliCommand":" REDISCLI_AUTH=gIRSGDdOQriMcOCPQHj1durmcXvsgVqm valkey-cli --user red-crfi7js8m55c703hl2h0 -h oregon-redis.localhost.render.com -p 6377 --tls"}
+            {"createdAt":"2026-06-09T16:25:25.533574Z","environmentIds":["evm-d8k3stdodlmc73btr2s0"],"id":"prj-d8k3stdodlmc73btr2r0","name":"first","owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"updatedAt":"2026-06-09T16:25:25.533574Z"}
         headers:
             Content-Length:
-                - "365"
+                - "282"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:29 GMT
+                - Tue, 09 Jun 2026 16:25:29 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9969"
+                - "382"
             Ratelimit-Reset:
                 - "30"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000165
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000771
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1342,7 +1344,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 46.818667ms
+        duration: 98.08475ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1361,7 +1363,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/logs/streams/resource/red-crfi7js8m55c703hl2h0
+        url: https://api.testing.render.com/v1/key-value/red-d8k3stdodlmc73btr2q0
         method: GET
       response:
         proto: HTTP/2.0
@@ -1369,27 +1371,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 73
+        content_length: 422
         uncompressed: false
         body: |
-            {"endpoint":"","resourceId":"red-crfi7js8m55c703hl2h0","setting":"drop"}
+            {"createdAt":"2026-06-09T16:25:25.489442Z","id":"red-d8k3stdodlmc73btr2q0","ipAllowList":null,"name":"test-keyvalue-paid","options":{"maxmemoryPolicy":"allkeys_lfu","persistenceMode":"journal_snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"starter","region":"oregon","status":"creating","updatedAt":"2026-06-09T16:25:25.489442Z","version":"8.1.4"}
         headers:
             Content-Length:
-                - "73"
+                - "422"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:29 GMT
+                - Tue, 09 Jun 2026 16:25:29 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9968"
+                - "381"
             Ratelimit-Reset:
                 - "30"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000166
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000772
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1400,56 +1402,54 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 50.907584ms
+        duration: 94.818125ms
     - id: 24
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 91
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: https://api.testing.render.com/v1
         remote_addr: ""
         request_uri: ""
-        body: '{"ipAllowList":[],"maxmemoryPolicy":"noeviction","name":"test-keyvalue-new","plan":"standard"}'
+        body: ""
         form: {}
         headers:
             Authorization:
                 - some-api-key
-            Content-Type:
-                - application/json
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/key-value/red-crfi7js8m55c703hl2h0
-        method: PATCH
+        url: https://api.testing.render.com/v1/environments/evm-d8k3stdodlmc73btr2s0
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 427
+        content_length: 246
         uncompressed: false
         body: |
-            {"createdAt":"2024-09-09T16:35:27.64367Z","environmentId":"evm-crfi7js8m55c703hl2fg","id":"red-crfi7js8m55c703hl2h0","ipAllowList":null,"name":"test-keyvalue-new","options":{"maxmemoryPolicy":"noeviction"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"Test Terraform","type":"team"},"plan":"standard","region":"oregon","status":"creating","updatedAt":"2024-09-09T16:35:29.577498Z","version":"6.2.14"}
+            {"databasesIds":null,"envGroupIds":null,"id":"evm-d8k3stdodlmc73btr2s0","name":"prod","networkIsolationEnabled":false,"projectId":"prj-d8k3stdodlmc73btr2r0","protectedStatus":"protected","redisIds":["red-d8k3stlodlmc73btr2vg"],"serviceIds":null}
         headers:
             Content-Length:
-                - "427"
+                - "246"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:29 GMT
+                - Tue, 09 Jun 2026 16:25:29 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9995"
+                - "380"
             Ratelimit-Reset:
                 - "30"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000167
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000773
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1460,7 +1460,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 175.396375ms
+        duration: 68.456708ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1479,7 +1479,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/key-value/red-crfi7js8m55c703hl2h0/connection-info
+        url: https://api.testing.render.com/v1/key-value/red-d8k3stdodlmc73btr2q0/connection-info
         method: GET
       response:
         proto: HTTP/2.0
@@ -1487,27 +1487,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 365
+        content_length: 367
         uncompressed: false
         body: |
-            {"externalConnectionString":"rediss://red-crfi7js8m55c703hl2h0:gIRSGDdOQriMcOCPQHj1durmcXvsgVqm@oregon-redis.localhost.render.com:6377","internalConnectionString":"redis://red-crfi7js8m55c703hl2h0:6379","cliCommand":" REDISCLI_AUTH=gIRSGDdOQriMcOCPQHj1durmcXvsgVqm valkey-cli --user red-crfi7js8m55c703hl2h0 -h oregon-redis.localhost.render.com -p 6377 --tls"}
+            {"cliCommand":" REDISCLI_AUTH=WaE4JEDy7ygZu0tOR8v73BR6mghAr1rG valkey-cli --user red-d8k3stdodlmc73btr2q0 -h oregon-keyvalue.localhost.render.com -p 6377 --tls","externalConnectionString":"rediss://red-d8k3stdodlmc73btr2q0:WaE4JEDy7ygZu0tOR8v73BR6mghAr1rG@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k3stdodlmc73btr2q0:6379"}
         headers:
             Content-Length:
-                - "365"
+                - "367"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:29 GMT
+                - Tue, 09 Jun 2026 16:25:29 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9967"
+                - "379"
             Ratelimit-Reset:
                 - "30"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000168
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000774
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1518,7 +1518,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 50.571ms
+        duration: 72.186125ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1537,30 +1537,35 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/logs/streams/resource/red-crfi7js8m55c703hl2h0
-        method: DELETE
+        url: https://api.testing.render.com/v1/projects/prj-d8k3stlodlmc73btr2tg
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 281
         uncompressed: false
-        body: ""
+        body: |
+            {"createdAt":"2026-06-09T16:25:26.03239Z","environmentIds":["evm-d8k3stlodlmc73btr2ug"],"id":"prj-d8k3stlodlmc73btr2tg","name":"second","owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"updatedAt":"2026-06-09T16:25:26.03239Z"}
         headers:
+            Content-Length:
+                - "281"
+            Content-Type:
+                - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:29 GMT
+                - Tue, 09 Jun 2026 16:25:30 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9994"
+                - "378"
             Ratelimit-Reset:
-                - "30"
+                - "29"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000169
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000775
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1569,9 +1574,9 @@ interactions:
                 - DENY
             X-Xss-Protection:
                 - 1; mode=block
-        status: 204 No Content
-        code: 204
-        duration: 51.482583ms
+        status: 200 OK
+        code: 200
+        duration: 110.558ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1590,30 +1595,35 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/environments/red-crfi7js8m55c703hl2h0/resources?resourceIds=red-crfi7js8m55c703hl2h0
-        method: DELETE
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8k3stdodlmc73btr2q0
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 50
         uncompressed: false
-        body: ""
+        body: |
+            {"message":"not found: red-d8k3stdodlmc73btr2q0"}
         headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:29 GMT
+                - Tue, 09 Jun 2026 16:25:30 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9993"
+                - "377"
             Ratelimit-Reset:
-                - "30"
+                - "29"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000170
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000776
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1622,58 +1632,56 @@ interactions:
                 - DENY
             X-Xss-Protection:
                 - 1; mode=block
-        status: 204 No Content
-        code: 204
-        duration: 64.240417ms
+        status: 404 Not Found
+        code: 404
+        duration: 53.447708ms
     - id: 28
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 44
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: https://api.testing.render.com/v1
         remote_addr: ""
         request_uri: ""
-        body: '{"resourceIds":["red-crfi7js8m55c703hl2h0"]}'
+        body: ""
         form: {}
         headers:
             Authorization:
                 - some-api-key
-            Content-Type:
-                - application/json
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/environments/evm-crfi7js8m55c703hl2gg/resources
-        method: POST
+        url: https://api.testing.render.com/v1/environments/evm-d8k3stlodlmc73btr2ug
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 214
+        content_length: 222
         uncompressed: false
         body: |
-            {"databasesIds":null,"envGroupIds":null,"id":"evm-crfi7js8m55c703hl2gg","name":"prod","projectId":"prj-crfi7js8m55c703hl2g0","protectedStatus":"protected","redisIds":["red-crfi7js8m55c703hl2h0"],"serviceIds":null}
+            {"databasesIds":null,"envGroupIds":null,"id":"evm-d8k3stlodlmc73btr2ug","name":"prod","networkIsolationEnabled":false,"projectId":"prj-d8k3stlodlmc73btr2tg","protectedStatus":"protected","redisIds":null,"serviceIds":null}
         headers:
             Content-Length:
-                - "214"
+                - "222"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:29 GMT
+                - Tue, 09 Jun 2026 16:25:30 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9992"
+                - "376"
             Ratelimit-Reset:
-                - "30"
+                - "29"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000171
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000777
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1682,9 +1690,9 @@ interactions:
                 - DENY
             X-Xss-Protection:
                 - 1; mode=block
-        status: 201 Created
-        code: 201
-        duration: 88.095459ms
+        status: 200 OK
+        code: 200
+        duration: 67.092542ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1703,7 +1711,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/projects/prj-crfi7js8m55c703hl2f0
+        url: https://api.testing.render.com/v1/key-value/red-d8k3stlodlmc73btr2vg
         method: GET
       response:
         proto: HTTP/2.0
@@ -1711,27 +1719,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 285
+        content_length: 554
         uncompressed: false
         body: |
-            {"createdAt":"2024-09-09T16:35:27.305482Z","environmentIds":["evm-crfi7js8m55c703hl2fg"],"id":"prj-crfi7js8m55c703hl2f0","name":"first","owner":{"email":"email@example.com","id":"some-owner-id","name":"Test Terraform","type":"team"},"updatedAt":"2024-09-09T16:35:27.305482Z"}
+            {"createdAt":"2026-06-09T16:25:26.405394Z","environmentId":"evm-d8k3stdodlmc73btr2s0","id":"red-d8k3stlodlmc73btr2vg","ipAllowList":[{"cidrBlock":"1.1.1.1/32","description":"test"},{"cidrBlock":"2.0.0.0/8","description":"test-2"}],"name":"test-keyvalue","options":{"maxmemoryPolicy":"allkeys_lfu","persistenceMode":"journal_snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"starter","region":"oregon","status":"creating","updatedAt":"2026-06-09T16:25:26.405394Z","version":"8.1.4"}
         headers:
             Content-Length:
-                - "285"
+                - "554"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:30 GMT
+                - Tue, 09 Jun 2026 16:25:30 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9966"
+                - "375"
             Ratelimit-Reset:
                 - "29"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000172
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000778
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1742,7 +1750,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 60.280292ms
+        duration: 117.784833ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1761,7 +1769,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/environments/evm-crfi7js8m55c703hl2fg
+        url: https://api.testing.render.com/v1/key-value/red-d8k3stlodlmc73btr2vg/connection-info
         method: GET
       response:
         proto: HTTP/2.0
@@ -1769,27 +1777,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 190
+        content_length: 367
         uncompressed: false
         body: |
-            {"databasesIds":null,"envGroupIds":null,"id":"evm-crfi7js8m55c703hl2fg","name":"prod","projectId":"prj-crfi7js8m55c703hl2f0","protectedStatus":"protected","redisIds":null,"serviceIds":null}
+            {"cliCommand":" REDISCLI_AUTH=J1Nn3zNY0GwZ2Pspo6Tno4kVBYanCegk valkey-cli --user red-d8k3stlodlmc73btr2vg -h oregon-keyvalue.localhost.render.com -p 6377 --tls","externalConnectionString":"rediss://red-d8k3stlodlmc73btr2vg:J1Nn3zNY0GwZ2Pspo6Tno4kVBYanCegk@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k3stlodlmc73btr2vg:6379"}
         headers:
             Content-Length:
-                - "190"
+                - "367"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:30 GMT
+                - Tue, 09 Jun 2026 16:25:30 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9965"
+                - "374"
             Ratelimit-Reset:
                 - "29"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000173
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000779
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1800,7 +1808,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 36.725375ms
+        duration: 82.739125ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1819,7 +1827,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/projects/prj-crfi7js8m55c703hl2g0
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8k3stlodlmc73btr2vg
         method: GET
       response:
         proto: HTTP/2.0
@@ -1827,27 +1835,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 286
+        content_length: 73
         uncompressed: false
         body: |
-            {"createdAt":"2024-09-09T16:35:27.450645Z","environmentIds":["evm-crfi7js8m55c703hl2gg"],"id":"prj-crfi7js8m55c703hl2g0","name":"second","owner":{"email":"email@example.com","id":"some-owner-id","name":"Test Terraform","type":"team"},"updatedAt":"2024-09-09T16:35:27.450645Z"}
+            {"endpoint":"","resourceId":"red-d8k3stlodlmc73btr2vg","setting":"drop"}
         headers:
             Content-Length:
-                - "286"
+                - "73"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:30 GMT
+                - Tue, 09 Jun 2026 16:25:30 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9964"
+                - "373"
             Ratelimit-Reset:
                 - "29"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000174
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000780
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1858,54 +1866,56 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 59.267083ms
+        duration: 82.940833ms
     - id: 32
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 123
         transfer_encoding: []
         trailer: {}
         host: https://api.testing.render.com/v1
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"ipAllowList":[],"maxmemoryPolicy":"noeviction","name":"test-keyvalue-new","persistenceMode":"snapshot","plan":"standard"}'
         form: {}
         headers:
             Authorization:
                 - some-api-key
+            Content-Type:
+                - application/json
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/environments/evm-crfi7js8m55c703hl2gg
-        method: GET
+        url: https://api.testing.render.com/v1/key-value/red-d8k3stlodlmc73btr2vg
+        method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 214
+        content_length: 456
         uncompressed: false
         body: |
-            {"databasesIds":null,"envGroupIds":null,"id":"evm-crfi7js8m55c703hl2gg","name":"prod","projectId":"prj-crfi7js8m55c703hl2g0","protectedStatus":"protected","redisIds":["red-crfi7js8m55c703hl2h0"],"serviceIds":null}
+            {"createdAt":"2026-06-09T16:25:26.405394Z","environmentId":"evm-d8k3stdodlmc73btr2s0","id":"red-d8k3stlodlmc73btr2vg","ipAllowList":null,"name":"test-keyvalue-new","options":{"maxmemoryPolicy":"noeviction","persistenceMode":"snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"standard","region":"oregon","status":"creating","updatedAt":"2026-06-09T16:25:31.182967Z","version":"8.1.4"}
         headers:
             Content-Length:
-                - "214"
+                - "456"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:30 GMT
+                - Tue, 09 Jun 2026 16:25:31 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "100"
             Ratelimit-Remaining:
-                - "9963"
+                - "96"
             Ratelimit-Reset:
-                - "29"
+                - "28"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000175
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000781
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1916,7 +1926,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 35.862083ms
+        duration: 474.559334ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1935,7 +1945,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/key-value/red-crfi7js8m55c703hl2h0
+        url: https://api.testing.render.com/v1/key-value/red-d8k3stlodlmc73btr2vg/connection-info
         method: GET
       response:
         proto: HTTP/2.0
@@ -1943,27 +1953,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 427
+        content_length: 367
         uncompressed: false
         body: |
-            {"createdAt":"2024-09-09T16:35:27.64367Z","environmentId":"evm-crfi7js8m55c703hl2gg","id":"red-crfi7js8m55c703hl2h0","ipAllowList":null,"name":"test-keyvalue-new","options":{"maxmemoryPolicy":"noeviction"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"Test Terraform","type":"team"},"plan":"standard","region":"oregon","status":"creating","updatedAt":"2024-09-09T16:35:29.885293Z","version":"6.2.14"}
+            {"cliCommand":" REDISCLI_AUTH=J1Nn3zNY0GwZ2Pspo6Tno4kVBYanCegk valkey-cli --user red-d8k3stlodlmc73btr2vg -h oregon-keyvalue.localhost.render.com -p 6377 --tls","externalConnectionString":"rediss://red-d8k3stlodlmc73btr2vg:J1Nn3zNY0GwZ2Pspo6Tno4kVBYanCegk@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k3stlodlmc73btr2vg:6379"}
         headers:
             Content-Length:
-                - "427"
+                - "367"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:30 GMT
+                - Tue, 09 Jun 2026 16:25:31 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9962"
+                - "372"
             Ratelimit-Reset:
-                - "29"
+                - "28"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000176
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000782
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1974,7 +1984,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 55.817083ms
+        duration: 87.1975ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1993,35 +2003,30 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/key-value/red-crfi7js8m55c703hl2h0/connection-info
-        method: GET
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8k3stlodlmc73btr2vg
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 365
+        content_length: 0
         uncompressed: false
-        body: |
-            {"externalConnectionString":"rediss://red-crfi7js8m55c703hl2h0:gIRSGDdOQriMcOCPQHj1durmcXvsgVqm@oregon-redis.localhost.render.com:6377","internalConnectionString":"redis://red-crfi7js8m55c703hl2h0:6379","cliCommand":" REDISCLI_AUTH=gIRSGDdOQriMcOCPQHj1durmcXvsgVqm valkey-cli --user red-crfi7js8m55c703hl2h0 -h oregon-redis.localhost.render.com -p 6377 --tls"}
+        body: ""
         headers:
-            Content-Length:
-                - "365"
-            Content-Type:
-                - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:30 GMT
+                - Tue, 09 Jun 2026 16:25:31 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "100"
             Ratelimit-Remaining:
-                - "9961"
+                - "95"
             Ratelimit-Reset:
-                - "29"
+                - "28"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000177
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000783
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2030,9 +2035,9 @@ interactions:
                 - DENY
             X-Xss-Protection:
                 - 1; mode=block
-        status: 200 OK
-        code: 200
-        duration: 51.258791ms
+        status: 204 No Content
+        code: 204
+        duration: 75.963875ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -2051,35 +2056,30 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/logs/streams/resource/red-crfi7js8m55c703hl2h0
-        method: GET
+        url: https://api.testing.render.com/v1/environments/red-d8k3stlodlmc73btr2vg/resources?resourceIds=red-d8k3stlodlmc73btr2vg
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 50
+        content_length: 0
         uncompressed: false
-        body: |
-            {"message":"not found: red-crfi7js8m55c703hl2h0"}
+        body: ""
         headers:
-            Content-Length:
-                - "50"
-            Content-Type:
-                - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:30 GMT
+                - Tue, 09 Jun 2026 16:25:31 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "100"
             Ratelimit-Remaining:
-                - "9960"
+                - "94"
             Ratelimit-Reset:
-                - "29"
+                - "28"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000178
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000784
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2088,56 +2088,58 @@ interactions:
                 - DENY
             X-Xss-Protection:
                 - 1; mode=block
-        status: 404 Not Found
-        code: 404
-        duration: 33.894542ms
+        status: 204 No Content
+        code: 204
+        duration: 93.07325ms
     - id: 36
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 44
         transfer_encoding: []
         trailer: {}
         host: https://api.testing.render.com/v1
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"resourceIds":["red-d8k3stlodlmc73btr2vg"]}'
         form: {}
         headers:
             Authorization:
                 - some-api-key
+            Content-Type:
+                - application/json
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/projects/prj-crfi7js8m55c703hl2f0
-        method: GET
+        url: https://api.testing.render.com/v1/environments/evm-d8k3stlodlmc73btr2ug/resources
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 285
+        content_length: 246
         uncompressed: false
         body: |
-            {"createdAt":"2024-09-09T16:35:27.305482Z","environmentIds":["evm-crfi7js8m55c703hl2fg"],"id":"prj-crfi7js8m55c703hl2f0","name":"first","owner":{"email":"email@example.com","id":"some-owner-id","name":"Test Terraform","type":"team"},"updatedAt":"2024-09-09T16:35:27.305482Z"}
+            {"databasesIds":null,"envGroupIds":null,"id":"evm-d8k3stlodlmc73btr2ug","name":"prod","networkIsolationEnabled":false,"projectId":"prj-d8k3stlodlmc73btr2tg","protectedStatus":"protected","redisIds":["red-d8k3stlodlmc73btr2vg"],"serviceIds":null}
         headers:
             Content-Length:
-                - "285"
+                - "246"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:30 GMT
+                - Tue, 09 Jun 2026 16:25:32 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "100"
             Ratelimit-Remaining:
-                - "9959"
+                - "93"
             Ratelimit-Reset:
-                - "29"
+                - "27"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000179
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000785
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2146,9 +2148,9 @@ interactions:
                 - DENY
             X-Xss-Protection:
                 - 1; mode=block
-        status: 200 OK
-        code: 200
-        duration: 53.741458ms
+        status: 201 Created
+        code: 201
+        duration: 131.830041ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -2167,7 +2169,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/environments/evm-crfi7js8m55c703hl2fg
+        url: https://api.testing.render.com/v1/key-value/red-d8k3stdodlmc73btr2q0
         method: GET
       response:
         proto: HTTP/2.0
@@ -2175,27 +2177,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 190
+        content_length: 422
         uncompressed: false
         body: |
-            {"databasesIds":null,"envGroupIds":null,"id":"evm-crfi7js8m55c703hl2fg","name":"prod","projectId":"prj-crfi7js8m55c703hl2f0","protectedStatus":"protected","redisIds":null,"serviceIds":null}
+            {"createdAt":"2026-06-09T16:25:25.489442Z","id":"red-d8k3stdodlmc73btr2q0","ipAllowList":null,"name":"test-keyvalue-paid","options":{"maxmemoryPolicy":"allkeys_lfu","persistenceMode":"journal_snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"starter","region":"oregon","status":"creating","updatedAt":"2026-06-09T16:25:25.489442Z","version":"8.1.4"}
         headers:
             Content-Length:
-                - "190"
+                - "422"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:30 GMT
+                - Tue, 09 Jun 2026 16:25:32 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9958"
+                - "371"
             Ratelimit-Reset:
-                - "29"
+                - "27"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000180
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000786
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2206,7 +2208,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 41.849834ms
+        duration: 79.902625ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -2225,7 +2227,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/projects/prj-crfi7js8m55c703hl2g0
+        url: https://api.testing.render.com/v1/projects/prj-d8k3stdodlmc73btr2r0
         method: GET
       response:
         proto: HTTP/2.0
@@ -2233,27 +2235,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 286
+        content_length: 282
         uncompressed: false
         body: |
-            {"createdAt":"2024-09-09T16:35:27.450645Z","environmentIds":["evm-crfi7js8m55c703hl2gg"],"id":"prj-crfi7js8m55c703hl2g0","name":"second","owner":{"email":"email@example.com","id":"some-owner-id","name":"Test Terraform","type":"team"},"updatedAt":"2024-09-09T16:35:27.450645Z"}
+            {"createdAt":"2026-06-09T16:25:25.533574Z","environmentIds":["evm-d8k3stdodlmc73btr2s0"],"id":"prj-d8k3stdodlmc73btr2r0","name":"first","owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"updatedAt":"2026-06-09T16:25:25.533574Z"}
         headers:
             Content-Length:
-                - "286"
+                - "282"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:30 GMT
+                - Tue, 09 Jun 2026 16:25:32 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9957"
+                - "370"
             Ratelimit-Reset:
-                - "29"
+                - "27"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000181
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000787
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2264,7 +2266,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 58.923833ms
+        duration: 99.253375ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -2283,7 +2285,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/environments/evm-crfi7js8m55c703hl2gg
+        url: https://api.testing.render.com/v1/key-value/red-d8k3stdodlmc73btr2q0/connection-info
         method: GET
       response:
         proto: HTTP/2.0
@@ -2291,27 +2293,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 214
+        content_length: 367
         uncompressed: false
         body: |
-            {"databasesIds":null,"envGroupIds":null,"id":"evm-crfi7js8m55c703hl2gg","name":"prod","projectId":"prj-crfi7js8m55c703hl2g0","protectedStatus":"protected","redisIds":["red-crfi7js8m55c703hl2h0"],"serviceIds":null}
+            {"cliCommand":" REDISCLI_AUTH=WaE4JEDy7ygZu0tOR8v73BR6mghAr1rG valkey-cli --user red-d8k3stdodlmc73btr2q0 -h oregon-keyvalue.localhost.render.com -p 6377 --tls","externalConnectionString":"rediss://red-d8k3stdodlmc73btr2q0:WaE4JEDy7ygZu0tOR8v73BR6mghAr1rG@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k3stdodlmc73btr2q0:6379"}
         headers:
             Content-Length:
-                - "214"
+                - "367"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:30 GMT
+                - Tue, 09 Jun 2026 16:25:32 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9956"
+                - "369"
             Ratelimit-Reset:
-                - "29"
+                - "27"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000182
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000788
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2322,7 +2324,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 37.673542ms
+        duration: 67.446209ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -2341,7 +2343,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/key-value/red-crfi7js8m55c703hl2h0
+        url: https://api.testing.render.com/v1/environments/evm-d8k3stdodlmc73btr2s0
         method: GET
       response:
         proto: HTTP/2.0
@@ -2349,27 +2351,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 427
+        content_length: 222
         uncompressed: false
         body: |
-            {"createdAt":"2024-09-09T16:35:27.64367Z","environmentId":"evm-crfi7js8m55c703hl2gg","id":"red-crfi7js8m55c703hl2h0","ipAllowList":null,"name":"test-keyvalue-new","options":{"maxmemoryPolicy":"noeviction"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"Test Terraform","type":"team"},"plan":"standard","region":"oregon","status":"creating","updatedAt":"2024-09-09T16:35:29.885293Z","version":"6.2.14"}
+            {"databasesIds":null,"envGroupIds":null,"id":"evm-d8k3stdodlmc73btr2s0","name":"prod","networkIsolationEnabled":false,"projectId":"prj-d8k3stdodlmc73btr2r0","protectedStatus":"protected","redisIds":null,"serviceIds":null}
         headers:
             Content-Length:
-                - "427"
+                - "222"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:30 GMT
+                - Tue, 09 Jun 2026 16:25:32 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9955"
+                - "368"
             Ratelimit-Reset:
-                - "29"
+                - "27"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000183
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000789
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2380,7 +2382,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 55.740833ms
+        duration: 69.650084ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2399,7 +2401,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/key-value/red-crfi7js8m55c703hl2h0/connection-info
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8k3stdodlmc73btr2q0
         method: GET
       response:
         proto: HTTP/2.0
@@ -2407,27 +2409,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 365
+        content_length: 50
         uncompressed: false
         body: |
-            {"externalConnectionString":"rediss://red-crfi7js8m55c703hl2h0:gIRSGDdOQriMcOCPQHj1durmcXvsgVqm@oregon-redis.localhost.render.com:6377","internalConnectionString":"redis://red-crfi7js8m55c703hl2h0:6379","cliCommand":" REDISCLI_AUTH=gIRSGDdOQriMcOCPQHj1durmcXvsgVqm valkey-cli --user red-crfi7js8m55c703hl2h0 -h oregon-redis.localhost.render.com -p 6377 --tls"}
+            {"message":"not found: red-d8k3stdodlmc73btr2q0"}
         headers:
             Content-Length:
-                - "365"
+                - "50"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:30 GMT
+                - Tue, 09 Jun 2026 16:25:33 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9954"
+                - "367"
             Ratelimit-Reset:
-                - "29"
+                - "26"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000184
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000790
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2436,9 +2438,9 @@ interactions:
                 - DENY
             X-Xss-Protection:
                 - 1; mode=block
-        status: 200 OK
-        code: 200
-        duration: 49.450459ms
+        status: 404 Not Found
+        code: 404
+        duration: 52.144417ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2457,7 +2459,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/logs/streams/resource/red-crfi7js8m55c703hl2h0
+        url: https://api.testing.render.com/v1/projects/prj-d8k3stlodlmc73btr2tg
         method: GET
       response:
         proto: HTTP/2.0
@@ -2465,87 +2467,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 50
+        content_length: 281
         uncompressed: false
         body: |
-            {"message":"not found: red-crfi7js8m55c703hl2h0"}
+            {"createdAt":"2026-06-09T16:25:26.03239Z","environmentIds":["evm-d8k3stlodlmc73btr2ug"],"id":"prj-d8k3stlodlmc73btr2tg","name":"second","owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"updatedAt":"2026-06-09T16:25:26.03239Z"}
         headers:
             Content-Length:
-                - "50"
+                - "281"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:30 GMT
+                - Tue, 09 Jun 2026 16:25:33 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9953"
+                - "366"
             Ratelimit-Reset:
-                - "29"
+                - "26"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000185
-            Vary:
-                - Origin
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Xss-Protection:
-                - 1; mode=block
-        status: 404 Not Found
-        code: 404
-        duration: 36.42925ms
-    - id: 43
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 187
-        transfer_encoding: []
-        trailer: {}
-        host: https://api.testing.render.com/v1
-        remote_addr: ""
-        request_uri: ""
-        body: '{"ipAllowList":[{"cidrBlock":"1.1.1.1/32","description":"test"},{"cidrBlock":"2.0.0.0/8","description":"test-2"}],"maxmemoryPolicy":"noeviction","name":"test-keyvalue-new","plan":"standard"}'
-        form: {}
-        headers:
-            Authorization:
-                - some-api-key
-            Content-Type:
-                - application/json
-            User-Agent:
-                - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/key-value/red-crfi7js8m55c703hl2h0
-        method: PATCH
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 521
-        uncompressed: false
-        body: |
-            {"createdAt":"2024-09-09T16:35:27.64367Z","environmentId":"evm-crfi7js8m55c703hl2gg","id":"red-crfi7js8m55c703hl2h0","ipAllowList":[{"cidrBlock":"1.1.1.1/32","description":"test"},{"cidrBlock":"2.0.0.0/8","description":"test-2"}],"name":"test-keyvalue-new","options":{"maxmemoryPolicy":"noeviction"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"Test Terraform","type":"team"},"plan":"standard","region":"oregon","status":"creating","updatedAt":"2024-09-09T16:35:31.240641Z","version":"6.2.14"}
-        headers:
-            Content-Length:
-                - "521"
-            Content-Type:
-                - application/json; charset=utf-8
-            Date:
-                - Mon, 09 Sep 2024 16:35:31 GMT
-            Ratelimit-Limit:
-                - "10000"
-            Ratelimit-Remaining:
-                - "9991"
-            Ratelimit-Reset:
-                - "28"
-            Referrer-Policy:
-                - same-origin
-            Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000186
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000791
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2556,7 +2498,65 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 202.713875ms
+        duration: 99.2125ms
+    - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/environments/evm-d8k3stlodlmc73btr2ug
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 246
+        uncompressed: false
+        body: |
+            {"databasesIds":null,"envGroupIds":null,"id":"evm-d8k3stlodlmc73btr2ug","name":"prod","networkIsolationEnabled":false,"projectId":"prj-d8k3stlodlmc73btr2tg","protectedStatus":"protected","redisIds":["red-d8k3stlodlmc73btr2vg"],"serviceIds":null}
+        headers:
+            Content-Length:
+                - "246"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:33 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "365"
+            Ratelimit-Reset:
+                - "26"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000792
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 67.004875ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -2575,7 +2575,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/key-value/red-crfi7js8m55c703hl2h0/connection-info
+        url: https://api.testing.render.com/v1/key-value/red-d8k3stlodlmc73btr2vg
         method: GET
       response:
         proto: HTTP/2.0
@@ -2583,27 +2583,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 365
+        content_length: 456
         uncompressed: false
         body: |
-            {"externalConnectionString":"rediss://red-crfi7js8m55c703hl2h0:gIRSGDdOQriMcOCPQHj1durmcXvsgVqm@oregon-redis.localhost.render.com:6377","internalConnectionString":"redis://red-crfi7js8m55c703hl2h0:6379","cliCommand":" REDISCLI_AUTH=gIRSGDdOQriMcOCPQHj1durmcXvsgVqm valkey-cli --user red-crfi7js8m55c703hl2h0 -h oregon-redis.localhost.render.com -p 6377 --tls"}
+            {"createdAt":"2026-06-09T16:25:26.405394Z","environmentId":"evm-d8k3stlodlmc73btr2ug","id":"red-d8k3stlodlmc73btr2vg","ipAllowList":null,"name":"test-keyvalue-new","options":{"maxmemoryPolicy":"noeviction","persistenceMode":"snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"standard","region":"oregon","status":"creating","updatedAt":"2026-06-09T16:25:32.058721Z","version":"8.1.4"}
         headers:
             Content-Length:
-                - "365"
+                - "456"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:31 GMT
+                - Tue, 09 Jun 2026 16:25:33 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9952"
+                - "364"
             Ratelimit-Reset:
-                - "28"
+                - "26"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000187
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000793
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2614,7 +2614,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 51.00625ms
+        duration: 100.105375ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -2633,7 +2633,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/projects/prj-crfi7js8m55c703hl2f0
+        url: https://api.testing.render.com/v1/key-value/red-d8k3stlodlmc73btr2vg/connection-info
         method: GET
       response:
         proto: HTTP/2.0
@@ -2641,27 +2641,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 285
+        content_length: 367
         uncompressed: false
         body: |
-            {"createdAt":"2024-09-09T16:35:27.305482Z","environmentIds":["evm-crfi7js8m55c703hl2fg"],"id":"prj-crfi7js8m55c703hl2f0","name":"first","owner":{"email":"email@example.com","id":"some-owner-id","name":"Test Terraform","type":"team"},"updatedAt":"2024-09-09T16:35:27.305482Z"}
+            {"cliCommand":" REDISCLI_AUTH=J1Nn3zNY0GwZ2Pspo6Tno4kVBYanCegk valkey-cli --user red-d8k3stlodlmc73btr2vg -h oregon-keyvalue.localhost.render.com -p 6377 --tls","externalConnectionString":"rediss://red-d8k3stlodlmc73btr2vg:J1Nn3zNY0GwZ2Pspo6Tno4kVBYanCegk@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k3stlodlmc73btr2vg:6379"}
         headers:
             Content-Length:
-                - "285"
+                - "367"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:31 GMT
+                - Tue, 09 Jun 2026 16:25:33 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9951"
+                - "363"
             Ratelimit-Reset:
-                - "28"
+                - "26"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000188
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000794
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2672,7 +2672,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 61.002583ms
+        duration: 79.691042ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -2691,7 +2691,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/environments/evm-crfi7js8m55c703hl2fg
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8k3stlodlmc73btr2vg
         method: GET
       response:
         proto: HTTP/2.0
@@ -2699,27 +2699,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 190
+        content_length: 50
         uncompressed: false
         body: |
-            {"databasesIds":null,"envGroupIds":null,"id":"evm-crfi7js8m55c703hl2fg","name":"prod","projectId":"prj-crfi7js8m55c703hl2f0","protectedStatus":"protected","redisIds":null,"serviceIds":null}
+            {"message":"not found: red-d8k3stlodlmc73btr2vg"}
         headers:
             Content-Length:
-                - "190"
+                - "50"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:31 GMT
+                - Tue, 09 Jun 2026 16:25:33 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9950"
+                - "362"
             Ratelimit-Reset:
-                - "28"
+                - "26"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000189
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000795
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2728,9 +2728,9 @@ interactions:
                 - DENY
             X-Xss-Protection:
                 - 1; mode=block
-        status: 200 OK
-        code: 200
-        duration: 36.159333ms
+        status: 404 Not Found
+        code: 404
+        duration: 51.193792ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -2749,7 +2749,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/projects/prj-crfi7js8m55c703hl2g0
+        url: https://api.testing.render.com/v1/projects/prj-d8k3stdodlmc73btr2r0
         method: GET
       response:
         proto: HTTP/2.0
@@ -2757,27 +2757,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 286
+        content_length: 282
         uncompressed: false
         body: |
-            {"createdAt":"2024-09-09T16:35:27.450645Z","environmentIds":["evm-crfi7js8m55c703hl2gg"],"id":"prj-crfi7js8m55c703hl2g0","name":"second","owner":{"email":"email@example.com","id":"some-owner-id","name":"Test Terraform","type":"team"},"updatedAt":"2024-09-09T16:35:27.450645Z"}
+            {"createdAt":"2026-06-09T16:25:25.533574Z","environmentIds":["evm-d8k3stdodlmc73btr2s0"],"id":"prj-d8k3stdodlmc73btr2r0","name":"first","owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"updatedAt":"2026-06-09T16:25:25.533574Z"}
         headers:
             Content-Length:
-                - "286"
+                - "282"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:31 GMT
+                - Tue, 09 Jun 2026 16:25:34 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9949"
+                - "361"
             Ratelimit-Reset:
-                - "28"
+                - "25"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000190
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000796
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2788,7 +2788,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 59.393625ms
+        duration: 96.751208ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -2807,7 +2807,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/environments/evm-crfi7js8m55c703hl2gg
+        url: https://api.testing.render.com/v1/key-value/red-d8k3stdodlmc73btr2q0
         method: GET
       response:
         proto: HTTP/2.0
@@ -2815,27 +2815,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 214
+        content_length: 422
         uncompressed: false
         body: |
-            {"databasesIds":null,"envGroupIds":null,"id":"evm-crfi7js8m55c703hl2gg","name":"prod","projectId":"prj-crfi7js8m55c703hl2g0","protectedStatus":"protected","redisIds":["red-crfi7js8m55c703hl2h0"],"serviceIds":null}
+            {"createdAt":"2026-06-09T16:25:25.489442Z","id":"red-d8k3stdodlmc73btr2q0","ipAllowList":null,"name":"test-keyvalue-paid","options":{"maxmemoryPolicy":"allkeys_lfu","persistenceMode":"journal_snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"starter","region":"oregon","status":"creating","updatedAt":"2026-06-09T16:25:25.489442Z","version":"8.1.4"}
         headers:
             Content-Length:
-                - "214"
+                - "422"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:31 GMT
+                - Tue, 09 Jun 2026 16:25:34 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9948"
+                - "360"
             Ratelimit-Reset:
-                - "28"
+                - "25"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000191
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000797
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2846,7 +2846,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 38.683625ms
+        duration: 87.809875ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -2865,7 +2865,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/key-value/red-crfi7js8m55c703hl2h0
+        url: https://api.testing.render.com/v1/environments/evm-d8k3stdodlmc73btr2s0
         method: GET
       response:
         proto: HTTP/2.0
@@ -2873,27 +2873,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 521
+        content_length: 222
         uncompressed: false
         body: |
-            {"createdAt":"2024-09-09T16:35:27.64367Z","environmentId":"evm-crfi7js8m55c703hl2gg","id":"red-crfi7js8m55c703hl2h0","ipAllowList":[{"cidrBlock":"1.1.1.1/32","description":"test"},{"cidrBlock":"2.0.0.0/8","description":"test-2"}],"name":"test-keyvalue-new","options":{"maxmemoryPolicy":"noeviction"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"Test Terraform","type":"team"},"plan":"standard","region":"oregon","status":"creating","updatedAt":"2024-09-09T16:35:31.240641Z","version":"6.2.14"}
+            {"databasesIds":null,"envGroupIds":null,"id":"evm-d8k3stdodlmc73btr2s0","name":"prod","networkIsolationEnabled":false,"projectId":"prj-d8k3stdodlmc73btr2r0","protectedStatus":"protected","redisIds":null,"serviceIds":null}
         headers:
             Content-Length:
-                - "521"
+                - "222"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:31 GMT
+                - Tue, 09 Jun 2026 16:25:34 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9947"
+                - "359"
             Ratelimit-Reset:
-                - "28"
+                - "25"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000192
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000798
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2904,7 +2904,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 57.896917ms
+        duration: 66.904375ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -2923,7 +2923,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/key-value/red-crfi7js8m55c703hl2h0/connection-info
+        url: https://api.testing.render.com/v1/key-value/red-d8k3stdodlmc73btr2q0/connection-info
         method: GET
       response:
         proto: HTTP/2.0
@@ -2931,27 +2931,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 365
+        content_length: 367
         uncompressed: false
         body: |
-            {"externalConnectionString":"rediss://red-crfi7js8m55c703hl2h0:gIRSGDdOQriMcOCPQHj1durmcXvsgVqm@oregon-redis.localhost.render.com:6377","internalConnectionString":"redis://red-crfi7js8m55c703hl2h0:6379","cliCommand":" REDISCLI_AUTH=gIRSGDdOQriMcOCPQHj1durmcXvsgVqm valkey-cli --user red-crfi7js8m55c703hl2h0 -h oregon-redis.localhost.render.com -p 6377 --tls"}
+            {"cliCommand":" REDISCLI_AUTH=WaE4JEDy7ygZu0tOR8v73BR6mghAr1rG valkey-cli --user red-d8k3stdodlmc73btr2q0 -h oregon-keyvalue.localhost.render.com -p 6377 --tls","externalConnectionString":"rediss://red-d8k3stdodlmc73btr2q0:WaE4JEDy7ygZu0tOR8v73BR6mghAr1rG@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k3stdodlmc73btr2q0:6379"}
         headers:
             Content-Length:
-                - "365"
+                - "367"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:31 GMT
+                - Tue, 09 Jun 2026 16:25:34 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9946"
+                - "358"
             Ratelimit-Reset:
-                - "28"
+                - "25"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000193
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000799
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2962,7 +2962,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 54.598209ms
+        duration: 68.318333ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -2981,7 +2981,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/logs/streams/resource/red-crfi7js8m55c703hl2h0
+        url: https://api.testing.render.com/v1/projects/prj-d8k3stlodlmc73btr2tg
         method: GET
       response:
         proto: HTTP/2.0
@@ -2989,27 +2989,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 50
+        content_length: 281
         uncompressed: false
         body: |
-            {"message":"not found: red-crfi7js8m55c703hl2h0"}
+            {"createdAt":"2026-06-09T16:25:26.03239Z","environmentIds":["evm-d8k3stlodlmc73btr2ug"],"id":"prj-d8k3stlodlmc73btr2tg","name":"second","owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"updatedAt":"2026-06-09T16:25:26.03239Z"}
         headers:
             Content-Length:
-                - "50"
+                - "281"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:31 GMT
+                - Tue, 09 Jun 2026 16:25:34 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9945"
+                - "357"
             Ratelimit-Reset:
-                - "28"
+                - "25"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000194
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000800
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -3018,9 +3018,9 @@ interactions:
                 - DENY
             X-Xss-Protection:
                 - 1; mode=block
-        status: 404 Not Found
-        code: 404
-        duration: 34.140375ms
+        status: 200 OK
+        code: 200
+        duration: 108.472209ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -3039,30 +3039,35 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/key-value/red-crfi7js8m55c703hl2h0
-        method: DELETE
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8k3stdodlmc73btr2q0
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 50
         uncompressed: false
-        body: ""
+        body: |
+            {"message":"not found: red-d8k3stdodlmc73btr2q0"}
         headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:32 GMT
+                - Tue, 09 Jun 2026 16:25:34 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9990"
+                - "356"
             Ratelimit-Reset:
-                - "27"
+                - "25"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000195
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000801
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -3071,9 +3076,9 @@ interactions:
                 - DENY
             X-Xss-Protection:
                 - 1; mode=block
-        status: 204 No Content
-        code: 204
-        duration: 61.533292ms
+        status: 404 Not Found
+        code: 404
+        duration: 54.369041ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -3092,30 +3097,35 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/projects/prj-crfi7js8m55c703hl2g0
-        method: DELETE
+        url: https://api.testing.render.com/v1/environments/evm-d8k3stlodlmc73btr2ug
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 246
         uncompressed: false
-        body: ""
+        body: |
+            {"databasesIds":null,"envGroupIds":null,"id":"evm-d8k3stlodlmc73btr2ug","name":"prod","networkIsolationEnabled":false,"projectId":"prj-d8k3stlodlmc73btr2tg","protectedStatus":"protected","redisIds":["red-d8k3stlodlmc73btr2vg"],"serviceIds":null}
         headers:
+            Content-Length:
+                - "246"
+            Content-Type:
+                - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:32 GMT
+                - Tue, 09 Jun 2026 16:25:35 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9989"
+                - "355"
             Ratelimit-Reset:
-                - "27"
+                - "24"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000196
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000802
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -3124,9 +3134,9 @@ interactions:
                 - DENY
             X-Xss-Protection:
                 - 1; mode=block
-        status: 204 No Content
-        code: 204
-        duration: 76.609375ms
+        status: 200 OK
+        code: 200
+        duration: 62.617083ms
     - id: 54
       request:
         proto: HTTP/1.1
@@ -3145,7 +3155,1459 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/projects/prj-crfi7js8m55c703hl2f0
+        url: https://api.testing.render.com/v1/key-value/red-d8k3stlodlmc73btr2vg
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 456
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T16:25:26.405394Z","environmentId":"evm-d8k3stlodlmc73btr2ug","id":"red-d8k3stlodlmc73btr2vg","ipAllowList":null,"name":"test-keyvalue-new","options":{"maxmemoryPolicy":"noeviction","persistenceMode":"snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"standard","region":"oregon","status":"creating","updatedAt":"2026-06-09T16:25:32.058721Z","version":"8.1.4"}
+        headers:
+            Content-Length:
+                - "456"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:35 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "354"
+            Ratelimit-Reset:
+                - "24"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000803
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 111.359625ms
+    - id: 55
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value/red-d8k3stlodlmc73btr2vg/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 367
+        uncompressed: false
+        body: |
+            {"cliCommand":" REDISCLI_AUTH=J1Nn3zNY0GwZ2Pspo6Tno4kVBYanCegk valkey-cli --user red-d8k3stlodlmc73btr2vg -h oregon-keyvalue.localhost.render.com -p 6377 --tls","externalConnectionString":"rediss://red-d8k3stlodlmc73btr2vg:J1Nn3zNY0GwZ2Pspo6Tno4kVBYanCegk@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k3stlodlmc73btr2vg:6379"}
+        headers:
+            Content-Length:
+                - "367"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:35 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "353"
+            Ratelimit-Reset:
+                - "24"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000804
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 84.530166ms
+    - id: 56
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8k3stlodlmc73btr2vg
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: red-d8k3stlodlmc73btr2vg"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:35 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "352"
+            Ratelimit-Reset:
+                - "24"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000805
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 56.268292ms
+    - id: 57
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 219
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: '{"ipAllowList":[{"cidrBlock":"1.1.1.1/32","description":"test"},{"cidrBlock":"2.0.0.0/8","description":"test-2"}],"maxmemoryPolicy":"noeviction","name":"test-keyvalue-new","persistenceMode":"snapshot","plan":"standard"}'
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            Content-Type:
+                - application/json
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value/red-d8k3stlodlmc73btr2vg
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 550
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T16:25:26.405394Z","environmentId":"evm-d8k3stlodlmc73btr2ug","id":"red-d8k3stlodlmc73btr2vg","ipAllowList":[{"cidrBlock":"1.1.1.1/32","description":"test"},{"cidrBlock":"2.0.0.0/8","description":"test-2"}],"name":"test-keyvalue-new","options":{"maxmemoryPolicy":"noeviction","persistenceMode":"snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"standard","region":"oregon","status":"creating","updatedAt":"2026-06-09T16:25:32.058721Z","version":"8.1.4"}
+        headers:
+            Content-Length:
+                - "550"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:35 GMT
+            Ratelimit-Limit:
+                - "100"
+            Ratelimit-Remaining:
+                - "92"
+            Ratelimit-Reset:
+                - "24"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000806
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 203.184ms
+    - id: 58
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value/red-d8k3stlodlmc73btr2vg/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 367
+        uncompressed: false
+        body: |
+            {"cliCommand":" REDISCLI_AUTH=J1Nn3zNY0GwZ2Pspo6Tno4kVBYanCegk valkey-cli --user red-d8k3stlodlmc73btr2vg -h oregon-keyvalue.localhost.render.com -p 6377 --tls","externalConnectionString":"rediss://red-d8k3stlodlmc73btr2vg:J1Nn3zNY0GwZ2Pspo6Tno4kVBYanCegk@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k3stlodlmc73btr2vg:6379"}
+        headers:
+            Content-Length:
+                - "367"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:35 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "351"
+            Ratelimit-Reset:
+                - "24"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000807
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 87.536083ms
+    - id: 59
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/projects/prj-d8k3stdodlmc73btr2r0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 282
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T16:25:25.533574Z","environmentIds":["evm-d8k3stdodlmc73btr2s0"],"id":"prj-d8k3stdodlmc73btr2r0","name":"first","owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"updatedAt":"2026-06-09T16:25:25.533574Z"}
+        headers:
+            Content-Length:
+                - "282"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:36 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "350"
+            Ratelimit-Reset:
+                - "23"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000808
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 114.886625ms
+    - id: 60
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value/red-d8k3stdodlmc73btr2q0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 422
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T16:25:25.489442Z","id":"red-d8k3stdodlmc73btr2q0","ipAllowList":null,"name":"test-keyvalue-paid","options":{"maxmemoryPolicy":"allkeys_lfu","persistenceMode":"journal_snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"starter","region":"oregon","status":"creating","updatedAt":"2026-06-09T16:25:25.489442Z","version":"8.1.4"}
+        headers:
+            Content-Length:
+                - "422"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:36 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "349"
+            Ratelimit-Reset:
+                - "23"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000809
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 83.249417ms
+    - id: 61
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/environments/evm-d8k3stdodlmc73btr2s0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 222
+        uncompressed: false
+        body: |
+            {"databasesIds":null,"envGroupIds":null,"id":"evm-d8k3stdodlmc73btr2s0","name":"prod","networkIsolationEnabled":false,"projectId":"prj-d8k3stdodlmc73btr2r0","protectedStatus":"protected","redisIds":null,"serviceIds":null}
+        headers:
+            Content-Length:
+                - "222"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:36 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "348"
+            Ratelimit-Reset:
+                - "23"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000810
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 69.63575ms
+    - id: 62
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value/red-d8k3stdodlmc73btr2q0/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 367
+        uncompressed: false
+        body: |
+            {"cliCommand":" REDISCLI_AUTH=WaE4JEDy7ygZu0tOR8v73BR6mghAr1rG valkey-cli --user red-d8k3stdodlmc73btr2q0 -h oregon-keyvalue.localhost.render.com -p 6377 --tls","externalConnectionString":"rediss://red-d8k3stdodlmc73btr2q0:WaE4JEDy7ygZu0tOR8v73BR6mghAr1rG@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k3stdodlmc73btr2q0:6379"}
+        headers:
+            Content-Length:
+                - "367"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:36 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "347"
+            Ratelimit-Reset:
+                - "23"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000811
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 68.714416ms
+    - id: 63
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/projects/prj-d8k3stlodlmc73btr2tg
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 281
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T16:25:26.03239Z","environmentIds":["evm-d8k3stlodlmc73btr2ug"],"id":"prj-d8k3stlodlmc73btr2tg","name":"second","owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"updatedAt":"2026-06-09T16:25:26.03239Z"}
+        headers:
+            Content-Length:
+                - "281"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:36 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "346"
+            Ratelimit-Reset:
+                - "23"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000812
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 96.071709ms
+    - id: 64
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8k3stdodlmc73btr2q0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: red-d8k3stdodlmc73btr2q0"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:37 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "345"
+            Ratelimit-Reset:
+                - "22"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000813
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 56.698542ms
+    - id: 65
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/environments/evm-d8k3stlodlmc73btr2ug
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 246
+        uncompressed: false
+        body: |
+            {"databasesIds":null,"envGroupIds":null,"id":"evm-d8k3stlodlmc73btr2ug","name":"prod","networkIsolationEnabled":false,"projectId":"prj-d8k3stlodlmc73btr2tg","protectedStatus":"protected","redisIds":["red-d8k3stlodlmc73btr2vg"],"serviceIds":null}
+        headers:
+            Content-Length:
+                - "246"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:37 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "344"
+            Ratelimit-Reset:
+                - "22"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000814
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 67.04275ms
+    - id: 66
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value/red-d8k3stlodlmc73btr2vg
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 550
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T16:25:26.405394Z","environmentId":"evm-d8k3stlodlmc73btr2ug","id":"red-d8k3stlodlmc73btr2vg","ipAllowList":[{"cidrBlock":"1.1.1.1/32","description":"test"},{"cidrBlock":"2.0.0.0/8","description":"test-2"}],"name":"test-keyvalue-new","options":{"maxmemoryPolicy":"noeviction","persistenceMode":"snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"standard","region":"oregon","status":"creating","updatedAt":"2026-06-09T16:25:32.058721Z","version":"8.1.4"}
+        headers:
+            Content-Length:
+                - "550"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:37 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "343"
+            Ratelimit-Reset:
+                - "22"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000815
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 101.499167ms
+    - id: 67
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value/red-d8k3stlodlmc73btr2vg/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 367
+        uncompressed: false
+        body: |
+            {"cliCommand":" REDISCLI_AUTH=J1Nn3zNY0GwZ2Pspo6Tno4kVBYanCegk valkey-cli --user red-d8k3stlodlmc73btr2vg -h oregon-keyvalue.localhost.render.com -p 6377 --tls","externalConnectionString":"rediss://red-d8k3stlodlmc73btr2vg:J1Nn3zNY0GwZ2Pspo6Tno4kVBYanCegk@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k3stlodlmc73btr2vg:6379"}
+        headers:
+            Content-Length:
+                - "367"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:37 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "342"
+            Ratelimit-Reset:
+                - "22"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000816
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 83.513958ms
+    - id: 68
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8k3stlodlmc73btr2vg
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: red-d8k3stlodlmc73btr2vg"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:37 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "341"
+            Ratelimit-Reset:
+                - "22"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000817
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 56.38ms
+    - id: 69
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/projects/prj-d8k3stdodlmc73btr2r0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 282
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T16:25:25.533574Z","environmentIds":["evm-d8k3stdodlmc73btr2s0"],"id":"prj-d8k3stdodlmc73btr2r0","name":"first","owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"updatedAt":"2026-06-09T16:25:25.533574Z"}
+        headers:
+            Content-Length:
+                - "282"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:37 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "340"
+            Ratelimit-Reset:
+                - "22"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000818
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 102.229791ms
+    - id: 70
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/projects/prj-d8k3stlodlmc73btr2tg
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 281
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T16:25:26.03239Z","environmentIds":["evm-d8k3stlodlmc73btr2ug"],"id":"prj-d8k3stlodlmc73btr2tg","name":"second","owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"updatedAt":"2026-06-09T16:25:26.03239Z"}
+        headers:
+            Content-Length:
+                - "281"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:38 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "339"
+            Ratelimit-Reset:
+                - "21"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000819
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 103.69925ms
+    - id: 71
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value/red-d8k3stdodlmc73btr2q0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 422
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T16:25:25.489442Z","id":"red-d8k3stdodlmc73btr2q0","ipAllowList":null,"name":"test-keyvalue-paid","options":{"maxmemoryPolicy":"allkeys_lfu","persistenceMode":"journal_snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"starter","region":"oregon","status":"creating","updatedAt":"2026-06-09T16:25:25.489442Z","version":"8.1.4"}
+        headers:
+            Content-Length:
+                - "422"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:38 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "338"
+            Ratelimit-Reset:
+                - "21"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000820
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 86.920166ms
+    - id: 72
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value/red-d8k3stlodlmc73btr2vg
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 550
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T16:25:26.405394Z","environmentId":"evm-d8k3stlodlmc73btr2ug","id":"red-d8k3stlodlmc73btr2vg","ipAllowList":[{"cidrBlock":"1.1.1.1/32","description":"test"},{"cidrBlock":"2.0.0.0/8","description":"test-2"}],"name":"test-keyvalue-new","options":{"maxmemoryPolicy":"noeviction","persistenceMode":"snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"standard","region":"oregon","status":"creating","updatedAt":"2026-06-09T16:25:32.058721Z","version":"8.1.4"}
+        headers:
+            Content-Length:
+                - "550"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:38 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "337"
+            Ratelimit-Reset:
+                - "21"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000821
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 96.655583ms
+    - id: 73
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/environments/evm-d8k3stdodlmc73btr2s0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 222
+        uncompressed: false
+        body: |
+            {"databasesIds":null,"envGroupIds":null,"id":"evm-d8k3stdodlmc73btr2s0","name":"prod","networkIsolationEnabled":false,"projectId":"prj-d8k3stdodlmc73btr2r0","protectedStatus":"protected","redisIds":null,"serviceIds":null}
+        headers:
+            Content-Length:
+                - "222"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:38 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "336"
+            Ratelimit-Reset:
+                - "21"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000822
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 68.211708ms
+    - id: 74
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/environments/evm-d8k3stlodlmc73btr2ug
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 246
+        uncompressed: false
+        body: |
+            {"databasesIds":null,"envGroupIds":null,"id":"evm-d8k3stlodlmc73btr2ug","name":"prod","networkIsolationEnabled":false,"projectId":"prj-d8k3stlodlmc73btr2tg","protectedStatus":"protected","redisIds":["red-d8k3stlodlmc73btr2vg"],"serviceIds":null}
+        headers:
+            Content-Length:
+                - "246"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:38 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "335"
+            Ratelimit-Reset:
+                - "21"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000823
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 73.3425ms
+    - id: 75
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value/red-d8k3stdodlmc73btr2q0/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 367
+        uncompressed: false
+        body: |
+            {"cliCommand":" REDISCLI_AUTH=WaE4JEDy7ygZu0tOR8v73BR6mghAr1rG valkey-cli --user red-d8k3stdodlmc73btr2q0 -h oregon-keyvalue.localhost.render.com -p 6377 --tls","externalConnectionString":"rediss://red-d8k3stdodlmc73btr2q0:WaE4JEDy7ygZu0tOR8v73BR6mghAr1rG@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k3stdodlmc73btr2q0:6379"}
+        headers:
+            Content-Length:
+                - "367"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:38 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "334"
+            Ratelimit-Reset:
+                - "21"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000824
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 66.336291ms
+    - id: 76
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value/red-d8k3stlodlmc73btr2vg/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 367
+        uncompressed: false
+        body: |
+            {"cliCommand":" REDISCLI_AUTH=J1Nn3zNY0GwZ2Pspo6Tno4kVBYanCegk valkey-cli --user red-d8k3stlodlmc73btr2vg -h oregon-keyvalue.localhost.render.com -p 6377 --tls","externalConnectionString":"rediss://red-d8k3stlodlmc73btr2vg:J1Nn3zNY0GwZ2Pspo6Tno4kVBYanCegk@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k3stlodlmc73btr2vg:6379"}
+        headers:
+            Content-Length:
+                - "367"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:39 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "333"
+            Ratelimit-Reset:
+                - "20"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000825
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 77.996458ms
+    - id: 77
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8k3stdodlmc73btr2q0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: red-d8k3stdodlmc73btr2q0"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:39 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "332"
+            Ratelimit-Reset:
+                - "20"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000826
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 52.755167ms
+    - id: 78
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8k3stlodlmc73btr2vg
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: red-d8k3stlodlmc73btr2vg"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:39 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "331"
+            Ratelimit-Reset:
+                - "20"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000827
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 54.608541ms
+    - id: 79
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value/red-d8k3stdodlmc73btr2q0
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -3158,17 +4620,17 @@ interactions:
         body: ""
         headers:
             Date:
-                - Mon, 09 Sep 2024 16:35:32 GMT
+                - Tue, 09 Jun 2026 16:25:39 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "100"
             Ratelimit-Remaining:
-                - "9988"
+                - "91"
             Ratelimit-Reset:
-                - "27"
+                - "20"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000197
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000828
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -3179,4 +4641,1959 @@ interactions:
                 - 1; mode=block
         status: 204 No Content
         code: 204
-        duration: 90.261125ms
+        duration: 97.669334ms
+    - id: 80
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value/red-d8k3stlodlmc73btr2vg
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Date:
+                - Tue, 09 Jun 2026 16:25:39 GMT
+            Ratelimit-Limit:
+                - "100"
+            Ratelimit-Remaining:
+                - "90"
+            Ratelimit-Reset:
+                - "20"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000829
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 204 No Content
+        code: 204
+        duration: 103.277375ms
+    - id: 81
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 150
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: '{"ipAllowList":[],"maxmemoryPolicy":"allkeys_lfu","name":"test-keyvalue-upgrade","ownerId":"some-owner-id","plan":"free","region":"oregon"}'
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            Content-Type:
+                - application/json
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 414
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T16:25:39.949526738Z","id":"red-d8k3t0todlmc73btr3eg","ipAllowList":null,"name":"test-keyvalue-upgrade","options":{"maxmemoryPolicy":"allkeys_lfu","persistenceMode":"off"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"free","region":"oregon","status":"unknown","updatedAt":"2026-06-09T16:25:39.949526738Z","version":"8.1.4"}
+        headers:
+            Content-Length:
+                - "414"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:40 GMT
+            Ratelimit-Limit:
+                - "20"
+            Ratelimit-Remaining:
+                - "9"
+            Ratelimit-Reset:
+                - "2060"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000830
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 201 Created
+        code: 201
+        duration: 282.745417ms
+    - id: 82
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/projects/prj-d8k3stlodlmc73btr2tg
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Date:
+                - Tue, 09 Jun 2026 16:25:40 GMT
+            Ratelimit-Limit:
+                - "100"
+            Ratelimit-Remaining:
+                - "89"
+            Ratelimit-Reset:
+                - "19"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000831
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 204 No Content
+        code: 204
+        duration: 128.738583ms
+    - id: 83
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value/red-d8k3t0todlmc73btr3eg/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 367
+        uncompressed: false
+        body: |
+            {"cliCommand":" REDISCLI_AUTH=8Winu0ktWaHJU9KKcIxLOraCu3TIGifV valkey-cli --user red-d8k3t0todlmc73btr3eg -h oregon-keyvalue.localhost.render.com -p 6377 --tls","externalConnectionString":"rediss://red-d8k3t0todlmc73btr3eg:8Winu0ktWaHJU9KKcIxLOraCu3TIGifV@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k3t0todlmc73btr3eg:6379"}
+        headers:
+            Content-Length:
+                - "367"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:40 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "330"
+            Ratelimit-Reset:
+                - "19"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000832
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 68.388ms
+    - id: 84
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/projects/prj-d8k3stdodlmc73btr2r0
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Date:
+                - Tue, 09 Jun 2026 16:25:40 GMT
+            Ratelimit-Limit:
+                - "100"
+            Ratelimit-Remaining:
+                - "88"
+            Ratelimit-Reset:
+                - "19"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000833
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 204 No Content
+        code: 204
+        duration: 136.679958ms
+    - id: 85
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value/red-d8k3t0todlmc73btr3eg
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 409
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T16:25:39.949527Z","id":"red-d8k3t0todlmc73btr3eg","ipAllowList":null,"name":"test-keyvalue-upgrade","options":{"maxmemoryPolicy":"allkeys_lfu","persistenceMode":"off"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"free","region":"oregon","status":"creating","updatedAt":"2026-06-09T16:25:39.949527Z","version":"8.1.4"}
+        headers:
+            Content-Length:
+                - "409"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:40 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "329"
+            Ratelimit-Reset:
+                - "19"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000834
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 89.117375ms
+    - id: 86
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value/red-d8k3t0todlmc73btr3eg/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 367
+        uncompressed: false
+        body: |
+            {"cliCommand":" REDISCLI_AUTH=8Winu0ktWaHJU9KKcIxLOraCu3TIGifV valkey-cli --user red-d8k3t0todlmc73btr3eg -h oregon-keyvalue.localhost.render.com -p 6377 --tls","externalConnectionString":"rediss://red-d8k3t0todlmc73btr3eg:8Winu0ktWaHJU9KKcIxLOraCu3TIGifV@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k3t0todlmc73btr3eg:6379"}
+        headers:
+            Content-Length:
+                - "367"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:40 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "328"
+            Ratelimit-Reset:
+                - "19"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000835
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 66.0265ms
+    - id: 87
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8k3t0todlmc73btr3eg
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: red-d8k3t0todlmc73btr3eg"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:41 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "327"
+            Ratelimit-Reset:
+                - "18"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000836
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 54.04925ms
+    - id: 88
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value/red-d8k3t0todlmc73btr3eg
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 409
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T16:25:39.949527Z","id":"red-d8k3t0todlmc73btr3eg","ipAllowList":null,"name":"test-keyvalue-upgrade","options":{"maxmemoryPolicy":"allkeys_lfu","persistenceMode":"off"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"free","region":"oregon","status":"creating","updatedAt":"2026-06-09T16:25:39.949527Z","version":"8.1.4"}
+        headers:
+            Content-Length:
+                - "409"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:41 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "326"
+            Ratelimit-Reset:
+                - "18"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000837
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 116.647667ms
+    - id: 89
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value/red-d8k3t0todlmc73btr3eg/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 367
+        uncompressed: false
+        body: |
+            {"cliCommand":" REDISCLI_AUTH=8Winu0ktWaHJU9KKcIxLOraCu3TIGifV valkey-cli --user red-d8k3t0todlmc73btr3eg -h oregon-keyvalue.localhost.render.com -p 6377 --tls","externalConnectionString":"rediss://red-d8k3t0todlmc73btr3eg:8Winu0ktWaHJU9KKcIxLOraCu3TIGifV@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k3t0todlmc73btr3eg:6379"}
+        headers:
+            Content-Length:
+                - "367"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:41 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "325"
+            Ratelimit-Reset:
+                - "18"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000838
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 65.709417ms
+    - id: 90
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8k3t0todlmc73btr3eg
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: red-d8k3t0todlmc73btr3eg"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:41 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "324"
+            Ratelimit-Reset:
+                - "18"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000839
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 53.868208ms
+    - id: 91
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 98
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: '{"ipAllowList":[],"maxmemoryPolicy":"allkeys_lfu","name":"test-keyvalue-upgrade","plan":"starter"}'
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            Content-Type:
+                - application/json
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value/red-d8k3t0todlmc73btr3eg
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 424
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T16:25:39.949527Z","id":"red-d8k3t0todlmc73btr3eg","ipAllowList":null,"name":"test-keyvalue-upgrade","options":{"maxmemoryPolicy":"allkeys_lfu","persistenceMode":"journal_snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"starter","region":"oregon","status":"creating","updatedAt":"2026-06-09T16:25:41.84786Z","version":"8.1.4"}
+        headers:
+            Content-Length:
+                - "424"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:41 GMT
+            Ratelimit-Limit:
+                - "100"
+            Ratelimit-Remaining:
+                - "87"
+            Ratelimit-Reset:
+                - "18"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000840
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 239.279417ms
+    - id: 92
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value/red-d8k3t0todlmc73btr3eg/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 367
+        uncompressed: false
+        body: |
+            {"cliCommand":" REDISCLI_AUTH=8Winu0ktWaHJU9KKcIxLOraCu3TIGifV valkey-cli --user red-d8k3t0todlmc73btr3eg -h oregon-keyvalue.localhost.render.com -p 6377 --tls","externalConnectionString":"rediss://red-d8k3t0todlmc73btr3eg:8Winu0ktWaHJU9KKcIxLOraCu3TIGifV@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k3t0todlmc73btr3eg:6379"}
+        headers:
+            Content-Length:
+                - "367"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:41 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "323"
+            Ratelimit-Reset:
+                - "18"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000841
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 62.725ms
+    - id: 93
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value/red-d8k3t0todlmc73btr3eg
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 424
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T16:25:39.949527Z","id":"red-d8k3t0todlmc73btr3eg","ipAllowList":null,"name":"test-keyvalue-upgrade","options":{"maxmemoryPolicy":"allkeys_lfu","persistenceMode":"journal_snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"starter","region":"oregon","status":"creating","updatedAt":"2026-06-09T16:25:41.84786Z","version":"8.1.4"}
+        headers:
+            Content-Length:
+                - "424"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:42 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "322"
+            Ratelimit-Reset:
+                - "17"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000842
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 82.7585ms
+    - id: 94
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value/red-d8k3t0todlmc73btr3eg/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 367
+        uncompressed: false
+        body: |
+            {"cliCommand":" REDISCLI_AUTH=8Winu0ktWaHJU9KKcIxLOraCu3TIGifV valkey-cli --user red-d8k3t0todlmc73btr3eg -h oregon-keyvalue.localhost.render.com -p 6377 --tls","externalConnectionString":"rediss://red-d8k3t0todlmc73btr3eg:8Winu0ktWaHJU9KKcIxLOraCu3TIGifV@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k3t0todlmc73btr3eg:6379"}
+        headers:
+            Content-Length:
+                - "367"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:42 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "321"
+            Ratelimit-Reset:
+                - "17"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000843
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 64.214375ms
+    - id: 95
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8k3t0todlmc73btr3eg
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: red-d8k3t0todlmc73btr3eg"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:42 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "320"
+            Ratelimit-Reset:
+                - "17"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000844
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 54.50475ms
+    - id: 96
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value/red-d8k3t0todlmc73btr3eg
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 424
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T16:25:39.949527Z","id":"red-d8k3t0todlmc73btr3eg","ipAllowList":null,"name":"test-keyvalue-upgrade","options":{"maxmemoryPolicy":"allkeys_lfu","persistenceMode":"journal_snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"starter","region":"oregon","status":"creating","updatedAt":"2026-06-09T16:25:41.84786Z","version":"8.1.4"}
+        headers:
+            Content-Length:
+                - "424"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:42 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "319"
+            Ratelimit-Reset:
+                - "17"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000845
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 82.5215ms
+    - id: 97
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value/red-d8k3t0todlmc73btr3eg/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 367
+        uncompressed: false
+        body: |
+            {"cliCommand":" REDISCLI_AUTH=8Winu0ktWaHJU9KKcIxLOraCu3TIGifV valkey-cli --user red-d8k3t0todlmc73btr3eg -h oregon-keyvalue.localhost.render.com -p 6377 --tls","externalConnectionString":"rediss://red-d8k3t0todlmc73btr3eg:8Winu0ktWaHJU9KKcIxLOraCu3TIGifV@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k3t0todlmc73btr3eg:6379"}
+        headers:
+            Content-Length:
+                - "367"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:42 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "318"
+            Ratelimit-Reset:
+                - "17"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000846
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 69.466375ms
+    - id: 98
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8k3t0todlmc73btr3eg
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: red-d8k3t0todlmc73btr3eg"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:43 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "317"
+            Ratelimit-Reset:
+                - "16"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000847
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 53.188208ms
+    - id: 99
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value/red-d8k3t0todlmc73btr3eg
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Date:
+                - Tue, 09 Jun 2026 16:25:43 GMT
+            Ratelimit-Limit:
+                - "100"
+            Ratelimit-Remaining:
+                - "86"
+            Ratelimit-Reset:
+                - "16"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000848
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 204 No Content
+        code: 204
+        duration: 97.045542ms
+    - id: 100
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 175
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: '{"ipAllowList":[],"maxmemoryPolicy":"allkeys_lfu","name":"test-keyvalue-upgrade2","ownerId":"some-owner-id","persistenceMode":"off","plan":"free","region":"oregon"}'
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            Content-Type:
+                - application/json
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 415
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T16:25:43.445871168Z","id":"red-d8k3t1todlmc73btr3m0","ipAllowList":null,"name":"test-keyvalue-upgrade2","options":{"maxmemoryPolicy":"allkeys_lfu","persistenceMode":"off"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"free","region":"oregon","status":"unknown","updatedAt":"2026-06-09T16:25:43.445871168Z","version":"8.1.4"}
+        headers:
+            Content-Length:
+                - "415"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:43 GMT
+            Ratelimit-Limit:
+                - "20"
+            Ratelimit-Remaining:
+                - "8"
+            Ratelimit-Reset:
+                - "2056"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000849
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 201 Created
+        code: 201
+        duration: 297.001875ms
+    - id: 101
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value/red-d8k3t1todlmc73btr3m0/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 367
+        uncompressed: false
+        body: |
+            {"cliCommand":" REDISCLI_AUTH=Ef1zeLCEqvuxS0vbVZLH2eVBYXQFiP1A valkey-cli --user red-d8k3t1todlmc73btr3m0 -h oregon-keyvalue.localhost.render.com -p 6377 --tls","externalConnectionString":"rediss://red-d8k3t1todlmc73btr3m0:Ef1zeLCEqvuxS0vbVZLH2eVBYXQFiP1A@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k3t1todlmc73btr3m0:6379"}
+        headers:
+            Content-Length:
+                - "367"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:43 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "316"
+            Ratelimit-Reset:
+                - "16"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000850
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 68.619708ms
+    - id: 102
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value/red-d8k3t1todlmc73btr3m0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 410
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T16:25:43.445871Z","id":"red-d8k3t1todlmc73btr3m0","ipAllowList":null,"name":"test-keyvalue-upgrade2","options":{"maxmemoryPolicy":"allkeys_lfu","persistenceMode":"off"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"free","region":"oregon","status":"creating","updatedAt":"2026-06-09T16:25:43.445871Z","version":"8.1.4"}
+        headers:
+            Content-Length:
+                - "410"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:43 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "315"
+            Ratelimit-Reset:
+                - "16"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000851
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 77.418875ms
+    - id: 103
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value/red-d8k3t1todlmc73btr3m0/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 367
+        uncompressed: false
+        body: |
+            {"cliCommand":" REDISCLI_AUTH=Ef1zeLCEqvuxS0vbVZLH2eVBYXQFiP1A valkey-cli --user red-d8k3t1todlmc73btr3m0 -h oregon-keyvalue.localhost.render.com -p 6377 --tls","externalConnectionString":"rediss://red-d8k3t1todlmc73btr3m0:Ef1zeLCEqvuxS0vbVZLH2eVBYXQFiP1A@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k3t1todlmc73btr3m0:6379"}
+        headers:
+            Content-Length:
+                - "367"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:44 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "314"
+            Ratelimit-Reset:
+                - "15"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000852
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 66.591417ms
+    - id: 104
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8k3t1todlmc73btr3m0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: red-d8k3t1todlmc73btr3m0"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:44 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "313"
+            Ratelimit-Reset:
+                - "15"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000853
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 54.028375ms
+    - id: 105
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value/red-d8k3t1todlmc73btr3m0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 410
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T16:25:43.445871Z","id":"red-d8k3t1todlmc73btr3m0","ipAllowList":null,"name":"test-keyvalue-upgrade2","options":{"maxmemoryPolicy":"allkeys_lfu","persistenceMode":"off"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"free","region":"oregon","status":"creating","updatedAt":"2026-06-09T16:25:43.445871Z","version":"8.1.4"}
+        headers:
+            Content-Length:
+                - "410"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:44 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "312"
+            Ratelimit-Reset:
+                - "15"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000854
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 81.88175ms
+    - id: 106
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value/red-d8k3t1todlmc73btr3m0/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 367
+        uncompressed: false
+        body: |
+            {"cliCommand":" REDISCLI_AUTH=Ef1zeLCEqvuxS0vbVZLH2eVBYXQFiP1A valkey-cli --user red-d8k3t1todlmc73btr3m0 -h oregon-keyvalue.localhost.render.com -p 6377 --tls","externalConnectionString":"rediss://red-d8k3t1todlmc73btr3m0:Ef1zeLCEqvuxS0vbVZLH2eVBYXQFiP1A@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k3t1todlmc73btr3m0:6379"}
+        headers:
+            Content-Length:
+                - "367"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:44 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "311"
+            Ratelimit-Reset:
+                - "15"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000855
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 64.270917ms
+    - id: 107
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8k3t1todlmc73btr3m0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: red-d8k3t1todlmc73btr3m0"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:44 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "310"
+            Ratelimit-Reset:
+                - "15"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000856
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 56.919834ms
+    - id: 108
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 128
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: '{"ipAllowList":[],"maxmemoryPolicy":"allkeys_lfu","name":"test-keyvalue-upgrade2","persistenceMode":"snapshot","plan":"starter"}'
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            Content-Type:
+                - application/json
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value/red-d8k3t1todlmc73btr3m0
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 418
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T16:25:43.445871Z","id":"red-d8k3t1todlmc73btr3m0","ipAllowList":null,"name":"test-keyvalue-upgrade2","options":{"maxmemoryPolicy":"allkeys_lfu","persistenceMode":"snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"starter","region":"oregon","status":"creating","updatedAt":"2026-06-09T16:25:45.044956Z","version":"8.1.4"}
+        headers:
+            Content-Length:
+                - "418"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:45 GMT
+            Ratelimit-Limit:
+                - "100"
+            Ratelimit-Remaining:
+                - "85"
+            Ratelimit-Reset:
+                - "15"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000857
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 403.379416ms
+    - id: 109
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value/red-d8k3t1todlmc73btr3m0/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 367
+        uncompressed: false
+        body: |
+            {"cliCommand":" REDISCLI_AUTH=Ef1zeLCEqvuxS0vbVZLH2eVBYXQFiP1A valkey-cli --user red-d8k3t1todlmc73btr3m0 -h oregon-keyvalue.localhost.render.com -p 6377 --tls","externalConnectionString":"rediss://red-d8k3t1todlmc73btr3m0:Ef1zeLCEqvuxS0vbVZLH2eVBYXQFiP1A@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k3t1todlmc73btr3m0:6379"}
+        headers:
+            Content-Length:
+                - "367"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:45 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "309"
+            Ratelimit-Reset:
+                - "14"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000858
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 68.763542ms
+    - id: 110
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value/red-d8k3t1todlmc73btr3m0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 418
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T16:25:43.445871Z","id":"red-d8k3t1todlmc73btr3m0","ipAllowList":null,"name":"test-keyvalue-upgrade2","options":{"maxmemoryPolicy":"allkeys_lfu","persistenceMode":"snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"starter","region":"oregon","status":"creating","updatedAt":"2026-06-09T16:25:45.044956Z","version":"8.1.4"}
+        headers:
+            Content-Length:
+                - "418"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:45 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "308"
+            Ratelimit-Reset:
+                - "14"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000859
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 149.885916ms
+    - id: 111
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value/red-d8k3t1todlmc73btr3m0/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 367
+        uncompressed: false
+        body: |
+            {"cliCommand":" REDISCLI_AUTH=Ef1zeLCEqvuxS0vbVZLH2eVBYXQFiP1A valkey-cli --user red-d8k3t1todlmc73btr3m0 -h oregon-keyvalue.localhost.render.com -p 6377 --tls","externalConnectionString":"rediss://red-d8k3t1todlmc73btr3m0:Ef1zeLCEqvuxS0vbVZLH2eVBYXQFiP1A@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k3t1todlmc73btr3m0:6379"}
+        headers:
+            Content-Length:
+                - "367"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:45 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "307"
+            Ratelimit-Reset:
+                - "14"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000860
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 68.632417ms
+    - id: 112
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8k3t1todlmc73btr3m0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: red-d8k3t1todlmc73btr3m0"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:25:45 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "306"
+            Ratelimit-Reset:
+                - "14"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000861
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 56.656042ms
+    - id: 113
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/key-value/red-d8k3t1todlmc73btr3m0
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Date:
+                - Tue, 09 Jun 2026 16:25:46 GMT
+            Ratelimit-Limit:
+                - "100"
+            Ratelimit-Remaining:
+                - "84"
+            Ratelimit-Reset:
+                - "13"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000862
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 204 No Content
+        code: 204
+        duration: 110.178667ms

--- a/internal/provider/keyvalue/resource/testdata/keyvalue_upgrade.tf
+++ b/internal/provider/keyvalue/resource/testdata/keyvalue_upgrade.tf
@@ -1,0 +1,10 @@
+variable "plan" {
+  type = string
+}
+
+resource "render_keyvalue" "test-keyvalue-upgrade" {
+  name              = "test-keyvalue-upgrade"
+  plan              = var.plan
+  region            = "oregon"
+  max_memory_policy = "allkeys_lfu"
+}

--- a/internal/provider/keyvalue/resource/testdata/keyvalue_upgrade2.tf
+++ b/internal/provider/keyvalue/resource/testdata/keyvalue_upgrade2.tf
@@ -1,0 +1,15 @@
+variable "plan" {
+  type = string
+}
+
+variable "persistence_mode" {
+  type = string
+}
+
+resource "render_keyvalue" "test-keyvalue-upgrade2" {
+  name              = "test-keyvalue-upgrade2"
+  plan              = var.plan
+  region            = "oregon"
+  max_memory_policy = "allkeys_lfu"
+  persistence_mode  = var.persistence_mode
+}

--- a/internal/provider/redis/datasource/datasource_test.go
+++ b/internal/provider/redis/datasource/datasource_test.go
@@ -1,0 +1,67 @@
+package datasource_test
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	th "terraform-provider-render/internal/provider/testhelpers"
+)
+
+func TestAccRedisDataSource(t *testing.T) {
+	resourceName := "data.render_redis.test"
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: th.SetupRecordingProvider(t, "redis_datasource_cassette"),
+		Steps: []resource.TestStep{
+			{
+				ConfigFile: config.StaticFile("./testdata/redis.tf"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrWith(resourceName, "id", func(value string) error {
+						if !strings.HasPrefix(value, "red-") {
+							return fmt.Errorf("expected id to start with red-, got: %s", value)
+						}
+						return nil
+					}),
+					resource.TestCheckResourceAttr(resourceName, "name", "some-redis"),
+					resource.TestCheckResourceAttr(resourceName, "plan", "starter"),
+					resource.TestCheckResourceAttr(resourceName, "region", "oregon"),
+					resource.TestCheckResourceAttr(resourceName, "max_memory_policy", "noeviction"),
+					resource.TestCheckResourceAttr(resourceName, "persistence_mode", "snapshot"),
+
+					resource.TestCheckResourceAttr(resourceName, "ip_allow_list.0.cidr_block", "1.1.1.1/32"),
+					resource.TestCheckResourceAttr(resourceName, "ip_allow_list.0.description", "one"),
+					resource.TestCheckResourceAttr(resourceName, "ip_allow_list.1.cidr_block", "2.2.2.2/32"),
+					resource.TestCheckResourceAttr(resourceName, "ip_allow_list.1.description", "two"),
+
+					resource.TestCheckResourceAttrWith(resourceName, "connection_info.external_connection_string", func(value string) error {
+						if !regexp.MustCompile(`^rediss://red-.*:.{32}@oregon-keyvalue\..*:637[7,9]$`).MatchString(value) {
+							return fmt.Errorf("expected external_connection_string: %s to match regex", value)
+						}
+
+						return nil
+					}),
+
+					resource.TestCheckResourceAttrWith(resourceName, "connection_info.internal_connection_string", func(value string) error {
+						if !regexp.MustCompile(`^redis://red-.*:637[7,9]$`).MatchString(value) {
+							return fmt.Errorf("expected internal_connection_string: %s to match regex", value)
+						}
+
+						return nil
+					}),
+
+					resource.TestCheckResourceAttrWith(resourceName, "connection_info.redis_cli_command", func(value string) error {
+						if !regexp.MustCompile(`^ REDISCLI_AUTH=.{32} valkey-cli --user red-.* -h oregon-keyvalue\..* -p 637[7,9] --tls$`).MatchString(value) {
+							return fmt.Errorf("expected cli_command: %s to match regex", value)
+						}
+
+						return nil
+					}),
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/redis/datasource/schema.go
+++ b/internal/provider/redis/datasource/schema.go
@@ -17,6 +17,7 @@ func Schema(ctx context.Context) schema.Schema {
 			"environment_id":      datasource.ResourceEnvironmentID,
 			"ip_allow_list":       datasource.IPAllowList,
 			"max_memory_policy":   datasource.MaxMemoryPolicy,
+			"persistence_mode":    datasource.PersistenceMode,
 			"name":                datasource.ServiceName,
 			"plan":                datasource.RedisPlan,
 			"region":              datasource.Region,

--- a/internal/provider/redis/datasource/testdata/redis.tf
+++ b/internal/provider/redis/datasource/testdata/redis.tf
@@ -1,0 +1,22 @@
+resource "render_redis" "test" {
+  name              = "some-redis"
+  plan              = "starter"
+  region            = "oregon"
+  max_memory_policy = "noeviction"
+  persistence_mode  = "snapshot"
+
+  ip_allow_list = [
+    {
+      cidr_block  = "1.1.1.1/32"
+      description = "one"
+    },
+    {
+      cidr_block  = "2.2.2.2/32"
+      description = "two"
+    }
+  ]
+}
+
+data "render_redis" "test" {
+  id = render_redis.test.id
+}

--- a/internal/provider/redis/datasource/testdata/redis_datasource_cassette.yaml
+++ b/internal/provider/redis/datasource/testdata/redis_datasource_cassette.yaml
@@ -1,0 +1,870 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 263
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: '{"ipAllowList":[{"cidrBlock":"1.1.1.1/32","description":"one"},{"cidrBlock":"2.2.2.2/32","description":"two"}],"maxmemoryPolicy":"noeviction","name":"some-redis","ownerId":"some-owner-id","persistenceMode":"snapshot","plan":"starter","region":"oregon"}'
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            Content-Type:
+                - application/json
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 501
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T16:52:21.311427568Z","id":"red-d8k49hdodlmc73btr41g","ipAllowList":[{"cidrBlock":"1.1.1.1/32","description":"one"},{"cidrBlock":"2.2.2.2/32","description":"two"}],"name":"some-redis","options":{"maxmemoryPolicy":"noeviction","persistenceMode":"snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"starter","region":"oregon","status":"unknown","updatedAt":"2026-06-09T16:52:21.311427568Z","version":"8.1.4"}
+        headers:
+            Content-Length:
+                - "501"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:52:21 GMT
+            Ratelimit-Limit:
+                - "20"
+            Ratelimit-Remaining:
+                - "5"
+            Ratelimit-Reset:
+                - "458"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000883
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 201 Created
+        code: 201
+        duration: 342.432ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis/red-d8k49hdodlmc73btr41g/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 372
+        uncompressed: false
+        body: |
+            {"externalConnectionString":"rediss://red-d8k49hdodlmc73btr41g:8ZYm1DRMrzGMW7tQnHpFnWesk0dg73Xl@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k49hdodlmc73btr41g:6379","redisCLICommand":" REDISCLI_AUTH=8ZYm1DRMrzGMW7tQnHpFnWesk0dg73Xl valkey-cli --user red-d8k49hdodlmc73btr41g -h oregon-keyvalue.localhost.render.com -p 6377 --tls"}
+        headers:
+            Content-Length:
+                - "372"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:52:21 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "399"
+            Ratelimit-Reset:
+                - "38"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000884
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 62.134666ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis/red-d8k49hdodlmc73btr41g
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 496
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T16:52:21.311428Z","id":"red-d8k49hdodlmc73btr41g","ipAllowList":[{"cidrBlock":"1.1.1.1/32","description":"one"},{"cidrBlock":"2.2.2.2/32","description":"two"}],"name":"some-redis","options":{"maxmemoryPolicy":"noeviction","persistenceMode":"snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"starter","region":"oregon","status":"creating","updatedAt":"2026-06-09T16:52:21.311428Z","version":"8.1.4"}
+        headers:
+            Content-Length:
+                - "496"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:52:21 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "398"
+            Ratelimit-Reset:
+                - "38"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000885
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 85.633791ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis/red-d8k49hdodlmc73btr41g/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 372
+        uncompressed: false
+        body: |
+            {"externalConnectionString":"rediss://red-d8k49hdodlmc73btr41g:8ZYm1DRMrzGMW7tQnHpFnWesk0dg73Xl@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k49hdodlmc73btr41g:6379","redisCLICommand":" REDISCLI_AUTH=8ZYm1DRMrzGMW7tQnHpFnWesk0dg73Xl valkey-cli --user red-d8k49hdodlmc73btr41g -h oregon-keyvalue.localhost.render.com -p 6377 --tls"}
+        headers:
+            Content-Length:
+                - "372"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:52:21 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "397"
+            Ratelimit-Reset:
+                - "38"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000886
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 65.595542ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8k49hdodlmc73btr41g
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: red-d8k49hdodlmc73btr41g"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:52:22 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "396"
+            Ratelimit-Reset:
+                - "37"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000887
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 51.056625ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis/red-d8k49hdodlmc73btr41g
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 496
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T16:52:21.311428Z","id":"red-d8k49hdodlmc73btr41g","ipAllowList":[{"cidrBlock":"1.1.1.1/32","description":"one"},{"cidrBlock":"2.2.2.2/32","description":"two"}],"name":"some-redis","options":{"maxmemoryPolicy":"noeviction","persistenceMode":"snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"starter","region":"oregon","status":"creating","updatedAt":"2026-06-09T16:52:21.311428Z","version":"8.1.4"}
+        headers:
+            Content-Length:
+                - "496"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:52:22 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "395"
+            Ratelimit-Reset:
+                - "37"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000888
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 87.193166ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis/red-d8k49hdodlmc73btr41g/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 372
+        uncompressed: false
+        body: |
+            {"externalConnectionString":"rediss://red-d8k49hdodlmc73btr41g:8ZYm1DRMrzGMW7tQnHpFnWesk0dg73Xl@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k49hdodlmc73btr41g:6379","redisCLICommand":" REDISCLI_AUTH=8ZYm1DRMrzGMW7tQnHpFnWesk0dg73Xl valkey-cli --user red-d8k49hdodlmc73btr41g -h oregon-keyvalue.localhost.render.com -p 6377 --tls"}
+        headers:
+            Content-Length:
+                - "372"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:52:22 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "394"
+            Ratelimit-Reset:
+                - "37"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000889
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 66.762042ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8k49hdodlmc73btr41g
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: red-d8k49hdodlmc73btr41g"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:52:22 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "393"
+            Ratelimit-Reset:
+                - "37"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000890
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 52.145208ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis/red-d8k49hdodlmc73btr41g
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 496
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T16:52:21.311428Z","id":"red-d8k49hdodlmc73btr41g","ipAllowList":[{"cidrBlock":"1.1.1.1/32","description":"one"},{"cidrBlock":"2.2.2.2/32","description":"two"}],"name":"some-redis","options":{"maxmemoryPolicy":"noeviction","persistenceMode":"snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"starter","region":"oregon","status":"creating","updatedAt":"2026-06-09T16:52:21.311428Z","version":"8.1.4"}
+        headers:
+            Content-Length:
+                - "496"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:52:22 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "392"
+            Ratelimit-Reset:
+                - "37"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000891
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 81.677083ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis/red-d8k49hdodlmc73btr41g/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 372
+        uncompressed: false
+        body: |
+            {"externalConnectionString":"rediss://red-d8k49hdodlmc73btr41g:8ZYm1DRMrzGMW7tQnHpFnWesk0dg73Xl@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k49hdodlmc73btr41g:6379","redisCLICommand":" REDISCLI_AUTH=8ZYm1DRMrzGMW7tQnHpFnWesk0dg73Xl valkey-cli --user red-d8k49hdodlmc73btr41g -h oregon-keyvalue.localhost.render.com -p 6377 --tls"}
+        headers:
+            Content-Length:
+                - "372"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:52:22 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "391"
+            Ratelimit-Reset:
+                - "37"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000892
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 65.860209ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8k49hdodlmc73btr41g
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: red-d8k49hdodlmc73btr41g"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:52:23 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "390"
+            Ratelimit-Reset:
+                - "36"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000893
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 55.694083ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis/red-d8k49hdodlmc73btr41g
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 496
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T16:52:21.311428Z","id":"red-d8k49hdodlmc73btr41g","ipAllowList":[{"cidrBlock":"1.1.1.1/32","description":"one"},{"cidrBlock":"2.2.2.2/32","description":"two"}],"name":"some-redis","options":{"maxmemoryPolicy":"noeviction","persistenceMode":"snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"starter","region":"oregon","status":"creating","updatedAt":"2026-06-09T16:52:21.311428Z","version":"8.1.4"}
+        headers:
+            Content-Length:
+                - "496"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:52:23 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "389"
+            Ratelimit-Reset:
+                - "36"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000894
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 82.628708ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis/red-d8k49hdodlmc73btr41g/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 372
+        uncompressed: false
+        body: |
+            {"externalConnectionString":"rediss://red-d8k49hdodlmc73btr41g:8ZYm1DRMrzGMW7tQnHpFnWesk0dg73Xl@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k49hdodlmc73btr41g:6379","redisCLICommand":" REDISCLI_AUTH=8ZYm1DRMrzGMW7tQnHpFnWesk0dg73Xl valkey-cli --user red-d8k49hdodlmc73btr41g -h oregon-keyvalue.localhost.render.com -p 6377 --tls"}
+        headers:
+            Content-Length:
+                - "372"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:52:23 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "388"
+            Ratelimit-Reset:
+                - "36"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000895
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 68.34775ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8k49hdodlmc73btr41g
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: red-d8k49hdodlmc73btr41g"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 16:52:23 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "387"
+            Ratelimit-Reset:
+                - "36"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000896
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 53.049042ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis/red-d8k49hdodlmc73btr41g
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Date:
+                - Tue, 09 Jun 2026 16:52:23 GMT
+            Ratelimit-Limit:
+                - "100"
+            Ratelimit-Remaining:
+                - "99"
+            Ratelimit-Reset:
+                - "36"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000897
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 204 No Content
+        code: 204
+        duration: 102.688375ms

--- a/internal/provider/redis/models.go
+++ b/internal/provider/redis/models.go
@@ -1,11 +1,12 @@
 package redis
 
 import (
+	"terraform-provider-render/internal/client/logs"
+	"terraform-provider-render/internal/provider/common"
+
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"terraform-provider-render/internal/client/logs"
-	"terraform-provider-render/internal/provider/common"
 
 	"terraform-provider-render/internal/client"
 )
@@ -15,6 +16,7 @@ type RedisModel struct {
 	EnvironmentID     types.String `tfsdk:"environment_id"`
 	IPAllowList       types.Set    `tfsdk:"ip_allow_list"`
 	MaxMemoryPolicy   types.String `tfsdk:"max_memory_policy"`
+	PersistenceMode   types.String `tfsdk:"persistence_mode"`
 	Name              types.String `tfsdk:"name"`
 	Plan              types.String `tfsdk:"plan"`
 	Region            types.String `tfsdk:"region"`
@@ -53,6 +55,7 @@ func ModelForRedisResult(redis *client.Redis, plan *RedisModel, connectionInfo *
 		EnvironmentID:     types.StringPointerValue(redis.EnvironmentId),
 		IPAllowList:       common.IPAllowListFromClient(redis.IpAllowList, diags),
 		MaxMemoryPolicy:   types.StringValue(*redis.Options.MaxmemoryPolicy),
+		PersistenceMode:   types.StringValue(string(*redis.Options.PersistenceMode)),
 		Name:              types.StringValue(redis.Name),
 		Plan:              types.StringValue(string(redis.Plan)),
 		Region:            types.StringValue(string(redis.Region)),

--- a/internal/provider/redis/resource/internal/create.go
+++ b/internal/provider/redis/resource/internal/create.go
@@ -17,10 +17,16 @@ func CreateRedisRequestFromModel(ownerID string, plan redis.RedisModel) (client.
 		maxMemoryPolicy = client.MaxmemoryPolicy(plan.MaxMemoryPolicy.ValueString())
 	}
 
+	var persistenceMode *client.PersistenceMode
+	if plan.PersistenceMode.ValueString() != "" {
+		persistenceMode = (*client.PersistenceMode)(plan.PersistenceMode.ValueStringPointer())
+	}
+
 	var createRedisBody = client.CreateRedisJSONRequestBody{
 		EnvironmentId:   plan.EnvironmentID.ValueStringPointer(),
 		IpAllowList:     &ipAllowList,
 		MaxmemoryPolicy: &maxMemoryPolicy,
+		PersistenceMode: persistenceMode,
 		Name:            plan.Name.ValueString(),
 		OwnerId:         ownerID,
 		Plan:            client.RedisPlan(plan.Plan.ValueString()),

--- a/internal/provider/redis/resource/internal/update.go
+++ b/internal/provider/redis/resource/internal/update.go
@@ -17,6 +17,11 @@ func UpdateServiceRequestFromModel(plan redis.RedisModel) (client.UpdateRedisJSO
 		maxMemoryPolicy = client.MaxmemoryPolicy(plan.MaxMemoryPolicy.ValueString())
 	}
 
+	var persistenceMode *client.PersistenceMode
+	if plan.PersistenceMode.ValueString() != "" {
+		persistenceMode = (*client.PersistenceMode)(plan.PersistenceMode.ValueStringPointer())
+	}
+
 	var redisPlan client.RedisPlan
 	if plan.Plan.ValueString() != "" {
 		redisPlan = client.RedisPlan(plan.Plan.ValueString())
@@ -25,6 +30,7 @@ func UpdateServiceRequestFromModel(plan redis.RedisModel) (client.UpdateRedisJSO
 	updateRedisRequest := client.UpdateRedisJSONRequestBody{
 		IpAllowList:     &ipAllowList,
 		MaxmemoryPolicy: &maxMemoryPolicy,
+		PersistenceMode: persistenceMode,
 		Name:            plan.Name.ValueStringPointer(),
 		Plan:            &redisPlan,
 	}

--- a/internal/provider/redis/resource/resource_test.go
+++ b/internal/provider/redis/resource/resource_test.go
@@ -29,6 +29,7 @@ func TestRedisResource(t *testing.T) {
 					"environment_name":       config.StringVariable("first"),
 					"has_allow_list":         config.BoolVariable(true),
 					"max_memory_policy":      config.StringVariable("allkeys_lfu"),
+					"persistence_mode":       config.StringVariable("journal_snapshot"),
 					"name":                   config.StringVariable("test-redis"),
 					"plan":                   config.StringVariable("starter"),
 					"has_log_stream_setting": config.BoolVariable(true),
@@ -44,6 +45,7 @@ func TestRedisResource(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "plan", "starter"),
 					resource.TestCheckResourceAttr(resourceName, "region", "oregon"),
 					resource.TestCheckResourceAttr(resourceName, "max_memory_policy", "allkeys_lfu"),
+					resource.TestCheckResourceAttr(resourceName, "persistence_mode", "journal_snapshot"),
 
 					resource.TestCheckResourceAttrWith(resourceName, "environment_id", func(value string) error {
 						if !strings.HasPrefix(value, "evm-") {
@@ -79,12 +81,15 @@ func TestRedisResource(t *testing.T) {
 					}),
 
 					resource.TestCheckResourceAttrWith(resourceName, "connection_info.redis_cli_command", func(value string) error {
-						if !regexp.MustCompile(`^ REDISCLI_AUTH=.{32} redis-cli --user red-[a-z0-9]+ -h .*-.*.com -p 637[7|9] --tls$`).MatchString(value) {
+						if !regexp.MustCompile(`^ REDISCLI_AUTH=.{32} valkey-cli --user red-[a-z0-9]+ -h .*-.*.com -p 637[7|9] --tls$`).MatchString(value) {
 							return fmt.Errorf("expected redis_cli_command: %s to match regex", value)
 						}
 
 						return nil
 					}),
+
+					// Check the default persistence mode of paid Redis
+					resource.TestCheckResourceAttr("render_redis.test-redis-paid", "persistence_mode", "journal_snapshot"),
 				),
 			},
 			{
@@ -98,6 +103,7 @@ func TestRedisResource(t *testing.T) {
 					"environment_name":       config.StringVariable("first"),
 					"has_allow_list":         config.BoolVariable(true),
 					"max_memory_policy":      config.StringVariable("allkeys_lfu"),
+					"persistence_mode":       config.StringVariable("journal_snapshot"),
 					"name":                   config.StringVariable("test-redis"),
 					"plan":                   config.StringVariable("starter"),
 					"has_log_stream_setting": config.BoolVariable(true),
@@ -111,6 +117,7 @@ func TestRedisResource(t *testing.T) {
 					"environment_name":       config.StringVariable("second"),
 					"has_allow_list":         config.BoolVariable(false),
 					"max_memory_policy":      config.StringVariable("noeviction"),
+					"persistence_mode":       config.StringVariable("snapshot"),
 					"name":                   config.StringVariable("test-redis-new"),
 					"plan":                   config.StringVariable("standard"),
 					"has_log_stream_setting": config.BoolVariable(false),
@@ -125,6 +132,7 @@ func TestRedisResource(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "plan", "standard"),
 					resource.TestCheckResourceAttr(resourceName, "region", "oregon"),
 					resource.TestCheckResourceAttr(resourceName, "max_memory_policy", "noeviction"),
+					resource.TestCheckResourceAttr(resourceName, "persistence_mode", "snapshot"),
 					resource.TestCheckNoResourceAttr(resourceName, "log_stream_override.setting"),
 
 					resource.TestCheckResourceAttrWith(resourceName, "environment_id", func(value string) error {
@@ -151,6 +159,7 @@ func TestRedisResource(t *testing.T) {
 					"environment_name":       config.StringVariable("second"),
 					"has_allow_list":         config.BoolVariable(true),
 					"max_memory_policy":      config.StringVariable("noeviction"),
+					"persistence_mode":       config.StringVariable("snapshot"),
 					"name":                   config.StringVariable("test-redis-new"),
 					"plan":                   config.StringVariable("standard"),
 					"has_log_stream_setting": config.BoolVariable(false),
@@ -166,6 +175,70 @@ func TestRedisResource(t *testing.T) {
 
 					resource.TestCheckResourceAttr(resourceName, "ip_allow_list.1.cidr_block", "2.0.0.0/8"),
 					resource.TestCheckResourceAttr(resourceName, "ip_allow_list.1.description", "test-2"),
+				),
+			},
+			// Test the upgrade path from free Redis to paid to make sure the default persistence mode behaves as expected
+			{
+				ResourceName: "render_redis.test-redis-upgrade",
+				ConfigFile:   config.StaticFile("./testdata/redis_upgrade.tf"),
+				ConfigVariables: config.Variables{
+					"plan": config.StringVariable("free"),
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						checks.ExpectNoReplace(),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("render_redis.test-redis-upgrade", "persistence_mode", "off"),
+				),
+			},
+			{
+				ResourceName: "render_redis.test-redis-upgrade",
+				ConfigFile:   config.StaticFile("./testdata/redis_upgrade.tf"),
+				ConfigVariables: config.Variables{
+					"plan": config.StringVariable("starter"),
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						checks.ExpectNoReplace(),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("render_redis.test-redis-upgrade", "persistence_mode", "journal_snapshot"),
+				),
+			},
+			// Test the upgrade path from free Redis to paid to make sure the specified persistence mode behaves as expected
+			{
+				ResourceName: "render_redis.test-redis-upgrade2",
+				ConfigFile:   config.StaticFile("./testdata/redis_upgrade2.tf"),
+				ConfigVariables: config.Variables{
+					"plan":             config.StringVariable("free"),
+					"persistence_mode": config.StringVariable("off"),
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						checks.ExpectNoReplace(),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("render_redis.test-redis-upgrade2", "persistence_mode", "off"),
+				),
+			},
+			{
+				ResourceName: "render_redis.test-redis-upgrade2",
+				ConfigFile:   config.StaticFile("./testdata/redis_upgrade2.tf"),
+				ConfigVariables: config.Variables{
+					"plan":             config.StringVariable("starter"),
+					"persistence_mode": config.StringVariable("snapshot"),
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						checks.ExpectNoReplace(),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("render_redis.test-redis-upgrade2", "persistence_mode", "snapshot"),
 				),
 			},
 		},

--- a/internal/provider/redis/resource/schema.go
+++ b/internal/provider/redis/resource/schema.go
@@ -16,6 +16,7 @@ func Schema(ctx context.Context) schema.Schema {
 			"environment_id":      resource.ResourceEnvironmentID,
 			"ip_allow_list":       resource.IPAllowList,
 			"max_memory_policy":   resource.MaxMemoryPolicy,
+			"persistence_mode":    resource.PersistenceMode,
 			"name":                resource.ServiceName,
 			"plan":                resource.RedisPlan,
 			"region":              resource.Region,

--- a/internal/provider/redis/resource/testdata/redis.tf
+++ b/internal/provider/redis/resource/testdata/redis.tf
@@ -7,6 +7,9 @@ variable "has_allow_list" {
 variable "max_memory_policy" {
   type = string
 }
+variable "persistence_mode" {
+  type = string
+}
 variable "name" {
   type = string
 }
@@ -19,33 +22,34 @@ variable "has_log_stream_setting" {
 
 locals {
   environment_map = {
-    "first" = render_project.first.environments,
+    "first"  = render_project.first.environments,
     "second" = render_project.second.environments,
   }
 }
 
-resource "render_project" "first"  {
+resource "render_project" "first" {
   name = "first"
   environments = {
     "prod" : { name : "prod", protected_status : "protected" },
   }
 }
 
-resource "render_project" "second"  {
+resource "render_project" "second" {
   name = "second"
   environments = {
     "prod" : { name : "prod", protected_status : "protected" },
   }
   # Ensure there is always an order to creating these
-  depends_on = [    render_project.first  ]
+  depends_on = [render_project.first]
 }
 
 resource "render_redis" "test-redis" {
-  environment_id = var.environment_name != null ? local.environment_map[var.environment_name]["prod"].id : null
+  environment_id    = var.environment_name != null ? local.environment_map[var.environment_name]["prod"].id : null
   max_memory_policy = var.max_memory_policy
-  name = var.name
-  plan = var.plan
-  region = "oregon"
+  persistence_mode  = var.persistence_mode
+  name              = var.name
+  plan              = var.plan
+  region            = "oregon"
   ip_allow_list = var.has_allow_list ? [
     {
       cidr_block  = "1.1.1.1/32"
@@ -61,4 +65,11 @@ resource "render_redis" "test-redis" {
   } : null
 
   depends_on = [render_project.first, render_project.second]
+}
+
+resource "render_redis" "test-redis-paid" {
+  name              = "test-redis-paid"
+  plan              = "starter"
+  region            = "oregon"
+  max_memory_policy = "allkeys_lfu"
 }

--- a/internal/provider/redis/resource/testdata/redis_cassette.yaml
+++ b/internal/provider/redis/resource/testdata/redis_cassette.yaml
@@ -6,13 +6,13 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 116
+        content_length: 148
         transfer_encoding: []
         trailer: {}
         host: https://api.testing.render.com/v1
         remote_addr: ""
         request_uri: ""
-        body: '{"environments":[{"name":"prod","protectedStatus":"protected"}],"name":"first","ownerId":"some-owner-id"}'
+        body: '{"environments":[{"name":"prod","networkIsolationEnabled":false,"protectedStatus":"protected"}],"name":"first","ownerId":"some-owner-id"}'
         form: {}
         headers:
             Authorization:
@@ -29,27 +29,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 285
+        content_length: 282
         uncompressed: false
         body: |
-            {"createdAt":"2024-09-09T16:35:27.305482Z","environmentIds":["evm-crfi7js8m55c703hl2fg"],"id":"prj-crfi7js8m55c703hl2f0","name":"first","owner":{"email":"email@example.com","id":"some-owner-id","name":"Test Terraform","type":"team"},"updatedAt":"2024-09-09T16:35:27.305482Z"}
+            {"createdAt":"2026-06-09T17:11:03.779133Z","environmentIds":["evm-d8k4i9todlmc73btr56g"],"id":"prj-d8k4i9todlmc73btr55g","name":"first","owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"updatedAt":"2026-06-09T17:11:03.779133Z"}
         headers:
             Content-Length:
-                - "285"
+                - "282"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:27 GMT
+                - Tue, 09 Jun 2026 17:11:03 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "100"
             Ratelimit-Remaining:
-                - "9998"
+                - "99"
             Ratelimit-Reset:
-                - "32"
+                - "56"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000143
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000959
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -60,8 +60,68 @@ interactions:
                 - 1; mode=block
         status: 201 Created
         code: 201
-        duration: 145.171ms
+        duration: 131.615334ms
     - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 147
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: '{"ipAllowList":[],"maxmemoryPolicy":"allkeys_lfu","name":"test-redis-paid","ownerId":"some-owner-id","plan":"starter","region":"oregon"}'
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            Content-Type:
+                - application/json
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 424
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T17:11:03.738122174Z","id":"red-d8k4i9todlmc73btr54g","ipAllowList":null,"name":"test-redis-paid","options":{"maxmemoryPolicy":"allkeys_lfu","persistenceMode":"journal_snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"starter","region":"oregon","status":"unknown","updatedAt":"2026-06-09T17:11:03.738122174Z","version":"8.1.4"}
+        headers:
+            Content-Length:
+                - "424"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:03 GMT
+            Ratelimit-Limit:
+                - "20"
+            Ratelimit-Remaining:
+                - "15"
+            Ratelimit-Reset:
+                - "2936"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000958
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 201 Created
+        code: 201
+        duration: 358.962291ms
+    - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -79,7 +139,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/environments/evm-crfi7js8m55c703hl2fg
+        url: https://api.testing.render.com/v1/environments/evm-d8k4i9todlmc73btr56g
         method: GET
       response:
         proto: HTTP/2.0
@@ -87,27 +147,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 190
+        content_length: 222
         uncompressed: false
         body: |
-            {"databasesIds":null,"envGroupIds":null,"id":"evm-crfi7js8m55c703hl2fg","name":"prod","projectId":"prj-crfi7js8m55c703hl2f0","protectedStatus":"protected","redisIds":null,"serviceIds":null}
+            {"databasesIds":null,"envGroupIds":null,"id":"evm-d8k4i9todlmc73btr56g","name":"prod","networkIsolationEnabled":false,"projectId":"prj-d8k4i9todlmc73btr55g","protectedStatus":"protected","redisIds":null,"serviceIds":null}
         headers:
             Content-Length:
-                - "190"
+                - "222"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:27 GMT
+                - Tue, 09 Jun 2026 17:11:03 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9987"
+                - "399"
             Ratelimit-Reset:
-                - "32"
+                - "56"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000144
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000960
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -118,67 +178,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 41.325375ms
-    - id: 2
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 117
-        transfer_encoding: []
-        trailer: {}
-        host: https://api.testing.render.com/v1
-        remote_addr: ""
-        request_uri: ""
-        body: '{"environments":[{"name":"prod","protectedStatus":"protected"}],"name":"second","ownerId":"some-owner-id"}'
-        form: {}
-        headers:
-            Authorization:
-                - some-api-key
-            Content-Type:
-                - application/json
-            User-Agent:
-                - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/projects
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 286
-        uncompressed: false
-        body: |
-            {"createdAt":"2024-09-09T16:35:27.450645Z","environmentIds":["evm-crfi7js8m55c703hl2gg"],"id":"prj-crfi7js8m55c703hl2g0","name":"second","owner":{"email":"email@example.com","id":"some-owner-id","name":"Test Terraform","type":"team"},"updatedAt":"2024-09-09T16:35:27.450645Z"}
-        headers:
-            Content-Length:
-                - "286"
-            Content-Type:
-                - application/json; charset=utf-8
-            Date:
-                - Mon, 09 Sep 2024 16:35:27 GMT
-            Ratelimit-Limit:
-                - "10000"
-            Ratelimit-Remaining:
-                - "9997"
-            Ratelimit-Reset:
-                - "32"
-            Referrer-Policy:
-                - same-origin
-            Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000145
-            Vary:
-                - Origin
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Xss-Protection:
-                - 1; mode=block
-        status: 201 Created
-        code: 201
-        duration: 81.226083ms
+        duration: 64.184041ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -197,7 +197,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/environments/evm-crfi7js8m55c703hl2gg
+        url: https://api.testing.render.com/v1/redis/red-d8k4i9todlmc73btr54g/connection-info
         method: GET
       response:
         proto: HTTP/2.0
@@ -205,27 +205,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 190
+        content_length: 372
         uncompressed: false
         body: |
-            {"databasesIds":null,"envGroupIds":null,"id":"evm-crfi7js8m55c703hl2gg","name":"prod","projectId":"prj-crfi7js8m55c703hl2g0","protectedStatus":"protected","redisIds":null,"serviceIds":null}
+            {"externalConnectionString":"rediss://red-d8k4i9todlmc73btr54g:uPs9p2GaBjeHP19tbn4bYjWQ2iGcegn5@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k4i9todlmc73btr54g:6379","redisCLICommand":" REDISCLI_AUTH=uPs9p2GaBjeHP19tbn4bYjWQ2iGcegn5 valkey-cli --user red-d8k4i9todlmc73btr54g -h oregon-keyvalue.localhost.render.com -p 6377 --tls"}
         headers:
             Content-Length:
-                - "190"
+                - "372"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:27 GMT
+                - Tue, 09 Jun 2026 17:11:04 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9986"
+                - "398"
             Ratelimit-Reset:
-                - "32"
+                - "55"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000146
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000961
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -236,19 +236,19 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 40.835125ms
+        duration: 62.822333ms
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 281
+        content_length: 149
         transfer_encoding: []
         trailer: {}
         host: https://api.testing.render.com/v1
         remote_addr: ""
         request_uri: ""
-        body: '{"environmentId":"evm-crfi7js8m55c703hl2fg","ipAllowList":[{"cidrBlock":"1.1.1.1/32","description":"test"},{"cidrBlock":"2.0.0.0/8","description":"test-2"}],"maxmemoryPolicy":"allkeys_lfu","name":"test-redis","ownerId":"some-owner-id","plan":"starter","region":"oregon"}'
+        body: '{"environments":[{"name":"prod","networkIsolationEnabled":false,"protectedStatus":"protected"}],"name":"second","ownerId":"some-owner-id"}'
         form: {}
         headers:
             Authorization:
@@ -257,7 +257,7 @@ interactions:
                 - application/json
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/redis
+        url: https://api.testing.render.com/v1/projects
         method: POST
       response:
         proto: HTTP/2.0
@@ -265,27 +265,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 524
+        content_length: 283
         uncompressed: false
         body: |
-            {"createdAt":"2024-09-09T16:35:27.643669961Z","environmentId":"evm-crfi7js8m55c703hl2fg","id":"red-crfi7js8m55c703hl2h0","ipAllowList":[{"cidrBlock":"1.1.1.1/32","description":"test"},{"cidrBlock":"2.0.0.0/8","description":"test-2"}],"name":"test-redis","options":{"maxmemoryPolicy":"allkeys_lfu"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"Test Terraform","type":"team"},"plan":"starter","region":"oregon","status":"creating","updatedAt":"2024-09-09T16:35:27.643669961Z","version":"6.2.14"}
+            {"createdAt":"2026-06-09T17:11:04.275047Z","environmentIds":["evm-d8k4ia5odlmc73btr590"],"id":"prj-d8k4ia5odlmc73btr580","name":"second","owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"updatedAt":"2026-06-09T17:11:04.275047Z"}
         headers:
             Content-Length:
-                - "524"
+                - "283"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:27 GMT
+                - Tue, 09 Jun 2026 17:11:04 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "100"
             Ratelimit-Remaining:
-                - "9999"
+                - "98"
             Ratelimit-Reset:
-                - "32"
+                - "55"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000147
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000962
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -296,7 +296,7 @@ interactions:
                 - 1; mode=block
         status: 201 Created
         code: 201
-        duration: 223.503667ms
+        duration: 121.60925ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -315,7 +315,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/redis/red-crfi7js8m55c703hl2h0/connection-info
+        url: https://api.testing.render.com/v1/environments/evm-d8k4ia5odlmc73btr590
         method: GET
       response:
         proto: HTTP/2.0
@@ -323,27 +323,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 365
+        content_length: 222
         uncompressed: false
         body: |
-            {"externalConnectionString":"rediss://red-crfi7js8m55c703hl2h0:gIRSGDdOQriMcOCPQHj1durmcXvsgVqm@oregon-redis.localhost.render.com:6377","internalConnectionString":"redis://red-crfi7js8m55c703hl2h0:6379","redisCLICommand":" REDISCLI_AUTH=gIRSGDdOQriMcOCPQHj1durmcXvsgVqm redis-cli --user red-crfi7js8m55c703hl2h0 -h oregon-redis.localhost.render.com -p 6377 --tls"}
+            {"databasesIds":null,"envGroupIds":null,"id":"evm-d8k4ia5odlmc73btr590","name":"prod","networkIsolationEnabled":false,"projectId":"prj-d8k4ia5odlmc73btr580","protectedStatus":"protected","redisIds":null,"serviceIds":null}
         headers:
             Content-Length:
-                - "365"
+                - "222"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:27 GMT
+                - Tue, 09 Jun 2026 17:11:04 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9985"
+                - "397"
             Ratelimit-Reset:
-                - "32"
+                - "55"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000148
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000963
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -354,8 +354,126 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 51.036208ms
+        duration: 69.142416ms
     - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 318
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: '{"environmentId":"evm-d8k4i9todlmc73btr56g","ipAllowList":[{"cidrBlock":"1.1.1.1/32","description":"test"},{"cidrBlock":"2.0.0.0/8","description":"test-2"}],"maxmemoryPolicy":"allkeys_lfu","name":"test-redis","ownerId":"some-owner-id","persistenceMode":"journal_snapshot","plan":"starter","region":"oregon"}'
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            Content-Type:
+                - application/json
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 557
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T17:11:04.649569082Z","environmentId":"evm-d8k4i9todlmc73btr56g","id":"red-d8k4ia5odlmc73btr5a0","ipAllowList":[{"cidrBlock":"1.1.1.1/32","description":"test"},{"cidrBlock":"2.0.0.0/8","description":"test-2"}],"name":"test-redis","options":{"maxmemoryPolicy":"allkeys_lfu","persistenceMode":"journal_snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"starter","region":"oregon","status":"creating","updatedAt":"2026-06-09T17:11:04.649569082Z","version":"8.1.4"}
+        headers:
+            Content-Length:
+                - "557"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:04 GMT
+            Ratelimit-Limit:
+                - "20"
+            Ratelimit-Remaining:
+                - "14"
+            Ratelimit-Reset:
+                - "2935"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000964
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 201 Created
+        code: 201
+        duration: 312.70075ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis/red-d8k4ia5odlmc73btr5a0/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 372
+        uncompressed: false
+        body: |
+            {"externalConnectionString":"rediss://red-d8k4ia5odlmc73btr5a0:hBFnAKplTyebA0SdRNnSdBJOkQ7QoR03@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k4ia5odlmc73btr5a0:6379","redisCLICommand":" REDISCLI_AUTH=hBFnAKplTyebA0SdRNnSdBJOkQ7QoR03 valkey-cli --user red-d8k4ia5odlmc73btr5a0 -h oregon-keyvalue.localhost.render.com -p 6377 --tls"}
+        headers:
+            Content-Length:
+                - "372"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:04 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "396"
+            Ratelimit-Reset:
+                - "55"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000965
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 79.963916ms
+    - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -375,7 +493,7 @@ interactions:
                 - application/json
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/logs/streams/resource/red-crfi7js8m55c703hl2h0
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8k4ia5odlmc73btr5a0
         method: PUT
       response:
         proto: HTTP/2.0
@@ -386,24 +504,24 @@ interactions:
         content_length: 73
         uncompressed: false
         body: |
-            {"endpoint":"","resourceId":"red-crfi7js8m55c703hl2h0","setting":"drop"}
+            {"endpoint":"","resourceId":"red-d8k4ia5odlmc73btr5a0","setting":"drop"}
         headers:
             Content-Length:
                 - "73"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:27 GMT
+                - Tue, 09 Jun 2026 17:11:05 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "100"
             Ratelimit-Remaining:
-                - "9996"
+                - "97"
             Ratelimit-Reset:
-                - "32"
+                - "54"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000149
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000966
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -414,123 +532,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 46.927083ms
-    - id: 7
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: https://api.testing.render.com/v1
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Authorization:
-                - some-api-key
-            User-Agent:
-                - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/projects/prj-crfi7js8m55c703hl2f0
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 285
-        uncompressed: false
-        body: |
-            {"createdAt":"2024-09-09T16:35:27.305482Z","environmentIds":["evm-crfi7js8m55c703hl2fg"],"id":"prj-crfi7js8m55c703hl2f0","name":"first","owner":{"email":"email@example.com","id":"some-owner-id","name":"Test Terraform","type":"team"},"updatedAt":"2024-09-09T16:35:27.305482Z"}
-        headers:
-            Content-Length:
-                - "285"
-            Content-Type:
-                - application/json; charset=utf-8
-            Date:
-                - Mon, 09 Sep 2024 16:35:28 GMT
-            Ratelimit-Limit:
-                - "10000"
-            Ratelimit-Remaining:
-                - "9984"
-            Ratelimit-Reset:
-                - "31"
-            Referrer-Policy:
-                - same-origin
-            Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000150
-            Vary:
-                - Origin
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Xss-Protection:
-                - 1; mode=block
-        status: 200 OK
-        code: 200
-        duration: 62.751583ms
-    - id: 8
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: https://api.testing.render.com/v1
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Authorization:
-                - some-api-key
-            User-Agent:
-                - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/environments/evm-crfi7js8m55c703hl2fg
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 214
-        uncompressed: false
-        body: |
-            {"databasesIds":null,"envGroupIds":null,"id":"evm-crfi7js8m55c703hl2fg","name":"prod","projectId":"prj-crfi7js8m55c703hl2f0","protectedStatus":"protected","redisIds":["red-crfi7js8m55c703hl2h0"],"serviceIds":null}
-        headers:
-            Content-Length:
-                - "214"
-            Content-Type:
-                - application/json; charset=utf-8
-            Date:
-                - Mon, 09 Sep 2024 16:35:28 GMT
-            Ratelimit-Limit:
-                - "10000"
-            Ratelimit-Remaining:
-                - "9983"
-            Ratelimit-Reset:
-                - "31"
-            Referrer-Policy:
-                - same-origin
-            Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000151
-            Vary:
-                - Origin
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Xss-Protection:
-                - 1; mode=block
-        status: 200 OK
-        code: 200
-        duration: 37.430167ms
+        duration: 70.073958ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -549,7 +551,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/projects/prj-crfi7js8m55c703hl2g0
+        url: https://api.testing.render.com/v1/projects/prj-d8k4i9todlmc73btr55g
         method: GET
       response:
         proto: HTTP/2.0
@@ -557,27 +559,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 286
+        content_length: 282
         uncompressed: false
         body: |
-            {"createdAt":"2024-09-09T16:35:27.450645Z","environmentIds":["evm-crfi7js8m55c703hl2gg"],"id":"prj-crfi7js8m55c703hl2g0","name":"second","owner":{"email":"email@example.com","id":"some-owner-id","name":"Test Terraform","type":"team"},"updatedAt":"2024-09-09T16:35:27.450645Z"}
+            {"createdAt":"2026-06-09T17:11:03.779133Z","environmentIds":["evm-d8k4i9todlmc73btr56g"],"id":"prj-d8k4i9todlmc73btr55g","name":"first","owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"updatedAt":"2026-06-09T17:11:03.779133Z"}
         headers:
             Content-Length:
-                - "286"
+                - "282"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:28 GMT
+                - Tue, 09 Jun 2026 17:11:05 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9982"
+                - "395"
             Ratelimit-Reset:
-                - "31"
+                - "54"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000152
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000967
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -588,7 +590,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 57.957209ms
+        duration: 99.081ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -607,7 +609,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/environments/evm-crfi7js8m55c703hl2gg
+        url: https://api.testing.render.com/v1/redis/red-d8k4i9todlmc73btr54g
         method: GET
       response:
         proto: HTTP/2.0
@@ -615,27 +617,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 190
+        content_length: 419
         uncompressed: false
         body: |
-            {"databasesIds":null,"envGroupIds":null,"id":"evm-crfi7js8m55c703hl2gg","name":"prod","projectId":"prj-crfi7js8m55c703hl2g0","protectedStatus":"protected","redisIds":null,"serviceIds":null}
+            {"createdAt":"2026-06-09T17:11:03.738122Z","id":"red-d8k4i9todlmc73btr54g","ipAllowList":null,"name":"test-redis-paid","options":{"maxmemoryPolicy":"allkeys_lfu","persistenceMode":"journal_snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"starter","region":"oregon","status":"creating","updatedAt":"2026-06-09T17:11:03.738122Z","version":"8.1.4"}
         headers:
             Content-Length:
-                - "190"
+                - "419"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:28 GMT
+                - Tue, 09 Jun 2026 17:11:05 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9981"
+                - "394"
             Ratelimit-Reset:
-                - "31"
+                - "54"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000153
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000968
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -646,7 +648,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 39.032458ms
+        duration: 110.886416ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -665,7 +667,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/redis/red-crfi7js8m55c703hl2h0
+        url: https://api.testing.render.com/v1/environments/evm-d8k4i9todlmc73btr56g
         method: GET
       response:
         proto: HTTP/2.0
@@ -673,27 +675,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 516
+        content_length: 246
         uncompressed: false
         body: |
-            {"createdAt":"2024-09-09T16:35:27.64367Z","environmentId":"evm-crfi7js8m55c703hl2fg","id":"red-crfi7js8m55c703hl2h0","ipAllowList":[{"cidrBlock":"1.1.1.1/32","description":"test"},{"cidrBlock":"2.0.0.0/8","description":"test-2"}],"name":"test-redis","options":{"maxmemoryPolicy":"allkeys_lfu"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"Test Terraform","type":"team"},"plan":"starter","region":"oregon","status":"creating","updatedAt":"2024-09-09T16:35:27.64367Z","version":"6.2.14"}
+            {"databasesIds":null,"envGroupIds":null,"id":"evm-d8k4i9todlmc73btr56g","name":"prod","networkIsolationEnabled":false,"projectId":"prj-d8k4i9todlmc73btr55g","protectedStatus":"protected","redisIds":["red-d8k4ia5odlmc73btr5a0"],"serviceIds":null}
         headers:
             Content-Length:
-                - "516"
+                - "246"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:28 GMT
+                - Tue, 09 Jun 2026 17:11:05 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9980"
+                - "393"
             Ratelimit-Reset:
-                - "31"
+                - "54"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000154
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000969
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -704,7 +706,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 55.451416ms
+        duration: 64.399ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -723,7 +725,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/redis/red-crfi7js8m55c703hl2h0/connection-info
+        url: https://api.testing.render.com/v1/redis/red-d8k4i9todlmc73btr54g/connection-info
         method: GET
       response:
         proto: HTTP/2.0
@@ -731,27 +733,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 365
+        content_length: 372
         uncompressed: false
         body: |
-            {"externalConnectionString":"rediss://red-crfi7js8m55c703hl2h0:gIRSGDdOQriMcOCPQHj1durmcXvsgVqm@oregon-redis.localhost.render.com:6377","internalConnectionString":"redis://red-crfi7js8m55c703hl2h0:6379","redisCLICommand":" REDISCLI_AUTH=gIRSGDdOQriMcOCPQHj1durmcXvsgVqm redis-cli --user red-crfi7js8m55c703hl2h0 -h oregon-redis.localhost.render.com -p 6377 --tls"}
+            {"externalConnectionString":"rediss://red-d8k4i9todlmc73btr54g:uPs9p2GaBjeHP19tbn4bYjWQ2iGcegn5@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k4i9todlmc73btr54g:6379","redisCLICommand":" REDISCLI_AUTH=uPs9p2GaBjeHP19tbn4bYjWQ2iGcegn5 valkey-cli --user red-d8k4i9todlmc73btr54g -h oregon-keyvalue.localhost.render.com -p 6377 --tls"}
         headers:
             Content-Length:
-                - "365"
+                - "372"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:28 GMT
+                - Tue, 09 Jun 2026 17:11:05 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9979"
+                - "392"
             Ratelimit-Reset:
-                - "31"
+                - "54"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000155
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000970
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -762,7 +764,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 54.70275ms
+        duration: 66.660167ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -781,7 +783,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/logs/streams/resource/red-crfi7js8m55c703hl2h0
+        url: https://api.testing.render.com/v1/projects/prj-d8k4ia5odlmc73btr580
         method: GET
       response:
         proto: HTTP/2.0
@@ -789,27 +791,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 73
+        content_length: 283
         uncompressed: false
         body: |
-            {"endpoint":"","resourceId":"red-crfi7js8m55c703hl2h0","setting":"drop"}
+            {"createdAt":"2026-06-09T17:11:04.275047Z","environmentIds":["evm-d8k4ia5odlmc73btr590"],"id":"prj-d8k4ia5odlmc73btr580","name":"second","owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"updatedAt":"2026-06-09T17:11:04.275047Z"}
         headers:
             Content-Length:
-                - "73"
+                - "283"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:28 GMT
+                - Tue, 09 Jun 2026 17:11:06 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9978"
+                - "391"
             Ratelimit-Reset:
-                - "31"
+                - "53"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000156
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000971
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -820,7 +822,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 52.137375ms
+        duration: 94.378708ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -839,7 +841,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/redis/red-crfi7js8m55c703hl2h0
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8k4i9todlmc73btr54g
         method: GET
       response:
         proto: HTTP/2.0
@@ -847,27 +849,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 516
+        content_length: 50
         uncompressed: false
         body: |
-            {"createdAt":"2024-09-09T16:35:27.64367Z","environmentId":"evm-crfi7js8m55c703hl2fg","id":"red-crfi7js8m55c703hl2h0","ipAllowList":[{"cidrBlock":"1.1.1.1/32","description":"test"},{"cidrBlock":"2.0.0.0/8","description":"test-2"}],"name":"test-redis","options":{"maxmemoryPolicy":"allkeys_lfu"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"Test Terraform","type":"team"},"plan":"starter","region":"oregon","status":"creating","updatedAt":"2024-09-09T16:35:27.64367Z","version":"6.2.14"}
+            {"message":"not found: red-d8k4i9todlmc73btr54g"}
         headers:
             Content-Length:
-                - "516"
+                - "50"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:28 GMT
+                - Tue, 09 Jun 2026 17:11:06 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9977"
+                - "390"
             Ratelimit-Reset:
-                - "31"
+                - "53"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000157
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000972
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -876,9 +878,9 @@ interactions:
                 - DENY
             X-Xss-Protection:
                 - 1; mode=block
-        status: 200 OK
-        code: 200
-        duration: 59.175ms
+        status: 404 Not Found
+        code: 404
+        duration: 55.450541ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -897,7 +899,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/redis/red-crfi7js8m55c703hl2h0/connection-info
+        url: https://api.testing.render.com/v1/environments/evm-d8k4ia5odlmc73btr590
         method: GET
       response:
         proto: HTTP/2.0
@@ -905,27 +907,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 365
+        content_length: 222
         uncompressed: false
         body: |
-            {"externalConnectionString":"rediss://red-crfi7js8m55c703hl2h0:gIRSGDdOQriMcOCPQHj1durmcXvsgVqm@oregon-redis.localhost.render.com:6377","internalConnectionString":"redis://red-crfi7js8m55c703hl2h0:6379","redisCLICommand":" REDISCLI_AUTH=gIRSGDdOQriMcOCPQHj1durmcXvsgVqm redis-cli --user red-crfi7js8m55c703hl2h0 -h oregon-redis.localhost.render.com -p 6377 --tls"}
+            {"databasesIds":null,"envGroupIds":null,"id":"evm-d8k4ia5odlmc73btr590","name":"prod","networkIsolationEnabled":false,"projectId":"prj-d8k4ia5odlmc73btr580","protectedStatus":"protected","redisIds":null,"serviceIds":null}
         headers:
             Content-Length:
-                - "365"
+                - "222"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:28 GMT
+                - Tue, 09 Jun 2026 17:11:06 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9976"
+                - "389"
             Ratelimit-Reset:
-                - "31"
+                - "53"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000158
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000973
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -936,7 +938,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 52.420791ms
+        duration: 63.605792ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -955,7 +957,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/logs/streams/resource/red-crfi7js8m55c703hl2h0
+        url: https://api.testing.render.com/v1/redis/red-d8k4ia5odlmc73btr5a0
         method: GET
       response:
         proto: HTTP/2.0
@@ -963,27 +965,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 73
+        content_length: 551
         uncompressed: false
         body: |
-            {"endpoint":"","resourceId":"red-crfi7js8m55c703hl2h0","setting":"drop"}
+            {"createdAt":"2026-06-09T17:11:04.649569Z","environmentId":"evm-d8k4i9todlmc73btr56g","id":"red-d8k4ia5odlmc73btr5a0","ipAllowList":[{"cidrBlock":"1.1.1.1/32","description":"test"},{"cidrBlock":"2.0.0.0/8","description":"test-2"}],"name":"test-redis","options":{"maxmemoryPolicy":"allkeys_lfu","persistenceMode":"journal_snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"starter","region":"oregon","status":"creating","updatedAt":"2026-06-09T17:11:04.649569Z","version":"8.1.4"}
         headers:
             Content-Length:
-                - "73"
+                - "551"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:28 GMT
+                - Tue, 09 Jun 2026 17:11:06 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9975"
+                - "388"
             Ratelimit-Reset:
-                - "31"
+                - "53"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000159
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000974
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -994,7 +996,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 48.333083ms
+        duration: 104.00975ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -1013,7 +1015,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/projects/prj-crfi7js8m55c703hl2f0
+        url: https://api.testing.render.com/v1/redis/red-d8k4ia5odlmc73btr5a0/connection-info
         method: GET
       response:
         proto: HTTP/2.0
@@ -1021,27 +1023,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 285
+        content_length: 372
         uncompressed: false
         body: |
-            {"createdAt":"2024-09-09T16:35:27.305482Z","environmentIds":["evm-crfi7js8m55c703hl2fg"],"id":"prj-crfi7js8m55c703hl2f0","name":"first","owner":{"email":"email@example.com","id":"some-owner-id","name":"Test Terraform","type":"team"},"updatedAt":"2024-09-09T16:35:27.305482Z"}
+            {"externalConnectionString":"rediss://red-d8k4ia5odlmc73btr5a0:hBFnAKplTyebA0SdRNnSdBJOkQ7QoR03@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k4ia5odlmc73btr5a0:6379","redisCLICommand":" REDISCLI_AUTH=hBFnAKplTyebA0SdRNnSdBJOkQ7QoR03 valkey-cli --user red-d8k4ia5odlmc73btr5a0 -h oregon-keyvalue.localhost.render.com -p 6377 --tls"}
         headers:
             Content-Length:
-                - "285"
+                - "372"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:29 GMT
+                - Tue, 09 Jun 2026 17:11:06 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9974"
+                - "387"
             Ratelimit-Reset:
-                - "30"
+                - "53"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000160
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000975
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1052,7 +1054,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 57.213625ms
+        duration: 84.506166ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -1071,7 +1073,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/environments/evm-crfi7js8m55c703hl2fg
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8k4ia5odlmc73btr5a0
         method: GET
       response:
         proto: HTTP/2.0
@@ -1079,27 +1081,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 214
+        content_length: 73
         uncompressed: false
         body: |
-            {"databasesIds":null,"envGroupIds":null,"id":"evm-crfi7js8m55c703hl2fg","name":"prod","projectId":"prj-crfi7js8m55c703hl2f0","protectedStatus":"protected","redisIds":["red-crfi7js8m55c703hl2h0"],"serviceIds":null}
+            {"endpoint":"","resourceId":"red-d8k4ia5odlmc73btr5a0","setting":"drop"}
         headers:
             Content-Length:
-                - "214"
+                - "73"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:29 GMT
+                - Tue, 09 Jun 2026 17:11:06 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9973"
+                - "386"
             Ratelimit-Reset:
-                - "30"
+                - "53"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000161
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000976
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1110,7 +1112,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 35.155291ms
+        duration: 77.956458ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -1129,7 +1131,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/projects/prj-crfi7js8m55c703hl2g0
+        url: https://api.testing.render.com/v1/redis/red-d8k4ia5odlmc73btr5a0
         method: GET
       response:
         proto: HTTP/2.0
@@ -1137,27 +1139,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 286
+        content_length: 551
         uncompressed: false
         body: |
-            {"createdAt":"2024-09-09T16:35:27.450645Z","environmentIds":["evm-crfi7js8m55c703hl2gg"],"id":"prj-crfi7js8m55c703hl2g0","name":"second","owner":{"email":"email@example.com","id":"some-owner-id","name":"Test Terraform","type":"team"},"updatedAt":"2024-09-09T16:35:27.450645Z"}
+            {"createdAt":"2026-06-09T17:11:04.649569Z","environmentId":"evm-d8k4i9todlmc73btr56g","id":"red-d8k4ia5odlmc73btr5a0","ipAllowList":[{"cidrBlock":"1.1.1.1/32","description":"test"},{"cidrBlock":"2.0.0.0/8","description":"test-2"}],"name":"test-redis","options":{"maxmemoryPolicy":"allkeys_lfu","persistenceMode":"journal_snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"starter","region":"oregon","status":"creating","updatedAt":"2026-06-09T17:11:04.649569Z","version":"8.1.4"}
         headers:
             Content-Length:
-                - "286"
+                - "551"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:29 GMT
+                - Tue, 09 Jun 2026 17:11:07 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9972"
+                - "385"
             Ratelimit-Reset:
-                - "30"
+                - "52"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000162
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000977
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1168,7 +1170,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 52.636792ms
+        duration: 99.416708ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1187,7 +1189,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/environments/evm-crfi7js8m55c703hl2gg
+        url: https://api.testing.render.com/v1/redis/red-d8k4ia5odlmc73btr5a0/connection-info
         method: GET
       response:
         proto: HTTP/2.0
@@ -1195,27 +1197,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 190
+        content_length: 372
         uncompressed: false
         body: |
-            {"databasesIds":null,"envGroupIds":null,"id":"evm-crfi7js8m55c703hl2gg","name":"prod","projectId":"prj-crfi7js8m55c703hl2g0","protectedStatus":"protected","redisIds":null,"serviceIds":null}
+            {"externalConnectionString":"rediss://red-d8k4ia5odlmc73btr5a0:hBFnAKplTyebA0SdRNnSdBJOkQ7QoR03@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k4ia5odlmc73btr5a0:6379","redisCLICommand":" REDISCLI_AUTH=hBFnAKplTyebA0SdRNnSdBJOkQ7QoR03 valkey-cli --user red-d8k4ia5odlmc73btr5a0 -h oregon-keyvalue.localhost.render.com -p 6377 --tls"}
         headers:
             Content-Length:
-                - "190"
+                - "372"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:29 GMT
+                - Tue, 09 Jun 2026 17:11:07 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9971"
+                - "384"
             Ratelimit-Reset:
-                - "30"
+                - "52"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000163
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000978
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1226,7 +1228,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 37.055417ms
+        duration: 79.563667ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1245,7 +1247,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/redis/red-crfi7js8m55c703hl2h0
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8k4ia5odlmc73btr5a0
         method: GET
       response:
         proto: HTTP/2.0
@@ -1253,27 +1255,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 516
+        content_length: 73
         uncompressed: false
         body: |
-            {"createdAt":"2024-09-09T16:35:27.64367Z","environmentId":"evm-crfi7js8m55c703hl2fg","id":"red-crfi7js8m55c703hl2h0","ipAllowList":[{"cidrBlock":"1.1.1.1/32","description":"test"},{"cidrBlock":"2.0.0.0/8","description":"test-2"}],"name":"test-redis","options":{"maxmemoryPolicy":"allkeys_lfu"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"Test Terraform","type":"team"},"plan":"starter","region":"oregon","status":"creating","updatedAt":"2024-09-09T16:35:27.64367Z","version":"6.2.14"}
+            {"endpoint":"","resourceId":"red-d8k4ia5odlmc73btr5a0","setting":"drop"}
         headers:
             Content-Length:
-                - "516"
+                - "73"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:29 GMT
+                - Tue, 09 Jun 2026 17:11:07 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9970"
+                - "383"
             Ratelimit-Reset:
-                - "30"
+                - "52"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000164
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000979
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1284,7 +1286,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 74.7005ms
+        duration: 77.462375ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1303,7 +1305,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/redis/red-crfi7js8m55c703hl2h0/connection-info
+        url: https://api.testing.render.com/v1/redis/red-d8k4i9todlmc73btr54g
         method: GET
       response:
         proto: HTTP/2.0
@@ -1311,27 +1313,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 365
+        content_length: 419
         uncompressed: false
         body: |
-            {"externalConnectionString":"rediss://red-crfi7js8m55c703hl2h0:gIRSGDdOQriMcOCPQHj1durmcXvsgVqm@oregon-redis.localhost.render.com:6377","internalConnectionString":"redis://red-crfi7js8m55c703hl2h0:6379","redisCLICommand":" REDISCLI_AUTH=gIRSGDdOQriMcOCPQHj1durmcXvsgVqm redis-cli --user red-crfi7js8m55c703hl2h0 -h oregon-redis.localhost.render.com -p 6377 --tls"}
+            {"createdAt":"2026-06-09T17:11:03.738122Z","id":"red-d8k4i9todlmc73btr54g","ipAllowList":null,"name":"test-redis-paid","options":{"maxmemoryPolicy":"allkeys_lfu","persistenceMode":"journal_snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"starter","region":"oregon","status":"creating","updatedAt":"2026-06-09T17:11:03.738122Z","version":"8.1.4"}
         headers:
             Content-Length:
-                - "365"
+                - "419"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:29 GMT
+                - Tue, 09 Jun 2026 17:11:07 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9969"
+                - "382"
             Ratelimit-Reset:
-                - "30"
+                - "52"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000165
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000980
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1342,7 +1344,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 46.818667ms
+        duration: 85.238542ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1361,7 +1363,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/logs/streams/resource/red-crfi7js8m55c703hl2h0
+        url: https://api.testing.render.com/v1/projects/prj-d8k4i9todlmc73btr55g
         method: GET
       response:
         proto: HTTP/2.0
@@ -1369,27 +1371,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 73
+        content_length: 282
         uncompressed: false
         body: |
-            {"endpoint":"","resourceId":"red-crfi7js8m55c703hl2h0","setting":"drop"}
+            {"createdAt":"2026-06-09T17:11:03.779133Z","environmentIds":["evm-d8k4i9todlmc73btr56g"],"id":"prj-d8k4i9todlmc73btr55g","name":"first","owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"updatedAt":"2026-06-09T17:11:03.779133Z"}
         headers:
             Content-Length:
-                - "73"
+                - "282"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:29 GMT
+                - Tue, 09 Jun 2026 17:11:07 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9968"
+                - "381"
             Ratelimit-Reset:
-                - "30"
+                - "52"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000166
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000981
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1400,56 +1402,54 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 50.907584ms
+        duration: 100.379458ms
     - id: 24
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 91
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: https://api.testing.render.com/v1
         remote_addr: ""
         request_uri: ""
-        body: '{"ipAllowList":[],"maxmemoryPolicy":"noeviction","name":"test-redis-new","plan":"standard"}'
+        body: ""
         form: {}
         headers:
             Authorization:
                 - some-api-key
-            Content-Type:
-                - application/json
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/redis/red-crfi7js8m55c703hl2h0
-        method: PATCH
+        url: https://api.testing.render.com/v1/redis/red-d8k4i9todlmc73btr54g/connection-info
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 427
+        content_length: 372
         uncompressed: false
         body: |
-            {"createdAt":"2024-09-09T16:35:27.64367Z","environmentId":"evm-crfi7js8m55c703hl2fg","id":"red-crfi7js8m55c703hl2h0","ipAllowList":null,"name":"test-redis-new","options":{"maxmemoryPolicy":"noeviction"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"Test Terraform","type":"team"},"plan":"standard","region":"oregon","status":"creating","updatedAt":"2024-09-09T16:35:29.577498Z","version":"6.2.14"}
+            {"externalConnectionString":"rediss://red-d8k4i9todlmc73btr54g:uPs9p2GaBjeHP19tbn4bYjWQ2iGcegn5@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k4i9todlmc73btr54g:6379","redisCLICommand":" REDISCLI_AUTH=uPs9p2GaBjeHP19tbn4bYjWQ2iGcegn5 valkey-cli --user red-d8k4i9todlmc73btr54g -h oregon-keyvalue.localhost.render.com -p 6377 --tls"}
         headers:
             Content-Length:
-                - "427"
+                - "372"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:29 GMT
+                - Tue, 09 Jun 2026 17:11:07 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9995"
+                - "380"
             Ratelimit-Reset:
-                - "30"
+                - "52"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000167
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000982
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1460,7 +1460,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 175.396375ms
+        duration: 67.3575ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1479,7 +1479,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/redis/red-crfi7js8m55c703hl2h0/connection-info
+        url: https://api.testing.render.com/v1/environments/evm-d8k4i9todlmc73btr56g
         method: GET
       response:
         proto: HTTP/2.0
@@ -1487,27 +1487,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 365
+        content_length: 246
         uncompressed: false
         body: |
-            {"externalConnectionString":"rediss://red-crfi7js8m55c703hl2h0:gIRSGDdOQriMcOCPQHj1durmcXvsgVqm@oregon-redis.localhost.render.com:6377","internalConnectionString":"redis://red-crfi7js8m55c703hl2h0:6379","redisCLICommand":" REDISCLI_AUTH=gIRSGDdOQriMcOCPQHj1durmcXvsgVqm redis-cli --user red-crfi7js8m55c703hl2h0 -h oregon-redis.localhost.render.com -p 6377 --tls"}
+            {"databasesIds":null,"envGroupIds":null,"id":"evm-d8k4i9todlmc73btr56g","name":"prod","networkIsolationEnabled":false,"projectId":"prj-d8k4i9todlmc73btr55g","protectedStatus":"protected","redisIds":["red-d8k4ia5odlmc73btr5a0"],"serviceIds":null}
         headers:
             Content-Length:
-                - "365"
+                - "246"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:29 GMT
+                - Tue, 09 Jun 2026 17:11:08 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9967"
+                - "379"
             Ratelimit-Reset:
-                - "30"
+                - "51"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000168
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000983
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1518,7 +1518,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 50.571ms
+        duration: 67.439041ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1537,30 +1537,35 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/logs/streams/resource/red-crfi7js8m55c703hl2h0
-        method: DELETE
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8k4i9todlmc73btr54g
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 50
         uncompressed: false
-        body: ""
+        body: |
+            {"message":"not found: red-d8k4i9todlmc73btr54g"}
         headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:29 GMT
+                - Tue, 09 Jun 2026 17:11:08 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9994"
+                - "378"
             Ratelimit-Reset:
-                - "30"
+                - "51"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000169
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000984
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1569,9 +1574,9 @@ interactions:
                 - DENY
             X-Xss-Protection:
                 - 1; mode=block
-        status: 204 No Content
-        code: 204
-        duration: 51.482583ms
+        status: 404 Not Found
+        code: 404
+        duration: 52.098042ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1590,30 +1595,35 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/environments/red-crfi7js8m55c703hl2h0/resources?resourceIds=red-crfi7js8m55c703hl2h0
-        method: DELETE
+        url: https://api.testing.render.com/v1/projects/prj-d8k4ia5odlmc73btr580
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 283
         uncompressed: false
-        body: ""
+        body: |
+            {"createdAt":"2026-06-09T17:11:04.275047Z","environmentIds":["evm-d8k4ia5odlmc73btr590"],"id":"prj-d8k4ia5odlmc73btr580","name":"second","owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"updatedAt":"2026-06-09T17:11:04.275047Z"}
         headers:
+            Content-Length:
+                - "283"
+            Content-Type:
+                - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:29 GMT
+                - Tue, 09 Jun 2026 17:11:08 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9993"
+                - "377"
             Ratelimit-Reset:
-                - "30"
+                - "51"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000170
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000985
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1622,58 +1632,56 @@ interactions:
                 - DENY
             X-Xss-Protection:
                 - 1; mode=block
-        status: 204 No Content
-        code: 204
-        duration: 64.240417ms
+        status: 200 OK
+        code: 200
+        duration: 95.023917ms
     - id: 28
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 44
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: https://api.testing.render.com/v1
         remote_addr: ""
         request_uri: ""
-        body: '{"resourceIds":["red-crfi7js8m55c703hl2h0"]}'
+        body: ""
         form: {}
         headers:
             Authorization:
                 - some-api-key
-            Content-Type:
-                - application/json
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/environments/evm-crfi7js8m55c703hl2gg/resources
-        method: POST
+        url: https://api.testing.render.com/v1/environments/evm-d8k4ia5odlmc73btr590
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 214
+        content_length: 222
         uncompressed: false
         body: |
-            {"databasesIds":null,"envGroupIds":null,"id":"evm-crfi7js8m55c703hl2gg","name":"prod","projectId":"prj-crfi7js8m55c703hl2g0","protectedStatus":"protected","redisIds":["red-crfi7js8m55c703hl2h0"],"serviceIds":null}
+            {"databasesIds":null,"envGroupIds":null,"id":"evm-d8k4ia5odlmc73btr590","name":"prod","networkIsolationEnabled":false,"projectId":"prj-d8k4ia5odlmc73btr580","protectedStatus":"protected","redisIds":null,"serviceIds":null}
         headers:
             Content-Length:
-                - "214"
+                - "222"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:29 GMT
+                - Tue, 09 Jun 2026 17:11:08 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9992"
+                - "376"
             Ratelimit-Reset:
-                - "30"
+                - "51"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000171
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000986
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1682,9 +1690,9 @@ interactions:
                 - DENY
             X-Xss-Protection:
                 - 1; mode=block
-        status: 201 Created
-        code: 201
-        duration: 88.095459ms
+        status: 200 OK
+        code: 200
+        duration: 62.710084ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1703,7 +1711,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/projects/prj-crfi7js8m55c703hl2f0
+        url: https://api.testing.render.com/v1/redis/red-d8k4ia5odlmc73btr5a0
         method: GET
       response:
         proto: HTTP/2.0
@@ -1711,27 +1719,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 285
+        content_length: 551
         uncompressed: false
         body: |
-            {"createdAt":"2024-09-09T16:35:27.305482Z","environmentIds":["evm-crfi7js8m55c703hl2fg"],"id":"prj-crfi7js8m55c703hl2f0","name":"first","owner":{"email":"email@example.com","id":"some-owner-id","name":"Test Terraform","type":"team"},"updatedAt":"2024-09-09T16:35:27.305482Z"}
+            {"createdAt":"2026-06-09T17:11:04.649569Z","environmentId":"evm-d8k4i9todlmc73btr56g","id":"red-d8k4ia5odlmc73btr5a0","ipAllowList":[{"cidrBlock":"1.1.1.1/32","description":"test"},{"cidrBlock":"2.0.0.0/8","description":"test-2"}],"name":"test-redis","options":{"maxmemoryPolicy":"allkeys_lfu","persistenceMode":"journal_snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"starter","region":"oregon","status":"creating","updatedAt":"2026-06-09T17:11:04.649569Z","version":"8.1.4"}
         headers:
             Content-Length:
-                - "285"
+                - "551"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:30 GMT
+                - Tue, 09 Jun 2026 17:11:08 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9966"
+                - "375"
             Ratelimit-Reset:
-                - "29"
+                - "51"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000172
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000987
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1742,7 +1750,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 60.280292ms
+        duration: 101.282291ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1761,7 +1769,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/environments/evm-crfi7js8m55c703hl2fg
+        url: https://api.testing.render.com/v1/redis/red-d8k4ia5odlmc73btr5a0/connection-info
         method: GET
       response:
         proto: HTTP/2.0
@@ -1769,27 +1777,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 190
+        content_length: 372
         uncompressed: false
         body: |
-            {"databasesIds":null,"envGroupIds":null,"id":"evm-crfi7js8m55c703hl2fg","name":"prod","projectId":"prj-crfi7js8m55c703hl2f0","protectedStatus":"protected","redisIds":null,"serviceIds":null}
+            {"externalConnectionString":"rediss://red-d8k4ia5odlmc73btr5a0:hBFnAKplTyebA0SdRNnSdBJOkQ7QoR03@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k4ia5odlmc73btr5a0:6379","redisCLICommand":" REDISCLI_AUTH=hBFnAKplTyebA0SdRNnSdBJOkQ7QoR03 valkey-cli --user red-d8k4ia5odlmc73btr5a0 -h oregon-keyvalue.localhost.render.com -p 6377 --tls"}
         headers:
             Content-Length:
-                - "190"
+                - "372"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:30 GMT
+                - Tue, 09 Jun 2026 17:11:08 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9965"
+                - "374"
             Ratelimit-Reset:
-                - "29"
+                - "51"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000173
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000988
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1800,7 +1808,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 36.725375ms
+        duration: 78.862667ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1819,7 +1827,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/projects/prj-crfi7js8m55c703hl2g0
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8k4ia5odlmc73btr5a0
         method: GET
       response:
         proto: HTTP/2.0
@@ -1827,27 +1835,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 286
+        content_length: 73
         uncompressed: false
         body: |
-            {"createdAt":"2024-09-09T16:35:27.450645Z","environmentIds":["evm-crfi7js8m55c703hl2gg"],"id":"prj-crfi7js8m55c703hl2g0","name":"second","owner":{"email":"email@example.com","id":"some-owner-id","name":"Test Terraform","type":"team"},"updatedAt":"2024-09-09T16:35:27.450645Z"}
+            {"endpoint":"","resourceId":"red-d8k4ia5odlmc73btr5a0","setting":"drop"}
         headers:
             Content-Length:
-                - "286"
+                - "73"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:30 GMT
+                - Tue, 09 Jun 2026 17:11:09 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9964"
+                - "373"
             Ratelimit-Reset:
-                - "29"
+                - "50"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000174
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000989
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1858,54 +1866,56 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 59.267083ms
+        duration: 79.209625ms
     - id: 32
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 120
         transfer_encoding: []
         trailer: {}
         host: https://api.testing.render.com/v1
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"ipAllowList":[],"maxmemoryPolicy":"noeviction","name":"test-redis-new","persistenceMode":"snapshot","plan":"standard"}'
         form: {}
         headers:
             Authorization:
                 - some-api-key
+            Content-Type:
+                - application/json
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/environments/evm-crfi7js8m55c703hl2gg
-        method: GET
+        url: https://api.testing.render.com/v1/redis/red-d8k4ia5odlmc73btr5a0
+        method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 214
+        content_length: 453
         uncompressed: false
         body: |
-            {"databasesIds":null,"envGroupIds":null,"id":"evm-crfi7js8m55c703hl2gg","name":"prod","projectId":"prj-crfi7js8m55c703hl2g0","protectedStatus":"protected","redisIds":["red-crfi7js8m55c703hl2h0"],"serviceIds":null}
+            {"createdAt":"2026-06-09T17:11:04.649569Z","environmentId":"evm-d8k4i9todlmc73btr56g","id":"red-d8k4ia5odlmc73btr5a0","ipAllowList":null,"name":"test-redis-new","options":{"maxmemoryPolicy":"noeviction","persistenceMode":"snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"standard","region":"oregon","status":"creating","updatedAt":"2026-06-09T17:11:09.441952Z","version":"8.1.4"}
         headers:
             Content-Length:
-                - "214"
+                - "453"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:30 GMT
+                - Tue, 09 Jun 2026 17:11:09 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "100"
             Ratelimit-Remaining:
-                - "9963"
+                - "96"
             Ratelimit-Reset:
-                - "29"
+                - "50"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000175
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000990
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1916,7 +1926,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 35.862083ms
+        duration: 444.270458ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1935,7 +1945,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/redis/red-crfi7js8m55c703hl2h0
+        url: https://api.testing.render.com/v1/redis/red-d8k4ia5odlmc73btr5a0/connection-info
         method: GET
       response:
         proto: HTTP/2.0
@@ -1943,27 +1953,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 427
+        content_length: 372
         uncompressed: false
         body: |
-            {"createdAt":"2024-09-09T16:35:27.64367Z","environmentId":"evm-crfi7js8m55c703hl2gg","id":"red-crfi7js8m55c703hl2h0","ipAllowList":null,"name":"test-redis-new","options":{"maxmemoryPolicy":"noeviction"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"Test Terraform","type":"team"},"plan":"standard","region":"oregon","status":"creating","updatedAt":"2024-09-09T16:35:29.885293Z","version":"6.2.14"}
+            {"externalConnectionString":"rediss://red-d8k4ia5odlmc73btr5a0:hBFnAKplTyebA0SdRNnSdBJOkQ7QoR03@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k4ia5odlmc73btr5a0:6379","redisCLICommand":" REDISCLI_AUTH=hBFnAKplTyebA0SdRNnSdBJOkQ7QoR03 valkey-cli --user red-d8k4ia5odlmc73btr5a0 -h oregon-keyvalue.localhost.render.com -p 6377 --tls"}
         headers:
             Content-Length:
-                - "427"
+                - "372"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:30 GMT
+                - Tue, 09 Jun 2026 17:11:09 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9962"
+                - "372"
             Ratelimit-Reset:
-                - "29"
+                - "50"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000176
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000991
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -1974,7 +1984,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 55.817083ms
+        duration: 76.477834ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1993,35 +2003,30 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/redis/red-crfi7js8m55c703hl2h0/connection-info
-        method: GET
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8k4ia5odlmc73btr5a0
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 365
+        content_length: 0
         uncompressed: false
-        body: |
-            {"externalConnectionString":"rediss://red-crfi7js8m55c703hl2h0:gIRSGDdOQriMcOCPQHj1durmcXvsgVqm@oregon-redis.localhost.render.com:6377","internalConnectionString":"redis://red-crfi7js8m55c703hl2h0:6379","redisCLICommand":" REDISCLI_AUTH=gIRSGDdOQriMcOCPQHj1durmcXvsgVqm redis-cli --user red-crfi7js8m55c703hl2h0 -h oregon-redis.localhost.render.com -p 6377 --tls"}
+        body: ""
         headers:
-            Content-Length:
-                - "365"
-            Content-Type:
-                - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:30 GMT
+                - Tue, 09 Jun 2026 17:11:09 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "100"
             Ratelimit-Remaining:
-                - "9961"
+                - "95"
             Ratelimit-Reset:
-                - "29"
+                - "50"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000177
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000992
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2030,9 +2035,9 @@ interactions:
                 - DENY
             X-Xss-Protection:
                 - 1; mode=block
-        status: 200 OK
-        code: 200
-        duration: 51.258791ms
+        status: 204 No Content
+        code: 204
+        duration: 69.191917ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -2051,35 +2056,30 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/logs/streams/resource/red-crfi7js8m55c703hl2h0
-        method: GET
+        url: https://api.testing.render.com/v1/environments/red-d8k4ia5odlmc73btr5a0/resources?resourceIds=red-d8k4ia5odlmc73btr5a0
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 50
+        content_length: 0
         uncompressed: false
-        body: |
-            {"message":"not found: red-crfi7js8m55c703hl2h0"}
+        body: ""
         headers:
-            Content-Length:
-                - "50"
-            Content-Type:
-                - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:30 GMT
+                - Tue, 09 Jun 2026 17:11:10 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "100"
             Ratelimit-Remaining:
-                - "9960"
+                - "94"
             Ratelimit-Reset:
-                - "29"
+                - "49"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000178
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000993
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2088,56 +2088,58 @@ interactions:
                 - DENY
             X-Xss-Protection:
                 - 1; mode=block
-        status: 404 Not Found
-        code: 404
-        duration: 33.894542ms
+        status: 204 No Content
+        code: 204
+        duration: 90.011166ms
     - id: 36
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 44
         transfer_encoding: []
         trailer: {}
         host: https://api.testing.render.com/v1
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"resourceIds":["red-d8k4ia5odlmc73btr5a0"]}'
         form: {}
         headers:
             Authorization:
                 - some-api-key
+            Content-Type:
+                - application/json
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/projects/prj-crfi7js8m55c703hl2f0
-        method: GET
+        url: https://api.testing.render.com/v1/environments/evm-d8k4ia5odlmc73btr590/resources
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 285
+        content_length: 246
         uncompressed: false
         body: |
-            {"createdAt":"2024-09-09T16:35:27.305482Z","environmentIds":["evm-crfi7js8m55c703hl2fg"],"id":"prj-crfi7js8m55c703hl2f0","name":"first","owner":{"email":"email@example.com","id":"some-owner-id","name":"Test Terraform","type":"team"},"updatedAt":"2024-09-09T16:35:27.305482Z"}
+            {"databasesIds":null,"envGroupIds":null,"id":"evm-d8k4ia5odlmc73btr590","name":"prod","networkIsolationEnabled":false,"projectId":"prj-d8k4ia5odlmc73btr580","protectedStatus":"protected","redisIds":["red-d8k4ia5odlmc73btr5a0"],"serviceIds":null}
         headers:
             Content-Length:
-                - "285"
+                - "246"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:30 GMT
+                - Tue, 09 Jun 2026 17:11:10 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "100"
             Ratelimit-Remaining:
-                - "9959"
+                - "93"
             Ratelimit-Reset:
-                - "29"
+                - "49"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000179
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000994
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2146,9 +2148,9 @@ interactions:
                 - DENY
             X-Xss-Protection:
                 - 1; mode=block
-        status: 200 OK
-        code: 200
-        duration: 53.741458ms
+        status: 201 Created
+        code: 201
+        duration: 127.414958ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -2167,7 +2169,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/environments/evm-crfi7js8m55c703hl2fg
+        url: https://api.testing.render.com/v1/projects/prj-d8k4i9todlmc73btr55g
         method: GET
       response:
         proto: HTTP/2.0
@@ -2175,27 +2177,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 190
+        content_length: 282
         uncompressed: false
         body: |
-            {"databasesIds":null,"envGroupIds":null,"id":"evm-crfi7js8m55c703hl2fg","name":"prod","projectId":"prj-crfi7js8m55c703hl2f0","protectedStatus":"protected","redisIds":null,"serviceIds":null}
+            {"createdAt":"2026-06-09T17:11:03.779133Z","environmentIds":["evm-d8k4i9todlmc73btr56g"],"id":"prj-d8k4i9todlmc73btr55g","name":"first","owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"updatedAt":"2026-06-09T17:11:03.779133Z"}
         headers:
             Content-Length:
-                - "190"
+                - "282"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:30 GMT
+                - Tue, 09 Jun 2026 17:11:10 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9958"
+                - "371"
             Ratelimit-Reset:
-                - "29"
+                - "49"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000180
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000995
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2206,7 +2208,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 41.849834ms
+        duration: 93.925625ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -2225,7 +2227,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/projects/prj-crfi7js8m55c703hl2g0
+        url: https://api.testing.render.com/v1/redis/red-d8k4i9todlmc73btr54g
         method: GET
       response:
         proto: HTTP/2.0
@@ -2233,27 +2235,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 286
+        content_length: 419
         uncompressed: false
         body: |
-            {"createdAt":"2024-09-09T16:35:27.450645Z","environmentIds":["evm-crfi7js8m55c703hl2gg"],"id":"prj-crfi7js8m55c703hl2g0","name":"second","owner":{"email":"email@example.com","id":"some-owner-id","name":"Test Terraform","type":"team"},"updatedAt":"2024-09-09T16:35:27.450645Z"}
+            {"createdAt":"2026-06-09T17:11:03.738122Z","id":"red-d8k4i9todlmc73btr54g","ipAllowList":null,"name":"test-redis-paid","options":{"maxmemoryPolicy":"allkeys_lfu","persistenceMode":"journal_snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"starter","region":"oregon","status":"creating","updatedAt":"2026-06-09T17:11:03.738122Z","version":"8.1.4"}
         headers:
             Content-Length:
-                - "286"
+                - "419"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:30 GMT
+                - Tue, 09 Jun 2026 17:11:10 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9957"
+                - "370"
             Ratelimit-Reset:
-                - "29"
+                - "49"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000181
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000996
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2264,7 +2266,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 58.923833ms
+        duration: 90.187333ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -2283,7 +2285,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/environments/evm-crfi7js8m55c703hl2gg
+        url: https://api.testing.render.com/v1/environments/evm-d8k4i9todlmc73btr56g
         method: GET
       response:
         proto: HTTP/2.0
@@ -2291,27 +2293,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 214
+        content_length: 222
         uncompressed: false
         body: |
-            {"databasesIds":null,"envGroupIds":null,"id":"evm-crfi7js8m55c703hl2gg","name":"prod","projectId":"prj-crfi7js8m55c703hl2g0","protectedStatus":"protected","redisIds":["red-crfi7js8m55c703hl2h0"],"serviceIds":null}
+            {"databasesIds":null,"envGroupIds":null,"id":"evm-d8k4i9todlmc73btr56g","name":"prod","networkIsolationEnabled":false,"projectId":"prj-d8k4i9todlmc73btr55g","protectedStatus":"protected","redisIds":null,"serviceIds":null}
         headers:
             Content-Length:
-                - "214"
+                - "222"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:30 GMT
+                - Tue, 09 Jun 2026 17:11:10 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9956"
+                - "369"
             Ratelimit-Reset:
-                - "29"
+                - "49"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000182
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000997
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2322,7 +2324,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 37.673542ms
+        duration: 66.361417ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -2341,7 +2343,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/redis/red-crfi7js8m55c703hl2h0
+        url: https://api.testing.render.com/v1/redis/red-d8k4i9todlmc73btr54g/connection-info
         method: GET
       response:
         proto: HTTP/2.0
@@ -2349,27 +2351,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 427
+        content_length: 372
         uncompressed: false
         body: |
-            {"createdAt":"2024-09-09T16:35:27.64367Z","environmentId":"evm-crfi7js8m55c703hl2gg","id":"red-crfi7js8m55c703hl2h0","ipAllowList":null,"name":"test-redis-new","options":{"maxmemoryPolicy":"noeviction"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"Test Terraform","type":"team"},"plan":"standard","region":"oregon","status":"creating","updatedAt":"2024-09-09T16:35:29.885293Z","version":"6.2.14"}
+            {"externalConnectionString":"rediss://red-d8k4i9todlmc73btr54g:uPs9p2GaBjeHP19tbn4bYjWQ2iGcegn5@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k4i9todlmc73btr54g:6379","redisCLICommand":" REDISCLI_AUTH=uPs9p2GaBjeHP19tbn4bYjWQ2iGcegn5 valkey-cli --user red-d8k4i9todlmc73btr54g -h oregon-keyvalue.localhost.render.com -p 6377 --tls"}
         headers:
             Content-Length:
-                - "427"
+                - "372"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:30 GMT
+                - Tue, 09 Jun 2026 17:11:11 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9955"
+                - "368"
             Ratelimit-Reset:
-                - "29"
+                - "48"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000183
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000998
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2380,7 +2382,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 55.740833ms
+        duration: 66.85375ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2399,7 +2401,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/redis/red-crfi7js8m55c703hl2h0/connection-info
+        url: https://api.testing.render.com/v1/projects/prj-d8k4ia5odlmc73btr580
         method: GET
       response:
         proto: HTTP/2.0
@@ -2407,27 +2409,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 365
+        content_length: 283
         uncompressed: false
         body: |
-            {"externalConnectionString":"rediss://red-crfi7js8m55c703hl2h0:gIRSGDdOQriMcOCPQHj1durmcXvsgVqm@oregon-redis.localhost.render.com:6377","internalConnectionString":"redis://red-crfi7js8m55c703hl2h0:6379","redisCLICommand":" REDISCLI_AUTH=gIRSGDdOQriMcOCPQHj1durmcXvsgVqm redis-cli --user red-crfi7js8m55c703hl2h0 -h oregon-redis.localhost.render.com -p 6377 --tls"}
+            {"createdAt":"2026-06-09T17:11:04.275047Z","environmentIds":["evm-d8k4ia5odlmc73btr590"],"id":"prj-d8k4ia5odlmc73btr580","name":"second","owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"updatedAt":"2026-06-09T17:11:04.275047Z"}
         headers:
             Content-Length:
-                - "365"
+                - "283"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:30 GMT
+                - Tue, 09 Jun 2026 17:11:11 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9954"
+                - "367"
             Ratelimit-Reset:
-                - "29"
+                - "48"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000184
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-000999
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2438,7 +2440,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 49.450459ms
+        duration: 91.089625ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2457,7 +2459,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/logs/streams/resource/red-crfi7js8m55c703hl2h0
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8k4i9todlmc73btr54g
         method: GET
       response:
         proto: HTTP/2.0
@@ -2468,24 +2470,24 @@ interactions:
         content_length: 50
         uncompressed: false
         body: |
-            {"message":"not found: red-crfi7js8m55c703hl2h0"}
+            {"message":"not found: red-d8k4i9todlmc73btr54g"}
         headers:
             Content-Length:
                 - "50"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:30 GMT
+                - Tue, 09 Jun 2026 17:11:11 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9953"
+                - "366"
             Ratelimit-Reset:
-                - "29"
+                - "48"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000185
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001000
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2496,56 +2498,54 @@ interactions:
                 - 1; mode=block
         status: 404 Not Found
         code: 404
-        duration: 36.42925ms
+        duration: 51.849125ms
     - id: 43
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 187
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: https://api.testing.render.com/v1
         remote_addr: ""
         request_uri: ""
-        body: '{"ipAllowList":[{"cidrBlock":"1.1.1.1/32","description":"test"},{"cidrBlock":"2.0.0.0/8","description":"test-2"}],"maxmemoryPolicy":"noeviction","name":"test-redis-new","plan":"standard"}'
+        body: ""
         form: {}
         headers:
             Authorization:
                 - some-api-key
-            Content-Type:
-                - application/json
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/redis/red-crfi7js8m55c703hl2h0
-        method: PATCH
+        url: https://api.testing.render.com/v1/environments/evm-d8k4ia5odlmc73btr590
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 521
+        content_length: 246
         uncompressed: false
         body: |
-            {"createdAt":"2024-09-09T16:35:27.64367Z","environmentId":"evm-crfi7js8m55c703hl2gg","id":"red-crfi7js8m55c703hl2h0","ipAllowList":[{"cidrBlock":"1.1.1.1/32","description":"test"},{"cidrBlock":"2.0.0.0/8","description":"test-2"}],"name":"test-redis-new","options":{"maxmemoryPolicy":"noeviction"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"Test Terraform","type":"team"},"plan":"standard","region":"oregon","status":"creating","updatedAt":"2024-09-09T16:35:31.240641Z","version":"6.2.14"}
+            {"databasesIds":null,"envGroupIds":null,"id":"evm-d8k4ia5odlmc73btr590","name":"prod","networkIsolationEnabled":false,"projectId":"prj-d8k4ia5odlmc73btr580","protectedStatus":"protected","redisIds":["red-d8k4ia5odlmc73btr5a0"],"serviceIds":null}
         headers:
             Content-Length:
-                - "521"
+                - "246"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:31 GMT
+                - Tue, 09 Jun 2026 17:11:11 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9991"
+                - "365"
             Ratelimit-Reset:
-                - "28"
+                - "48"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000186
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001001
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2556,7 +2556,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 202.713875ms
+        duration: 63.576584ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -2575,7 +2575,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/redis/red-crfi7js8m55c703hl2h0/connection-info
+        url: https://api.testing.render.com/v1/redis/red-d8k4ia5odlmc73btr5a0
         method: GET
       response:
         proto: HTTP/2.0
@@ -2583,27 +2583,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 365
+        content_length: 453
         uncompressed: false
         body: |
-            {"externalConnectionString":"rediss://red-crfi7js8m55c703hl2h0:gIRSGDdOQriMcOCPQHj1durmcXvsgVqm@oregon-redis.localhost.render.com:6377","internalConnectionString":"redis://red-crfi7js8m55c703hl2h0:6379","redisCLICommand":" REDISCLI_AUTH=gIRSGDdOQriMcOCPQHj1durmcXvsgVqm redis-cli --user red-crfi7js8m55c703hl2h0 -h oregon-redis.localhost.render.com -p 6377 --tls"}
+            {"createdAt":"2026-06-09T17:11:04.649569Z","environmentId":"evm-d8k4ia5odlmc73btr590","id":"red-d8k4ia5odlmc73btr5a0","ipAllowList":null,"name":"test-redis-new","options":{"maxmemoryPolicy":"noeviction","persistenceMode":"snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"standard","region":"oregon","status":"creating","updatedAt":"2026-06-09T17:11:10.293562Z","version":"8.1.4"}
         headers:
             Content-Length:
-                - "365"
+                - "453"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:31 GMT
+                - Tue, 09 Jun 2026 17:11:11 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9952"
+                - "364"
             Ratelimit-Reset:
-                - "28"
+                - "48"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000187
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001002
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2614,7 +2614,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 51.00625ms
+        duration: 99.86475ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -2633,7 +2633,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/projects/prj-crfi7js8m55c703hl2f0
+        url: https://api.testing.render.com/v1/redis/red-d8k4ia5odlmc73btr5a0/connection-info
         method: GET
       response:
         proto: HTTP/2.0
@@ -2641,27 +2641,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 285
+        content_length: 372
         uncompressed: false
         body: |
-            {"createdAt":"2024-09-09T16:35:27.305482Z","environmentIds":["evm-crfi7js8m55c703hl2fg"],"id":"prj-crfi7js8m55c703hl2f0","name":"first","owner":{"email":"email@example.com","id":"some-owner-id","name":"Test Terraform","type":"team"},"updatedAt":"2024-09-09T16:35:27.305482Z"}
+            {"externalConnectionString":"rediss://red-d8k4ia5odlmc73btr5a0:hBFnAKplTyebA0SdRNnSdBJOkQ7QoR03@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k4ia5odlmc73btr5a0:6379","redisCLICommand":" REDISCLI_AUTH=hBFnAKplTyebA0SdRNnSdBJOkQ7QoR03 valkey-cli --user red-d8k4ia5odlmc73btr5a0 -h oregon-keyvalue.localhost.render.com -p 6377 --tls"}
         headers:
             Content-Length:
-                - "285"
+                - "372"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:31 GMT
+                - Tue, 09 Jun 2026 17:11:11 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9951"
+                - "363"
             Ratelimit-Reset:
-                - "28"
+                - "48"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000188
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001003
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2672,7 +2672,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 61.002583ms
+        duration: 84.504208ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -2691,7 +2691,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/environments/evm-crfi7js8m55c703hl2fg
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8k4ia5odlmc73btr5a0
         method: GET
       response:
         proto: HTTP/2.0
@@ -2699,27 +2699,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 190
+        content_length: 50
         uncompressed: false
         body: |
-            {"databasesIds":null,"envGroupIds":null,"id":"evm-crfi7js8m55c703hl2fg","name":"prod","projectId":"prj-crfi7js8m55c703hl2f0","protectedStatus":"protected","redisIds":null,"serviceIds":null}
+            {"message":"not found: red-d8k4ia5odlmc73btr5a0"}
         headers:
             Content-Length:
-                - "190"
+                - "50"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:31 GMT
+                - Tue, 09 Jun 2026 17:11:12 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9950"
+                - "362"
             Ratelimit-Reset:
-                - "28"
+                - "47"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000189
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001004
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2728,9 +2728,9 @@ interactions:
                 - DENY
             X-Xss-Protection:
                 - 1; mode=block
-        status: 200 OK
-        code: 200
-        duration: 36.159333ms
+        status: 404 Not Found
+        code: 404
+        duration: 52.502333ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -2749,7 +2749,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/projects/prj-crfi7js8m55c703hl2g0
+        url: https://api.testing.render.com/v1/projects/prj-d8k4i9todlmc73btr55g
         method: GET
       response:
         proto: HTTP/2.0
@@ -2757,27 +2757,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 286
+        content_length: 282
         uncompressed: false
         body: |
-            {"createdAt":"2024-09-09T16:35:27.450645Z","environmentIds":["evm-crfi7js8m55c703hl2gg"],"id":"prj-crfi7js8m55c703hl2g0","name":"second","owner":{"email":"email@example.com","id":"some-owner-id","name":"Test Terraform","type":"team"},"updatedAt":"2024-09-09T16:35:27.450645Z"}
+            {"createdAt":"2026-06-09T17:11:03.779133Z","environmentIds":["evm-d8k4i9todlmc73btr56g"],"id":"prj-d8k4i9todlmc73btr55g","name":"first","owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"updatedAt":"2026-06-09T17:11:03.779133Z"}
         headers:
             Content-Length:
-                - "286"
+                - "282"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:31 GMT
+                - Tue, 09 Jun 2026 17:11:12 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9949"
+                - "361"
             Ratelimit-Reset:
-                - "28"
+                - "47"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000190
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001005
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2788,7 +2788,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 59.393625ms
+        duration: 97.982875ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -2807,7 +2807,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/environments/evm-crfi7js8m55c703hl2gg
+        url: https://api.testing.render.com/v1/redis/red-d8k4i9todlmc73btr54g
         method: GET
       response:
         proto: HTTP/2.0
@@ -2815,27 +2815,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 214
+        content_length: 419
         uncompressed: false
         body: |
-            {"databasesIds":null,"envGroupIds":null,"id":"evm-crfi7js8m55c703hl2gg","name":"prod","projectId":"prj-crfi7js8m55c703hl2g0","protectedStatus":"protected","redisIds":["red-crfi7js8m55c703hl2h0"],"serviceIds":null}
+            {"createdAt":"2026-06-09T17:11:03.738122Z","id":"red-d8k4i9todlmc73btr54g","ipAllowList":null,"name":"test-redis-paid","options":{"maxmemoryPolicy":"allkeys_lfu","persistenceMode":"journal_snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"starter","region":"oregon","status":"creating","updatedAt":"2026-06-09T17:11:03.738122Z","version":"8.1.4"}
         headers:
             Content-Length:
-                - "214"
+                - "419"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:31 GMT
+                - Tue, 09 Jun 2026 17:11:12 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9948"
+                - "360"
             Ratelimit-Reset:
-                - "28"
+                - "47"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000191
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001006
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2846,7 +2846,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 38.683625ms
+        duration: 89.402583ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -2865,7 +2865,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/redis/red-crfi7js8m55c703hl2h0
+        url: https://api.testing.render.com/v1/environments/evm-d8k4i9todlmc73btr56g
         method: GET
       response:
         proto: HTTP/2.0
@@ -2873,27 +2873,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 521
+        content_length: 222
         uncompressed: false
         body: |
-            {"createdAt":"2024-09-09T16:35:27.64367Z","environmentId":"evm-crfi7js8m55c703hl2gg","id":"red-crfi7js8m55c703hl2h0","ipAllowList":[{"cidrBlock":"1.1.1.1/32","description":"test"},{"cidrBlock":"2.0.0.0/8","description":"test-2"}],"name":"test-redis-new","options":{"maxmemoryPolicy":"noeviction"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"Test Terraform","type":"team"},"plan":"standard","region":"oregon","status":"creating","updatedAt":"2024-09-09T16:35:31.240641Z","version":"6.2.14"}
+            {"databasesIds":null,"envGroupIds":null,"id":"evm-d8k4i9todlmc73btr56g","name":"prod","networkIsolationEnabled":false,"projectId":"prj-d8k4i9todlmc73btr55g","protectedStatus":"protected","redisIds":null,"serviceIds":null}
         headers:
             Content-Length:
-                - "521"
+                - "222"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:31 GMT
+                - Tue, 09 Jun 2026 17:11:12 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9947"
+                - "359"
             Ratelimit-Reset:
-                - "28"
+                - "47"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000192
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001007
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2904,7 +2904,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 57.896917ms
+        duration: 62.4275ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -2923,7 +2923,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/redis/red-crfi7js8m55c703hl2h0/connection-info
+        url: https://api.testing.render.com/v1/redis/red-d8k4i9todlmc73btr54g/connection-info
         method: GET
       response:
         proto: HTTP/2.0
@@ -2931,27 +2931,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 365
+        content_length: 372
         uncompressed: false
         body: |
-            {"externalConnectionString":"rediss://red-crfi7js8m55c703hl2h0:gIRSGDdOQriMcOCPQHj1durmcXvsgVqm@oregon-redis.localhost.render.com:6377","internalConnectionString":"redis://red-crfi7js8m55c703hl2h0:6379","redisCLICommand":" REDISCLI_AUTH=gIRSGDdOQriMcOCPQHj1durmcXvsgVqm redis-cli --user red-crfi7js8m55c703hl2h0 -h oregon-redis.localhost.render.com -p 6377 --tls"}
+            {"externalConnectionString":"rediss://red-d8k4i9todlmc73btr54g:uPs9p2GaBjeHP19tbn4bYjWQ2iGcegn5@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k4i9todlmc73btr54g:6379","redisCLICommand":" REDISCLI_AUTH=uPs9p2GaBjeHP19tbn4bYjWQ2iGcegn5 valkey-cli --user red-d8k4i9todlmc73btr54g -h oregon-keyvalue.localhost.render.com -p 6377 --tls"}
         headers:
             Content-Length:
-                - "365"
+                - "372"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:31 GMT
+                - Tue, 09 Jun 2026 17:11:12 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9946"
+                - "358"
             Ratelimit-Reset:
-                - "28"
+                - "47"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000193
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001008
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -2962,7 +2962,7 @@ interactions:
                 - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 54.598209ms
+        duration: 63.704917ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -2981,7 +2981,7 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/logs/streams/resource/red-crfi7js8m55c703hl2h0
+        url: https://api.testing.render.com/v1/projects/prj-d8k4ia5odlmc73btr580
         method: GET
       response:
         proto: HTTP/2.0
@@ -2989,27 +2989,27 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 50
+        content_length: 283
         uncompressed: false
         body: |
-            {"message":"not found: red-crfi7js8m55c703hl2h0"}
+            {"createdAt":"2026-06-09T17:11:04.275047Z","environmentIds":["evm-d8k4ia5odlmc73btr590"],"id":"prj-d8k4ia5odlmc73btr580","name":"second","owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"updatedAt":"2026-06-09T17:11:04.275047Z"}
         headers:
             Content-Length:
-                - "50"
+                - "283"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:31 GMT
+                - Tue, 09 Jun 2026 17:11:12 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9945"
+                - "357"
             Ratelimit-Reset:
-                - "28"
+                - "47"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000194
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001009
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -3018,9 +3018,9 @@ interactions:
                 - DENY
             X-Xss-Protection:
                 - 1; mode=block
-        status: 404 Not Found
-        code: 404
-        duration: 34.140375ms
+        status: 200 OK
+        code: 200
+        duration: 92.579042ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -3039,30 +3039,35 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/redis/red-crfi7js8m55c703hl2h0
-        method: DELETE
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8k4i9todlmc73btr54g
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 50
         uncompressed: false
-        body: ""
+        body: |
+            {"message":"not found: red-d8k4i9todlmc73btr54g"}
         headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:32 GMT
+                - Tue, 09 Jun 2026 17:11:13 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9990"
+                - "356"
             Ratelimit-Reset:
-                - "27"
+                - "46"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000195
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001010
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -3071,9 +3076,9 @@ interactions:
                 - DENY
             X-Xss-Protection:
                 - 1; mode=block
-        status: 204 No Content
-        code: 204
-        duration: 61.533292ms
+        status: 404 Not Found
+        code: 404
+        duration: 54.761041ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -3092,30 +3097,35 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/projects/prj-crfi7js8m55c703hl2g0
-        method: DELETE
+        url: https://api.testing.render.com/v1/environments/evm-d8k4ia5odlmc73btr590
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 246
         uncompressed: false
-        body: ""
+        body: |
+            {"databasesIds":null,"envGroupIds":null,"id":"evm-d8k4ia5odlmc73btr590","name":"prod","networkIsolationEnabled":false,"projectId":"prj-d8k4ia5odlmc73btr580","protectedStatus":"protected","redisIds":["red-d8k4ia5odlmc73btr5a0"],"serviceIds":null}
         headers:
+            Content-Length:
+                - "246"
+            Content-Type:
+                - application/json; charset=utf-8
             Date:
-                - Mon, 09 Sep 2024 16:35:32 GMT
+                - Tue, 09 Jun 2026 17:11:13 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "400"
             Ratelimit-Remaining:
-                - "9989"
+                - "355"
             Ratelimit-Reset:
-                - "27"
+                - "46"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000196
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001011
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -3124,9 +3134,9 @@ interactions:
                 - DENY
             X-Xss-Protection:
                 - 1; mode=block
-        status: 204 No Content
-        code: 204
-        duration: 76.609375ms
+        status: 200 OK
+        code: 200
+        duration: 67.607625ms
     - id: 54
       request:
         proto: HTTP/1.1
@@ -3145,7 +3155,1459 @@ interactions:
                 - some-api-key
             User-Agent:
                 - terraform-provider-render/test
-        url: https://api.testing.render.com/v1/projects/prj-crfi7js8m55c703hl2f0
+        url: https://api.testing.render.com/v1/redis/red-d8k4ia5odlmc73btr5a0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 453
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T17:11:04.649569Z","environmentId":"evm-d8k4ia5odlmc73btr590","id":"red-d8k4ia5odlmc73btr5a0","ipAllowList":null,"name":"test-redis-new","options":{"maxmemoryPolicy":"noeviction","persistenceMode":"snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"standard","region":"oregon","status":"creating","updatedAt":"2026-06-09T17:11:10.293562Z","version":"8.1.4"}
+        headers:
+            Content-Length:
+                - "453"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:13 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "354"
+            Ratelimit-Reset:
+                - "46"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001012
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 101.5735ms
+    - id: 55
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis/red-d8k4ia5odlmc73btr5a0/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 372
+        uncompressed: false
+        body: |
+            {"externalConnectionString":"rediss://red-d8k4ia5odlmc73btr5a0:hBFnAKplTyebA0SdRNnSdBJOkQ7QoR03@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k4ia5odlmc73btr5a0:6379","redisCLICommand":" REDISCLI_AUTH=hBFnAKplTyebA0SdRNnSdBJOkQ7QoR03 valkey-cli --user red-d8k4ia5odlmc73btr5a0 -h oregon-keyvalue.localhost.render.com -p 6377 --tls"}
+        headers:
+            Content-Length:
+                - "372"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:13 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "353"
+            Ratelimit-Reset:
+                - "46"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001013
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 79.369875ms
+    - id: 56
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8k4ia5odlmc73btr5a0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: red-d8k4ia5odlmc73btr5a0"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:13 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "352"
+            Ratelimit-Reset:
+                - "46"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001014
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 51.276459ms
+    - id: 57
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 216
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: '{"ipAllowList":[{"cidrBlock":"1.1.1.1/32","description":"test"},{"cidrBlock":"2.0.0.0/8","description":"test-2"}],"maxmemoryPolicy":"noeviction","name":"test-redis-new","persistenceMode":"snapshot","plan":"standard"}'
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            Content-Type:
+                - application/json
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis/red-d8k4ia5odlmc73btr5a0
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 547
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T17:11:04.649569Z","environmentId":"evm-d8k4ia5odlmc73btr590","id":"red-d8k4ia5odlmc73btr5a0","ipAllowList":[{"cidrBlock":"1.1.1.1/32","description":"test"},{"cidrBlock":"2.0.0.0/8","description":"test-2"}],"name":"test-redis-new","options":{"maxmemoryPolicy":"noeviction","persistenceMode":"snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"standard","region":"oregon","status":"creating","updatedAt":"2026-06-09T17:11:10.293562Z","version":"8.1.4"}
+        headers:
+            Content-Length:
+                - "547"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:14 GMT
+            Ratelimit-Limit:
+                - "100"
+            Ratelimit-Remaining:
+                - "92"
+            Ratelimit-Reset:
+                - "46"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001015
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 181.325333ms
+    - id: 58
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis/red-d8k4ia5odlmc73btr5a0/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 372
+        uncompressed: false
+        body: |
+            {"externalConnectionString":"rediss://red-d8k4ia5odlmc73btr5a0:hBFnAKplTyebA0SdRNnSdBJOkQ7QoR03@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k4ia5odlmc73btr5a0:6379","redisCLICommand":" REDISCLI_AUTH=hBFnAKplTyebA0SdRNnSdBJOkQ7QoR03 valkey-cli --user red-d8k4ia5odlmc73btr5a0 -h oregon-keyvalue.localhost.render.com -p 6377 --tls"}
+        headers:
+            Content-Length:
+                - "372"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:14 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "351"
+            Ratelimit-Reset:
+                - "45"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001016
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 76.183584ms
+    - id: 59
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/projects/prj-d8k4i9todlmc73btr55g
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 282
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T17:11:03.779133Z","environmentIds":["evm-d8k4i9todlmc73btr56g"],"id":"prj-d8k4i9todlmc73btr55g","name":"first","owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"updatedAt":"2026-06-09T17:11:03.779133Z"}
+        headers:
+            Content-Length:
+                - "282"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:14 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "350"
+            Ratelimit-Reset:
+                - "45"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001017
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 90.615083ms
+    - id: 60
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis/red-d8k4i9todlmc73btr54g
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 419
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T17:11:03.738122Z","id":"red-d8k4i9todlmc73btr54g","ipAllowList":null,"name":"test-redis-paid","options":{"maxmemoryPolicy":"allkeys_lfu","persistenceMode":"journal_snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"starter","region":"oregon","status":"creating","updatedAt":"2026-06-09T17:11:03.738122Z","version":"8.1.4"}
+        headers:
+            Content-Length:
+                - "419"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:14 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "349"
+            Ratelimit-Reset:
+                - "45"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001018
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 105.294917ms
+    - id: 61
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/environments/evm-d8k4i9todlmc73btr56g
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 222
+        uncompressed: false
+        body: |
+            {"databasesIds":null,"envGroupIds":null,"id":"evm-d8k4i9todlmc73btr56g","name":"prod","networkIsolationEnabled":false,"projectId":"prj-d8k4i9todlmc73btr55g","protectedStatus":"protected","redisIds":null,"serviceIds":null}
+        headers:
+            Content-Length:
+                - "222"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:14 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "348"
+            Ratelimit-Reset:
+                - "45"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001019
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 63.268125ms
+    - id: 62
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis/red-d8k4i9todlmc73btr54g/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 372
+        uncompressed: false
+        body: |
+            {"externalConnectionString":"rediss://red-d8k4i9todlmc73btr54g:uPs9p2GaBjeHP19tbn4bYjWQ2iGcegn5@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k4i9todlmc73btr54g:6379","redisCLICommand":" REDISCLI_AUTH=uPs9p2GaBjeHP19tbn4bYjWQ2iGcegn5 valkey-cli --user red-d8k4i9todlmc73btr54g -h oregon-keyvalue.localhost.render.com -p 6377 --tls"}
+        headers:
+            Content-Length:
+                - "372"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:14 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "347"
+            Ratelimit-Reset:
+                - "45"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001020
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 60.864917ms
+    - id: 63
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/projects/prj-d8k4ia5odlmc73btr580
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 283
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T17:11:04.275047Z","environmentIds":["evm-d8k4ia5odlmc73btr590"],"id":"prj-d8k4ia5odlmc73btr580","name":"second","owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"updatedAt":"2026-06-09T17:11:04.275047Z"}
+        headers:
+            Content-Length:
+                - "283"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:15 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "346"
+            Ratelimit-Reset:
+                - "44"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001021
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 88.849875ms
+    - id: 64
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8k4i9todlmc73btr54g
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: red-d8k4i9todlmc73btr54g"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:15 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "345"
+            Ratelimit-Reset:
+                - "44"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001022
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 52.531584ms
+    - id: 65
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/environments/evm-d8k4ia5odlmc73btr590
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 246
+        uncompressed: false
+        body: |
+            {"databasesIds":null,"envGroupIds":null,"id":"evm-d8k4ia5odlmc73btr590","name":"prod","networkIsolationEnabled":false,"projectId":"prj-d8k4ia5odlmc73btr580","protectedStatus":"protected","redisIds":["red-d8k4ia5odlmc73btr5a0"],"serviceIds":null}
+        headers:
+            Content-Length:
+                - "246"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:15 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "344"
+            Ratelimit-Reset:
+                - "44"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001023
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 68.043042ms
+    - id: 66
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis/red-d8k4ia5odlmc73btr5a0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 547
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T17:11:04.649569Z","environmentId":"evm-d8k4ia5odlmc73btr590","id":"red-d8k4ia5odlmc73btr5a0","ipAllowList":[{"cidrBlock":"1.1.1.1/32","description":"test"},{"cidrBlock":"2.0.0.0/8","description":"test-2"}],"name":"test-redis-new","options":{"maxmemoryPolicy":"noeviction","persistenceMode":"snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"standard","region":"oregon","status":"creating","updatedAt":"2026-06-09T17:11:10.293562Z","version":"8.1.4"}
+        headers:
+            Content-Length:
+                - "547"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:15 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "343"
+            Ratelimit-Reset:
+                - "44"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001024
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 98.133208ms
+    - id: 67
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis/red-d8k4ia5odlmc73btr5a0/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 372
+        uncompressed: false
+        body: |
+            {"externalConnectionString":"rediss://red-d8k4ia5odlmc73btr5a0:hBFnAKplTyebA0SdRNnSdBJOkQ7QoR03@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k4ia5odlmc73btr5a0:6379","redisCLICommand":" REDISCLI_AUTH=hBFnAKplTyebA0SdRNnSdBJOkQ7QoR03 valkey-cli --user red-d8k4ia5odlmc73btr5a0 -h oregon-keyvalue.localhost.render.com -p 6377 --tls"}
+        headers:
+            Content-Length:
+                - "372"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:15 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "342"
+            Ratelimit-Reset:
+                - "44"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001025
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 84.045583ms
+    - id: 68
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8k4ia5odlmc73btr5a0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: red-d8k4ia5odlmc73btr5a0"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:15 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "341"
+            Ratelimit-Reset:
+                - "44"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001026
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 54.055625ms
+    - id: 69
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/projects/prj-d8k4i9todlmc73btr55g
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 282
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T17:11:03.779133Z","environmentIds":["evm-d8k4i9todlmc73btr56g"],"id":"prj-d8k4i9todlmc73btr55g","name":"first","owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"updatedAt":"2026-06-09T17:11:03.779133Z"}
+        headers:
+            Content-Length:
+                - "282"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:16 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "340"
+            Ratelimit-Reset:
+                - "43"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001027
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 99.689792ms
+    - id: 70
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/projects/prj-d8k4ia5odlmc73btr580
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 283
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T17:11:04.275047Z","environmentIds":["evm-d8k4ia5odlmc73btr590"],"id":"prj-d8k4ia5odlmc73btr580","name":"second","owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"updatedAt":"2026-06-09T17:11:04.275047Z"}
+        headers:
+            Content-Length:
+                - "283"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:16 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "339"
+            Ratelimit-Reset:
+                - "43"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001028
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 94.237583ms
+    - id: 71
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis/red-d8k4i9todlmc73btr54g
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 419
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T17:11:03.738122Z","id":"red-d8k4i9todlmc73btr54g","ipAllowList":null,"name":"test-redis-paid","options":{"maxmemoryPolicy":"allkeys_lfu","persistenceMode":"journal_snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"starter","region":"oregon","status":"creating","updatedAt":"2026-06-09T17:11:03.738122Z","version":"8.1.4"}
+        headers:
+            Content-Length:
+                - "419"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:16 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "338"
+            Ratelimit-Reset:
+                - "43"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001029
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 80.851042ms
+    - id: 72
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis/red-d8k4ia5odlmc73btr5a0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 547
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T17:11:04.649569Z","environmentId":"evm-d8k4ia5odlmc73btr590","id":"red-d8k4ia5odlmc73btr5a0","ipAllowList":[{"cidrBlock":"1.1.1.1/32","description":"test"},{"cidrBlock":"2.0.0.0/8","description":"test-2"}],"name":"test-redis-new","options":{"maxmemoryPolicy":"noeviction","persistenceMode":"snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"standard","region":"oregon","status":"creating","updatedAt":"2026-06-09T17:11:10.293562Z","version":"8.1.4"}
+        headers:
+            Content-Length:
+                - "547"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:16 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "337"
+            Ratelimit-Reset:
+                - "43"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001030
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 97.588041ms
+    - id: 73
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/environments/evm-d8k4i9todlmc73btr56g
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 222
+        uncompressed: false
+        body: |
+            {"databasesIds":null,"envGroupIds":null,"id":"evm-d8k4i9todlmc73btr56g","name":"prod","networkIsolationEnabled":false,"projectId":"prj-d8k4i9todlmc73btr55g","protectedStatus":"protected","redisIds":null,"serviceIds":null}
+        headers:
+            Content-Length:
+                - "222"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:16 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "336"
+            Ratelimit-Reset:
+                - "43"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001031
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 62.948042ms
+    - id: 74
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/environments/evm-d8k4ia5odlmc73btr590
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 246
+        uncompressed: false
+        body: |
+            {"databasesIds":null,"envGroupIds":null,"id":"evm-d8k4ia5odlmc73btr590","name":"prod","networkIsolationEnabled":false,"projectId":"prj-d8k4ia5odlmc73btr580","protectedStatus":"protected","redisIds":["red-d8k4ia5odlmc73btr5a0"],"serviceIds":null}
+        headers:
+            Content-Length:
+                - "246"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:16 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "335"
+            Ratelimit-Reset:
+                - "43"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001032
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 71.096334ms
+    - id: 75
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis/red-d8k4i9todlmc73btr54g/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 372
+        uncompressed: false
+        body: |
+            {"externalConnectionString":"rediss://red-d8k4i9todlmc73btr54g:uPs9p2GaBjeHP19tbn4bYjWQ2iGcegn5@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k4i9todlmc73btr54g:6379","redisCLICommand":" REDISCLI_AUTH=uPs9p2GaBjeHP19tbn4bYjWQ2iGcegn5 valkey-cli --user red-d8k4i9todlmc73btr54g -h oregon-keyvalue.localhost.render.com -p 6377 --tls"}
+        headers:
+            Content-Length:
+                - "372"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:17 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "334"
+            Ratelimit-Reset:
+                - "42"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001033
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 67.883125ms
+    - id: 76
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis/red-d8k4ia5odlmc73btr5a0/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 372
+        uncompressed: false
+        body: |
+            {"externalConnectionString":"rediss://red-d8k4ia5odlmc73btr5a0:hBFnAKplTyebA0SdRNnSdBJOkQ7QoR03@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k4ia5odlmc73btr5a0:6379","redisCLICommand":" REDISCLI_AUTH=hBFnAKplTyebA0SdRNnSdBJOkQ7QoR03 valkey-cli --user red-d8k4ia5odlmc73btr5a0 -h oregon-keyvalue.localhost.render.com -p 6377 --tls"}
+        headers:
+            Content-Length:
+                - "372"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:17 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "333"
+            Ratelimit-Reset:
+                - "42"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001034
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 77.537417ms
+    - id: 77
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8k4i9todlmc73btr54g
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: red-d8k4i9todlmc73btr54g"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:17 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "332"
+            Ratelimit-Reset:
+                - "42"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001035
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 52.080917ms
+    - id: 78
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8k4ia5odlmc73btr5a0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: red-d8k4ia5odlmc73btr5a0"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:17 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "331"
+            Ratelimit-Reset:
+                - "42"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001036
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 55.5855ms
+    - id: 79
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis/red-d8k4i9todlmc73btr54g
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -3158,17 +4620,17 @@ interactions:
         body: ""
         headers:
             Date:
-                - Mon, 09 Sep 2024 16:35:32 GMT
+                - Tue, 09 Jun 2026 17:11:17 GMT
             Ratelimit-Limit:
-                - "10000"
+                - "100"
             Ratelimit-Remaining:
-                - "9988"
+                - "91"
             Ratelimit-Reset:
-                - "27"
+                - "42"
             Referrer-Policy:
                 - same-origin
             Render-Request-Id:
-                - api-cb6686ccd-gtczz/osocDdt2rF-000197
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001037
             Vary:
                 - Origin
             X-Content-Type-Options:
@@ -3179,4 +4641,1959 @@ interactions:
                 - 1; mode=block
         status: 204 No Content
         code: 204
-        duration: 90.261125ms
+        duration: 113.84425ms
+    - id: 80
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis/red-d8k4ia5odlmc73btr5a0
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Date:
+                - Tue, 09 Jun 2026 17:11:17 GMT
+            Ratelimit-Limit:
+                - "100"
+            Ratelimit-Remaining:
+                - "90"
+            Ratelimit-Reset:
+                - "42"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001038
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 204 No Content
+        code: 204
+        duration: 105.272416ms
+    - id: 81
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 147
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: '{"ipAllowList":[],"maxmemoryPolicy":"allkeys_lfu","name":"test-redis-upgrade","ownerId":"some-owner-id","plan":"free","region":"oregon"}'
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            Content-Type:
+                - application/json
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 411
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T17:11:18.141023335Z","id":"red-d8k4idlodlmc73btr5pg","ipAllowList":null,"name":"test-redis-upgrade","options":{"maxmemoryPolicy":"allkeys_lfu","persistenceMode":"off"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"free","region":"oregon","status":"unknown","updatedAt":"2026-06-09T17:11:18.141023335Z","version":"8.1.4"}
+        headers:
+            Content-Length:
+                - "411"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:18 GMT
+            Ratelimit-Limit:
+                - "20"
+            Ratelimit-Remaining:
+                - "13"
+            Ratelimit-Reset:
+                - "2921"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001039
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 201 Created
+        code: 201
+        duration: 270.080958ms
+    - id: 82
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/projects/prj-d8k4ia5odlmc73btr580
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Date:
+                - Tue, 09 Jun 2026 17:11:18 GMT
+            Ratelimit-Limit:
+                - "100"
+            Ratelimit-Remaining:
+                - "89"
+            Ratelimit-Reset:
+                - "41"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001040
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 204 No Content
+        code: 204
+        duration: 133.141375ms
+    - id: 83
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis/red-d8k4idlodlmc73btr5pg/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 372
+        uncompressed: false
+        body: |
+            {"externalConnectionString":"rediss://red-d8k4idlodlmc73btr5pg:AI8BTiOr64uDes7ByHNHjfL7h20ur8mW@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k4idlodlmc73btr5pg:6379","redisCLICommand":" REDISCLI_AUTH=AI8BTiOr64uDes7ByHNHjfL7h20ur8mW valkey-cli --user red-d8k4idlodlmc73btr5pg -h oregon-keyvalue.localhost.render.com -p 6377 --tls"}
+        headers:
+            Content-Length:
+                - "372"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:18 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "330"
+            Ratelimit-Reset:
+                - "41"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001041
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 69.451417ms
+    - id: 84
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/projects/prj-d8k4i9todlmc73btr55g
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Date:
+                - Tue, 09 Jun 2026 17:11:18 GMT
+            Ratelimit-Limit:
+                - "100"
+            Ratelimit-Remaining:
+                - "88"
+            Ratelimit-Reset:
+                - "41"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001042
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 204 No Content
+        code: 204
+        duration: 125.522583ms
+    - id: 85
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis/red-d8k4idlodlmc73btr5pg
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 406
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T17:11:18.141023Z","id":"red-d8k4idlodlmc73btr5pg","ipAllowList":null,"name":"test-redis-upgrade","options":{"maxmemoryPolicy":"allkeys_lfu","persistenceMode":"off"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"free","region":"oregon","status":"creating","updatedAt":"2026-06-09T17:11:18.141023Z","version":"8.1.4"}
+        headers:
+            Content-Length:
+                - "406"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:18 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "329"
+            Ratelimit-Reset:
+                - "41"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001043
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 80.609416ms
+    - id: 86
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis/red-d8k4idlodlmc73btr5pg/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 372
+        uncompressed: false
+        body: |
+            {"externalConnectionString":"rediss://red-d8k4idlodlmc73btr5pg:AI8BTiOr64uDes7ByHNHjfL7h20ur8mW@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k4idlodlmc73btr5pg:6379","redisCLICommand":" REDISCLI_AUTH=AI8BTiOr64uDes7ByHNHjfL7h20ur8mW valkey-cli --user red-d8k4idlodlmc73btr5pg -h oregon-keyvalue.localhost.render.com -p 6377 --tls"}
+        headers:
+            Content-Length:
+                - "372"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:19 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "328"
+            Ratelimit-Reset:
+                - "40"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001044
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 62.166292ms
+    - id: 87
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8k4idlodlmc73btr5pg
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: red-d8k4idlodlmc73btr5pg"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:19 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "327"
+            Ratelimit-Reset:
+                - "40"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001045
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 53.165917ms
+    - id: 88
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis/red-d8k4idlodlmc73btr5pg
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 406
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T17:11:18.141023Z","id":"red-d8k4idlodlmc73btr5pg","ipAllowList":null,"name":"test-redis-upgrade","options":{"maxmemoryPolicy":"allkeys_lfu","persistenceMode":"off"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"free","region":"oregon","status":"creating","updatedAt":"2026-06-09T17:11:18.141023Z","version":"8.1.4"}
+        headers:
+            Content-Length:
+                - "406"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:19 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "326"
+            Ratelimit-Reset:
+                - "40"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001046
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 88.745167ms
+    - id: 89
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis/red-d8k4idlodlmc73btr5pg/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 372
+        uncompressed: false
+        body: |
+            {"externalConnectionString":"rediss://red-d8k4idlodlmc73btr5pg:AI8BTiOr64uDes7ByHNHjfL7h20ur8mW@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k4idlodlmc73btr5pg:6379","redisCLICommand":" REDISCLI_AUTH=AI8BTiOr64uDes7ByHNHjfL7h20ur8mW valkey-cli --user red-d8k4idlodlmc73btr5pg -h oregon-keyvalue.localhost.render.com -p 6377 --tls"}
+        headers:
+            Content-Length:
+                - "372"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:19 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "325"
+            Ratelimit-Reset:
+                - "40"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001047
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 67.448584ms
+    - id: 90
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8k4idlodlmc73btr5pg
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: red-d8k4idlodlmc73btr5pg"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:19 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "324"
+            Ratelimit-Reset:
+                - "40"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001048
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 50.562333ms
+    - id: 91
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 95
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: '{"ipAllowList":[],"maxmemoryPolicy":"allkeys_lfu","name":"test-redis-upgrade","plan":"starter"}'
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            Content-Type:
+                - application/json
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis/red-d8k4idlodlmc73btr5pg
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 422
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T17:11:18.141023Z","id":"red-d8k4idlodlmc73btr5pg","ipAllowList":null,"name":"test-redis-upgrade","options":{"maxmemoryPolicy":"allkeys_lfu","persistenceMode":"journal_snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"starter","region":"oregon","status":"creating","updatedAt":"2026-06-09T17:11:19.977254Z","version":"8.1.4"}
+        headers:
+            Content-Length:
+                - "422"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:20 GMT
+            Ratelimit-Limit:
+                - "100"
+            Ratelimit-Remaining:
+                - "87"
+            Ratelimit-Reset:
+                - "40"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001049
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 199.116917ms
+    - id: 92
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis/red-d8k4idlodlmc73btr5pg/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 372
+        uncompressed: false
+        body: |
+            {"externalConnectionString":"rediss://red-d8k4idlodlmc73btr5pg:AI8BTiOr64uDes7ByHNHjfL7h20ur8mW@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k4idlodlmc73btr5pg:6379","redisCLICommand":" REDISCLI_AUTH=AI8BTiOr64uDes7ByHNHjfL7h20ur8mW valkey-cli --user red-d8k4idlodlmc73btr5pg -h oregon-keyvalue.localhost.render.com -p 6377 --tls"}
+        headers:
+            Content-Length:
+                - "372"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:20 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "323"
+            Ratelimit-Reset:
+                - "39"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001050
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 64.105583ms
+    - id: 93
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis/red-d8k4idlodlmc73btr5pg
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 422
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T17:11:18.141023Z","id":"red-d8k4idlodlmc73btr5pg","ipAllowList":null,"name":"test-redis-upgrade","options":{"maxmemoryPolicy":"allkeys_lfu","persistenceMode":"journal_snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"starter","region":"oregon","status":"creating","updatedAt":"2026-06-09T17:11:19.977254Z","version":"8.1.4"}
+        headers:
+            Content-Length:
+                - "422"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:20 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "322"
+            Ratelimit-Reset:
+                - "39"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001051
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 82.828291ms
+    - id: 94
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis/red-d8k4idlodlmc73btr5pg/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 372
+        uncompressed: false
+        body: |
+            {"externalConnectionString":"rediss://red-d8k4idlodlmc73btr5pg:AI8BTiOr64uDes7ByHNHjfL7h20ur8mW@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k4idlodlmc73btr5pg:6379","redisCLICommand":" REDISCLI_AUTH=AI8BTiOr64uDes7ByHNHjfL7h20ur8mW valkey-cli --user red-d8k4idlodlmc73btr5pg -h oregon-keyvalue.localhost.render.com -p 6377 --tls"}
+        headers:
+            Content-Length:
+                - "372"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:20 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "321"
+            Ratelimit-Reset:
+                - "39"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001052
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 65.798791ms
+    - id: 95
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8k4idlodlmc73btr5pg
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: red-d8k4idlodlmc73btr5pg"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:20 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "320"
+            Ratelimit-Reset:
+                - "39"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001053
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 50.398416ms
+    - id: 96
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis/red-d8k4idlodlmc73btr5pg
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 422
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T17:11:18.141023Z","id":"red-d8k4idlodlmc73btr5pg","ipAllowList":null,"name":"test-redis-upgrade","options":{"maxmemoryPolicy":"allkeys_lfu","persistenceMode":"journal_snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"starter","region":"oregon","status":"creating","updatedAt":"2026-06-09T17:11:19.977254Z","version":"8.1.4"}
+        headers:
+            Content-Length:
+                - "422"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:20 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "319"
+            Ratelimit-Reset:
+                - "39"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001054
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 84.293625ms
+    - id: 97
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis/red-d8k4idlodlmc73btr5pg/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 372
+        uncompressed: false
+        body: |
+            {"externalConnectionString":"rediss://red-d8k4idlodlmc73btr5pg:AI8BTiOr64uDes7ByHNHjfL7h20ur8mW@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k4idlodlmc73btr5pg:6379","redisCLICommand":" REDISCLI_AUTH=AI8BTiOr64uDes7ByHNHjfL7h20ur8mW valkey-cli --user red-d8k4idlodlmc73btr5pg -h oregon-keyvalue.localhost.render.com -p 6377 --tls"}
+        headers:
+            Content-Length:
+                - "372"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:21 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "318"
+            Ratelimit-Reset:
+                - "39"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001055
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 67.630166ms
+    - id: 98
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8k4idlodlmc73btr5pg
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: red-d8k4idlodlmc73btr5pg"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:21 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "317"
+            Ratelimit-Reset:
+                - "38"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001056
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 53.555667ms
+    - id: 99
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis/red-d8k4idlodlmc73btr5pg
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Date:
+                - Tue, 09 Jun 2026 17:11:21 GMT
+            Ratelimit-Limit:
+                - "100"
+            Ratelimit-Remaining:
+                - "86"
+            Ratelimit-Reset:
+                - "38"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001057
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 204 No Content
+        code: 204
+        duration: 98.463333ms
+    - id: 100
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 172
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: '{"ipAllowList":[],"maxmemoryPolicy":"allkeys_lfu","name":"test-redis-upgrade2","ownerId":"some-owner-id","persistenceMode":"off","plan":"free","region":"oregon"}'
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            Content-Type:
+                - application/json
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 412
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T17:11:21.546307962Z","id":"red-d8k4iedodlmc73btr610","ipAllowList":null,"name":"test-redis-upgrade2","options":{"maxmemoryPolicy":"allkeys_lfu","persistenceMode":"off"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"free","region":"oregon","status":"unknown","updatedAt":"2026-06-09T17:11:21.546307962Z","version":"8.1.4"}
+        headers:
+            Content-Length:
+                - "412"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:21 GMT
+            Ratelimit-Limit:
+                - "20"
+            Ratelimit-Remaining:
+                - "12"
+            Ratelimit-Reset:
+                - "2918"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001058
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 201 Created
+        code: 201
+        duration: 242.329ms
+    - id: 101
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis/red-d8k4iedodlmc73btr610/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 372
+        uncompressed: false
+        body: |
+            {"externalConnectionString":"rediss://red-d8k4iedodlmc73btr610:E1h4hN7c9cSLIP3b6xjUAYBOiOZL6SAO@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k4iedodlmc73btr610:6379","redisCLICommand":" REDISCLI_AUTH=E1h4hN7c9cSLIP3b6xjUAYBOiOZL6SAO valkey-cli --user red-d8k4iedodlmc73btr610 -h oregon-keyvalue.localhost.render.com -p 6377 --tls"}
+        headers:
+            Content-Length:
+                - "372"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:21 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "316"
+            Ratelimit-Reset:
+                - "38"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001059
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 61.851208ms
+    - id: 102
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis/red-d8k4iedodlmc73btr610
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 407
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T17:11:21.546308Z","id":"red-d8k4iedodlmc73btr610","ipAllowList":null,"name":"test-redis-upgrade2","options":{"maxmemoryPolicy":"allkeys_lfu","persistenceMode":"off"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"free","region":"oregon","status":"creating","updatedAt":"2026-06-09T17:11:21.546308Z","version":"8.1.4"}
+        headers:
+            Content-Length:
+                - "407"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:22 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "315"
+            Ratelimit-Reset:
+                - "38"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001060
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 85.374209ms
+    - id: 103
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis/red-d8k4iedodlmc73btr610/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 372
+        uncompressed: false
+        body: |
+            {"externalConnectionString":"rediss://red-d8k4iedodlmc73btr610:E1h4hN7c9cSLIP3b6xjUAYBOiOZL6SAO@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k4iedodlmc73btr610:6379","redisCLICommand":" REDISCLI_AUTH=E1h4hN7c9cSLIP3b6xjUAYBOiOZL6SAO valkey-cli --user red-d8k4iedodlmc73btr610 -h oregon-keyvalue.localhost.render.com -p 6377 --tls"}
+        headers:
+            Content-Length:
+                - "372"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:22 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "314"
+            Ratelimit-Reset:
+                - "37"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001061
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 63.539458ms
+    - id: 104
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8k4iedodlmc73btr610
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: red-d8k4iedodlmc73btr610"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:22 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "313"
+            Ratelimit-Reset:
+                - "37"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001062
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 51.867541ms
+    - id: 105
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis/red-d8k4iedodlmc73btr610
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 407
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T17:11:21.546308Z","id":"red-d8k4iedodlmc73btr610","ipAllowList":null,"name":"test-redis-upgrade2","options":{"maxmemoryPolicy":"allkeys_lfu","persistenceMode":"off"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"free","region":"oregon","status":"creating","updatedAt":"2026-06-09T17:11:21.546308Z","version":"8.1.4"}
+        headers:
+            Content-Length:
+                - "407"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:22 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "312"
+            Ratelimit-Reset:
+                - "37"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001063
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 83.251ms
+    - id: 106
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis/red-d8k4iedodlmc73btr610/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 372
+        uncompressed: false
+        body: |
+            {"externalConnectionString":"rediss://red-d8k4iedodlmc73btr610:E1h4hN7c9cSLIP3b6xjUAYBOiOZL6SAO@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k4iedodlmc73btr610:6379","redisCLICommand":" REDISCLI_AUTH=E1h4hN7c9cSLIP3b6xjUAYBOiOZL6SAO valkey-cli --user red-d8k4iedodlmc73btr610 -h oregon-keyvalue.localhost.render.com -p 6377 --tls"}
+        headers:
+            Content-Length:
+                - "372"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:22 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "311"
+            Ratelimit-Reset:
+                - "37"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001064
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 65.467334ms
+    - id: 107
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8k4iedodlmc73btr610
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: red-d8k4iedodlmc73btr610"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:22 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "310"
+            Ratelimit-Reset:
+                - "37"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001065
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 52.102583ms
+    - id: 108
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 125
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: '{"ipAllowList":[],"maxmemoryPolicy":"allkeys_lfu","name":"test-redis-upgrade2","persistenceMode":"snapshot","plan":"starter"}'
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            Content-Type:
+                - application/json
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis/red-d8k4iedodlmc73btr610
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 415
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T17:11:21.546308Z","id":"red-d8k4iedodlmc73btr610","ipAllowList":null,"name":"test-redis-upgrade2","options":{"maxmemoryPolicy":"allkeys_lfu","persistenceMode":"snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"starter","region":"oregon","status":"creating","updatedAt":"2026-06-09T17:11:23.080507Z","version":"8.1.4"}
+        headers:
+            Content-Length:
+                - "415"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:23 GMT
+            Ratelimit-Limit:
+                - "100"
+            Ratelimit-Remaining:
+                - "85"
+            Ratelimit-Reset:
+                - "37"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001066
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 260.249083ms
+    - id: 109
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis/red-d8k4iedodlmc73btr610/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 372
+        uncompressed: false
+        body: |
+            {"externalConnectionString":"rediss://red-d8k4iedodlmc73btr610:E1h4hN7c9cSLIP3b6xjUAYBOiOZL6SAO@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k4iedodlmc73btr610:6379","redisCLICommand":" REDISCLI_AUTH=E1h4hN7c9cSLIP3b6xjUAYBOiOZL6SAO valkey-cli --user red-d8k4iedodlmc73btr610 -h oregon-keyvalue.localhost.render.com -p 6377 --tls"}
+        headers:
+            Content-Length:
+                - "372"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:23 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "309"
+            Ratelimit-Reset:
+                - "36"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001067
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 61.236292ms
+    - id: 110
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis/red-d8k4iedodlmc73btr610
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 415
+        uncompressed: false
+        body: |
+            {"createdAt":"2026-06-09T17:11:21.546308Z","id":"red-d8k4iedodlmc73btr610","ipAllowList":null,"name":"test-redis-upgrade2","options":{"maxmemoryPolicy":"allkeys_lfu","persistenceMode":"snapshot"},"owner":{"email":"email@example.com","id":"some-owner-id","name":"My Workspace","type":"team"},"plan":"starter","region":"oregon","status":"creating","updatedAt":"2026-06-09T17:11:23.080507Z","version":"8.1.4"}
+        headers:
+            Content-Length:
+                - "415"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:23 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "308"
+            Ratelimit-Reset:
+                - "36"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001068
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 89.289083ms
+    - id: 111
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis/red-d8k4iedodlmc73btr610/connection-info
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 372
+        uncompressed: false
+        body: |
+            {"externalConnectionString":"rediss://red-d8k4iedodlmc73btr610:E1h4hN7c9cSLIP3b6xjUAYBOiOZL6SAO@oregon-keyvalue.localhost.render.com:6377","internalConnectionString":"redis://red-d8k4iedodlmc73btr610:6379","redisCLICommand":" REDISCLI_AUTH=E1h4hN7c9cSLIP3b6xjUAYBOiOZL6SAO valkey-cli --user red-d8k4iedodlmc73btr610 -h oregon-keyvalue.localhost.render.com -p 6377 --tls"}
+        headers:
+            Content-Length:
+                - "372"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:23 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "307"
+            Ratelimit-Reset:
+                - "36"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001069
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 62.060375ms
+    - id: 112
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/red-d8k4iedodlmc73btr610
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: red-d8k4iedodlmc73btr610"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 09 Jun 2026 17:11:23 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "306"
+            Ratelimit-Reset:
+                - "36"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001070
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 49.835208ms
+    - id: 113
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/redis/red-d8k4iedodlmc73btr610
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Date:
+                - Tue, 09 Jun 2026 17:11:24 GMT
+            Ratelimit-Limit:
+                - "100"
+            Ratelimit-Remaining:
+                - "84"
+            Ratelimit-Reset:
+                - "35"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-77b8955cbd-dgpw5/1xnsbqNRn3-001071
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 204 No Content
+        code: 204
+        duration: 100.260042ms

--- a/internal/provider/redis/resource/testdata/redis_upgrade.tf
+++ b/internal/provider/redis/resource/testdata/redis_upgrade.tf
@@ -1,0 +1,10 @@
+variable "plan" {
+  type = string
+}
+
+resource "render_redis" "test-redis-upgrade" {
+  name              = "test-redis-upgrade"
+  plan              = var.plan
+  region            = "oregon"
+  max_memory_policy = "allkeys_lfu"
+}

--- a/internal/provider/redis/resource/testdata/redis_upgrade2.tf
+++ b/internal/provider/redis/resource/testdata/redis_upgrade2.tf
@@ -1,0 +1,15 @@
+variable "plan" {
+  type = string
+}
+
+variable "persistence_mode" {
+  type = string
+}
+
+resource "render_redis" "test-redis-upgrade2" {
+  name              = "test-redis-upgrade2"
+  plan              = var.plan
+  region            = "oregon"
+  max_memory_policy = "allkeys_lfu"
+  persistence_mode  = var.persistence_mode
+}

--- a/internal/provider/redis/validate.go
+++ b/internal/provider/redis/validate.go
@@ -22,6 +22,14 @@ func ValidateMaxMemoryPolicyFunc() validator.String {
 	)
 }
 
+func ValidatePersistenceModeFunc() validator.String {
+	return stringvalidator.OneOf(
+		string(client.PersistenceModeJournalSnapshot),
+		string(client.PersistenceModeSnapshot),
+		string(client.PersistenceModeOff),
+	)
+}
+
 func ValidateRedisPlanFunc() validator.String {
 	return stringvalidator.Any(
 		isNonCustomRedisPlanFunc(),

--- a/internal/provider/types/datasource/redis.go
+++ b/internal/provider/types/datasource/redis.go
@@ -15,6 +15,14 @@ var MaxMemoryPolicy = schema.StringAttribute{
 	},
 }
 
+var PersistenceMode = schema.StringAttribute{
+	Computed:    true,
+	Description: "The type of persistence to use for saving data",
+	Validators: []validator.String{
+		redis.ValidatePersistenceModeFunc(),
+	},
+}
+
 var RedisPlan = schema.StringAttribute{
 	Computed:    true,
 	Description: "Plan for the Redis instance",

--- a/internal/provider/types/resource/redis.go
+++ b/internal/provider/types/resource/redis.go
@@ -18,6 +18,16 @@ var MaxMemoryPolicy = schema.StringAttribute{
 	},
 }
 
+var PersistenceMode = schema.StringAttribute{
+	Optional:            true,
+	Computed:            true,
+	Description:         "The type of persistence to use for saving data. Value values are journal_snapshot, snapshot, off.",
+	MarkdownDescription: "The type of persistence to use for saving data. Value values are `journal_snapshot`, `snapshot`, `off`.",
+	Validators: []validator.String{
+		redis.ValidatePersistenceModeFunc(),
+	},
+}
+
 var RedisPlan = schema.StringAttribute{
 	Optional:            true,
 	Computed:            true,


### PR DESCRIPTION
This adds support for the new Key Value `persistenceMode` setting.

Paid Render Key Value instances now support three different disk persistence modes:
- Journal + Snapshot: Append writes to a journal and periodically save full snapshots.
        This matches the behavior of all paid Key Value instances previously
- Snapshot only: Disable journaling while continuing to save periodic snapshots.
- Off: Disable all disk-backed persistence.

More details are in the [change log](https://render.com/changelog/specify-disk-persistence-behavior-for-paid-key-value-instances) and [docs](https://render.com/docs/key-value#data-persistence). The [REST API](https://api-docs.render.com/reference/update-key-value) docs have also been updated.