### PR TITLE
[DOC-166] Fix cron job examples

### DIFF
--- a/docs/resources/cron_job.md
+++ b/docs/resources/cron_job.md
@@ -14,18 +14,16 @@ Provides a Render Cron Job resource.
 
 ```terraform
 resource "render_cron_job" "cron-job-example" {
-  name               = "example-cron-job"
-  plan               = "starter"
-  region             = "ohio"
-  runtime            = "python"
-  schedule           = "30 2 * * *" // Run daily at 2:30 AM
-  start_command      = "echo 'cron job running'"
-  pre_deploy_command = "pip install -r requirements.txt"
+  name          = "example-cron-job"
+  plan          = "starter"
+  region        = "ohio"
+  schedule      = "30 2 * * *" // Run daily at 2:30 AM
+  start_command = "echo 'cron job running'"
 
   runtime_source = {
     native_runtime = {
       auto_deploy   = true
-      branch        = "master"
+      branch        = "main"
       build_command = "pip install -r requirements.txt"
       build_filter = {
         ignored_paths = ["cronjob/tests/**"]

--- a/examples/resources/render_cron_job/resource.tf
+++ b/examples/resources/render_cron_job/resource.tf
@@ -1,16 +1,14 @@
 resource "render_cron_job" "cron-job-example" {
-  name               = "example-cron-job"
-  plan               = "starter"
-  region             = "ohio"
-  runtime            = "python"
-  schedule           = "30 2 * * *" // Run daily at 2:30 AM
-  start_command      = "echo 'cron job running'"
-  pre_deploy_command = "pip install -r requirements.txt"
+  name          = "example-cron-job"
+  plan          = "starter"
+  region        = "ohio"
+  schedule      = "30 2 * * *" // Run daily at 2:30 AM
+  start_command = "echo 'cron job running'"
 
   runtime_source = {
     native_runtime = {
       auto_deploy   = true
-      branch        = "master"
+      branch        = "main"
       build_command = "pip install -r requirements.txt"
       build_filter = {
         ignored_paths = ["cronjob/tests/**"]


### PR DESCRIPTION
Fix cron job docs/example to match the actual Terraform schema:

- Removed unsupported `runtime` and `pre_deploy_command` from the `render_cron_job` example.
  - Kept runtime configuration under `runtime_source.native_runtime.runtime` (where it is supported).
- Updated example branch from `master` to `main`

I tested these changes locally and successfully planned and applied! 