### PR TITLE
ignore windows arm due to deprecation in go 1.26

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,6 +29,8 @@ builds:
   ignore:
     - goos: darwin
       goarch: '386'
+    - goos: windows
+      goarch: arm
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
 - format: zip


### PR DESCRIPTION
Apparently, go 1.26 dropped the windows/arm port so we need to ignore it to fix this failure: https://github.com/render-oss/terraform-provider-render/actions/runs/29872453966/job/88775475327