### PR TITLE
[DOC-238] Fix examples to used the most current runtime_source field

### DIFF
--- a/docs/resources/env_group_link.md
+++ b/docs/resources/env_group_link.md
@@ -17,8 +17,7 @@ resource "render_web_service" "web" {
   name    = "web-service"
   plan    = "starter"
   region  = "ohio"
-  runtime = "image"
-  deploy_configuration = {
+  runtime_source = {
     image = {
       image_url = "docker.io/library/nginx",
       tag       = "latest",

--- a/examples/resources/render_env_group_link/resource.tf
+++ b/examples/resources/render_env_group_link/resource.tf
@@ -2,8 +2,7 @@ resource "render_web_service" "web" {
   name    = "web-service"
   plan    = "starter"
   region  = "ohio"
-  runtime = "image"
-  deploy_configuration = {
+  runtime_source = {
     image = {
       image_url = "docker.io/library/nginx",
       tag       = "latest",


### PR DESCRIPTION
[Fixing ticket](https://linear.app/render-com/issue/DOC-238/terraform-provider-example-does-not-have-required-field).

Adding required `runtime_source` field! I ran the example personally and Terraform successfully planned and applied ✨ 

