### PR TITLE
fix: don't send maintenance_mode for free-tier web services

### DIFF
--- a/internal/provider/webservice/models.go
+++ b/internal/provider/webservice/models.go
@@ -62,6 +62,16 @@ func ModelForServiceResult(service *common.WrappedService, plan WebServiceModel,
 		ipAllowList = common.IPAllowListFromClient(*details.IpAllowList, diags)
 	}
 
+	// The API omits maintenance_mode for free-tier services, which would otherwise be
+	// stored as null and conflict with the schema's default object, causing a perpetual
+	// diff. Unlike num_instances / ip_allow_list above (which key off the plan value), this
+	// attribute has a static schema default, so fall back to that default to keep state and
+	// the computed default in agreement.
+	maintenanceMode := common.DefaultMaintenanceMode()
+	if details.MaintenanceMode != nil {
+		maintenanceMode = common.MaintenanceModeFromClient(details.MaintenanceMode, diags)
+	}
+
 	webServicesModel := &WebServiceModel{
 		Id:                         types.StringValue(service.Id),
 		CustomDomains:              common.CustomDomainClientsToCustomDomainModelsNonRedirecting(service.CustomDomains),
@@ -81,7 +91,7 @@ func ModelForServiceResult(service *common.WrappedService, plan WebServiceModel,
 		MaxShutdownDelaySeconds:    common.IntPointerAsValue(details.MaxShutdownDelaySeconds),
 		IPAllowList:                ipAllowList,
 
-		MaintenanceMode:      common.MaintenanceModeFromClient(details.MaintenanceMode, diags),
+		MaintenanceMode:      maintenanceMode,
 		Autoscaling:          common.AutoscalingFromClient(details.Autoscaling, diags),
 		Disk:                 common.DiskToDiskModel(details.Disk),
 		EnvVars:              common.EnvVarsFromClientCursors(service.EnvVars, plan.EnvVars),

--- a/internal/provider/webservice/models_test.go
+++ b/internal/provider/webservice/models_test.go
@@ -1,0 +1,72 @@
+package webservice
+
+import (
+	"testing"
+
+	"terraform-provider-render/internal/client"
+	"terraform-provider-render/internal/provider/common"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func wrappedServiceForMaintenanceMode(t *testing.T, servicePlan client.Plan, maintenanceMode *client.MaintenanceMode) *common.WrappedService {
+	t.Helper()
+
+	details := client.WebServiceDetails{
+		Env:                client.ServiceEnvImage,
+		Runtime:            client.ServiceRuntimeImage,
+		EnvSpecificDetails: client.EnvSpecificDetails{},
+		Plan:               servicePlan,
+		Region:             client.Region("oregon"),
+		NumInstances:       1,
+		Url:                "https://test.onrender.com",
+		MaintenanceMode:    maintenanceMode,
+	}
+
+	var serviceDetails client.Service_ServiceDetails
+	require.NoError(t, serviceDetails.FromWebServiceDetails(details))
+
+	imagePath := "nginx:latest"
+	return &common.WrappedService{
+		Service: &client.Service{
+			Id:             "srv-1",
+			Name:           "test-web-service",
+			Slug:           "test-web-service",
+			OwnerId:        "owner-123",
+			ImagePath:      &imagePath,
+			ServiceDetails: serviceDetails,
+		},
+	}
+}
+
+// Issue #80: the API omits maintenance_mode for free-tier services. Storing that as null
+// would conflict with the schema's default object and cause a perpetual diff, so the read
+// mapper must fall back to the default instead.
+func TestModelForServiceResult_DefaultsMaintenanceModeWhenAPIOmitsIt(t *testing.T) {
+	wrapped := wrappedServiceForMaintenanceMode(t, client.PlanFree, nil)
+
+	plan := WebServiceModel{MaintenanceMode: common.DefaultMaintenanceMode()}
+	model, err := ModelForServiceResult(wrapped, plan, diag.Diagnostics{})
+	require.NoError(t, err)
+
+	assert.False(t, model.MaintenanceMode.IsNull(), "maintenance_mode must not be null for free-tier services")
+	assert.Equal(t, common.DefaultMaintenanceMode(), model.MaintenanceMode)
+}
+
+func TestModelForServiceResult_MapsMaintenanceModeWhenAPIReturnsIt(t *testing.T) {
+	wrapped := wrappedServiceForMaintenanceMode(t, client.PlanStarter, &client.MaintenanceMode{
+		Enabled: true,
+		Uri:     "https://status.example.com",
+	})
+
+	plan := WebServiceModel{MaintenanceMode: common.DefaultMaintenanceMode()}
+	model, err := ModelForServiceResult(wrapped, plan, diag.Diagnostics{})
+	require.NoError(t, err)
+
+	require.False(t, model.MaintenanceMode.IsNull())
+	attrs := model.MaintenanceMode.Attributes()
+	assert.Equal(t, "true", attrs["enabled"].String())
+	assert.Equal(t, `"https://status.example.com"`, attrs["uri"].String())
+}

--- a/internal/provider/webservice/resource/internal/create.go
+++ b/internal/provider/webservice/resource/internal/create.go
@@ -24,6 +24,13 @@ func CreateServiceRequestFromModel(ctx context.Context, ownerID string, plan web
 
 	servicePlan := client.Plan(plan.Plan.ValueString())
 
+	// Maintenance mode can only be configured for non-free tier services, so omit it
+	// entirely on the free plan to avoid the API rejecting the request.
+	var maintenanceMode *client.MaintenanceMode
+	if servicePlan != client.PlanFree {
+		maintenanceMode = common.ToClientMaintenanceMode(plan.MaintenanceMode)
+	}
+
 	pullRequestPreviewsEnabled := client.PullRequestPreviewsEnabledNo
 	if plan.PullRequestPreviewsEnabled.ValueBool() {
 		pullRequestPreviewsEnabled = client.PullRequestPreviewsEnabledYes
@@ -61,7 +68,7 @@ func CreateServiceRequestFromModel(ctx context.Context, ownerID string, plan web
 		Previews:                   common.PreviewsObjectToPreviews(ctx, plan.Previews),
 		PullRequestPreviewsEnabled: &pullRequestPreviewsEnabled,
 		Region:                     &region,
-		MaintenanceMode:            common.ToClientMaintenanceMode(plan.MaintenanceMode),
+		MaintenanceMode:            maintenanceMode,
 		MaxShutdownDelaySeconds:    common.ValueAsIntPointer(plan.MaxShutdownDelaySeconds),
 		Autoscaling:                autoscaling,
 		IpAllowList:                ipAllowList,

--- a/internal/provider/webservice/resource/internal/create_test.go
+++ b/internal/provider/webservice/resource/internal/create_test.go
@@ -1,0 +1,40 @@
+package internal
+
+import (
+	"context"
+	"testing"
+
+	"terraform-provider-render/internal/client"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Issue #80: maintenance mode can only be configured for non-free tier services, so it
+// must be omitted from the create payload on the free plan.
+func TestCreateServiceRequestFromModel_OmitsMaintenanceModeOnFreePlan(t *testing.T) {
+	ctx := context.Background()
+
+	plan := webServiceModelForPlan(string(client.PlanFree))
+	req, err := CreateServiceRequestFromModel(ctx, "owner-123", plan)
+	require.NoError(t, err)
+
+	details, err := req.ServiceDetails.AsWebServiceDetailsPOST()
+	require.NoError(t, err)
+
+	assert.Nil(t, details.MaintenanceMode, "maintenance_mode must be omitted for free-tier services")
+}
+
+func TestCreateServiceRequestFromModel_IncludesMaintenanceModeOnPaidPlan(t *testing.T) {
+	ctx := context.Background()
+
+	plan := webServiceModelForPlan(string(client.PlanStarter))
+	req, err := CreateServiceRequestFromModel(ctx, "owner-123", plan)
+	require.NoError(t, err)
+
+	details, err := req.ServiceDetails.AsWebServiceDetailsPOST()
+	require.NoError(t, err)
+
+	require.NotNil(t, details.MaintenanceMode, "maintenance_mode must be sent for paid-tier services")
+	assert.False(t, details.MaintenanceMode.Enabled)
+}

--- a/internal/provider/webservice/resource/internal/update.go
+++ b/internal/provider/webservice/resource/internal/update.go
@@ -15,6 +15,14 @@ func UpdateServiceRequestFromModel(ctx context.Context, plan webservice.WebServi
 
 	servicePlan := client.Plan(plan.Plan.ValueString())
 
+	// Maintenance mode can only be configured for non-free tier services. Sending it on
+	// a free-tier service (even the disabled default) makes the API reject the update, so
+	// omit it entirely on the free plan.
+	var maintenanceMode *client.MaintenanceMode
+	if servicePlan != client.PlanFree {
+		maintenanceMode = common.ToClientMaintenanceMode(plan.MaintenanceMode)
+	}
+
 	pullRequestPreviewsEnabled := client.PullRequestPreviewsEnabledNo
 	if plan.PullRequestPreviewsEnabled.ValueBool() {
 		pullRequestPreviewsEnabled = client.PullRequestPreviewsEnabledYes
@@ -50,7 +58,7 @@ func UpdateServiceRequestFromModel(ctx context.Context, plan webservice.WebServi
 		PreDeployCommand:           &preDeployCommand,
 		Previews:                   common.PreviewsObjectToPreviews(ctx, plan.Previews),
 		PullRequestPreviewsEnabled: &pullRequestPreviewsEnabled,
-		MaintenanceMode:            common.ToClientMaintenanceMode(plan.MaintenanceMode),
+		MaintenanceMode:            maintenanceMode,
 		MaxShutdownDelaySeconds:    common.ValueAsIntPointer(plan.MaxShutdownDelaySeconds),
 		Runtime:                    common.From(client.ServiceRuntime(plan.RuntimeSource.Runtime())),
 		IpAllowList:                ipAllowList,

--- a/internal/provider/webservice/resource/internal/update_test.go
+++ b/internal/provider/webservice/resource/internal/update_test.go
@@ -1,0 +1,59 @@
+package internal
+
+import (
+	"context"
+	"testing"
+
+	"terraform-provider-render/internal/client"
+	"terraform-provider-render/internal/provider/common"
+	commontypes "terraform-provider-render/internal/provider/common/types"
+	"terraform-provider-render/internal/provider/webservice"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func webServiceModelForPlan(servicePlan string) webservice.WebServiceModel {
+	return webservice.WebServiceModel{
+		Name:            types.StringValue("test-web-service"),
+		Plan:            types.StringValue(servicePlan),
+		MaintenanceMode: common.DefaultMaintenanceMode(),
+		RuntimeSource: &common.RuntimeSourceModel{
+			Image: &common.ImageRuntimeSourceModel{
+				ImageURL: commontypes.ImageURLStringValue{StringValue: types.StringValue("nginx:latest")},
+			},
+		},
+		PullRequestPreviewsEnabled: types.BoolValue(false),
+		PreDeployCommand:           types.StringNull(),
+	}
+}
+
+// Issue #80: maintenance mode can only be configured for non-free tier services, so it
+// must be omitted from the update payload on the free plan or the API rejects the request.
+func TestUpdateServiceRequestFromModel_OmitsMaintenanceModeOnFreePlan(t *testing.T) {
+	ctx := context.Background()
+
+	plan := webServiceModelForPlan(string(client.PlanFree))
+	req, err := UpdateServiceRequestFromModel(ctx, plan, webservice.WebServiceModel{}, "owner-123")
+	require.NoError(t, err)
+
+	details, err := req.ServiceDetails.AsWebServiceDetailsPATCH()
+	require.NoError(t, err)
+
+	assert.Nil(t, details.MaintenanceMode, "maintenance_mode must be omitted for free-tier services")
+}
+
+func TestUpdateServiceRequestFromModel_IncludesMaintenanceModeOnPaidPlan(t *testing.T) {
+	ctx := context.Background()
+
+	plan := webServiceModelForPlan(string(client.PlanStarter))
+	req, err := UpdateServiceRequestFromModel(ctx, plan, webservice.WebServiceModel{}, "owner-123")
+	require.NoError(t, err)
+
+	details, err := req.ServiceDetails.AsWebServiceDetailsPATCH()
+	require.NoError(t, err)
+
+	require.NotNil(t, details.MaintenanceMode, "maintenance_mode must be sent for paid-tier services")
+	assert.False(t, details.MaintenanceMode.Enabled)
+}

--- a/internal/provider/webservice/resource/resource.go
+++ b/internal/provider/webservice/resource/resource.go
@@ -290,5 +290,6 @@ func (r *webServiceResource) ConfigValidators(ctx context.Context) []resource.Co
 		resourcecommon.RuntimeSourceValidator,
 		resourcecommon.ImageTagOrDigestValidator,
 		resourcecommon.PreviewGenerationValidator,
+		maintenanceModeFreeTierValidator{},
 	}
 }

--- a/internal/provider/webservice/resource/resource_test.go
+++ b/internal/provider/webservice/resource/resource_test.go
@@ -2,6 +2,7 @@ package resource_test
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -331,6 +332,82 @@ func TestEnvVarsResource(t *testing.T) {
 					resource.TestCheckNoResourceAttr(resourceName, "env_vars"),
 					resource.TestCheckNoResourceAttr(resourceName, "secret_files"),
 				),
+			},
+		},
+	})
+}
+
+// TestFreeTierMaintenanceMode is a regression test for issue #80. The Render API omits
+// maintenance_mode for free-tier services, which previously left the attribute null in
+// state and conflicted with its schema default, producing a perpetual diff. The cassette
+// models a free-tier service (plan "free", no maintenanceMode in any response), so each
+// step's implicit post-apply plan check asserts an empty plan and only passes because the
+// read path now falls back to the default instead of null.
+//
+// Note: go-vcr matches on method+URL only, so this test does not inspect the request
+// bodies and therefore does not by itself prove the create/update payloads omit
+// maintenance_mode on the free plan. That wire-level omission is covered by the unit tests
+// in create_test.go / update_test.go.
+func TestFreeTierMaintenanceMode(t *testing.T) {
+	resourceName := "render_web_service.service"
+
+	maintenanceModeDisabled := resource.ComposeAggregateTestCheckFunc(
+		resource.TestCheckResourceAttr(resourceName, "plan", "free"),
+		resource.TestCheckResourceAttr(resourceName, "maintenance_mode.enabled", "false"),
+		resource.TestCheckResourceAttr(resourceName, "maintenance_mode.uri", ""),
+	)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: th.SetupRecordingProvider(t, "maintenance_mode_free_cassette"),
+		Steps: []resource.TestStep{
+			// Create a free-tier service with no env vars.
+			{
+				ResourceName: resourceName,
+				ConfigFile:   config.StaticFile("./testdata/maintenance_mode_free.tf"),
+				ConfigVariables: config.Variables{
+					"env_var_count": config.IntegerVariable(0),
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						checks.ExpectNoReplace(),
+					},
+				},
+				Check: maintenanceModeDisabled,
+			},
+			// Update the free-tier service (add an env var). Previously this failed because
+			// the provider always included maintenance_mode in the PATCH payload.
+			{
+				ResourceName: resourceName,
+				ConfigFile:   config.StaticFile("./testdata/maintenance_mode_free.tf"),
+				ConfigVariables: config.Variables{
+					"env_var_count": config.IntegerVariable(1),
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						checks.ExpectNoReplace(),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					maintenanceModeDisabled,
+					resource.TestCheckResourceAttr(resourceName, "env_vars.foo.value", "bar"),
+				),
+			},
+		},
+	})
+}
+
+// TestFreeTierMaintenanceModeRejectsEnabled covers the other half of issue #80: enabling
+// maintenance mode on a free-tier service is rejected at plan time with a clear message,
+// rather than being silently dropped and failing at apply. Validation runs before any API
+// call, so no cassette interactions are consumed.
+func TestFreeTierMaintenanceModeRejectsEnabled(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: th.SetupRecordingProvider(t, "maintenance_mode_free_cassette"),
+		Steps: []resource.TestStep{
+			{
+				ConfigFile:  config.StaticFile("./testdata/maintenance_mode_free_enabled.tf"),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile("maintenance mode can only be configured for non-free tier services"),
 			},
 		},
 	})

--- a/internal/provider/webservice/resource/testdata/maintenance_mode_free.tf
+++ b/internal/provider/webservice/resource/testdata/maintenance_mode_free.tf
@@ -1,0 +1,38 @@
+variable "env_var_count" {
+  type = number
+}
+
+# Issue #80: a free-tier web service. The Render API omits maintenance_mode for free
+# services, so the provider must not perpetually diff on it nor send it on updates.
+# The service name is kept identical to env_var.tf so the recorded by-name lookups match.
+resource "render_web_service" "service" {
+  name    = "web-service-env-var-tf"
+  plan    = "free"
+  region  = "oregon"
+
+  runtime_source = {
+    image = {
+      image_url = "nginx"
+    }
+  }
+
+  env_vars = (var.env_var_count == 0 ? null :
+  (var.env_var_count == 1 ? {
+    foo = {value = "bar"}
+  } : {
+    foo = {value = "bar"}
+    baz = {value = "qux"}
+  }))
+
+  secret_files = (var.env_var_count == 0 ? null :
+  (var.env_var_count == 1 ? {
+    file1 = {content = "bar"}
+  } : {
+    file1 = {content = "bar"}
+    file2 = {content = "qux"}
+  }))
+}
+
+data "render_web_service" "service" {
+  id = render_web_service.service.id
+}

--- a/internal/provider/webservice/resource/testdata/maintenance_mode_free_cassette.yaml
+++ b/internal/provider/webservice/resource/testdata/maintenance_mode_free_cassette.yaml
@@ -1,0 +1,9660 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 408
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: '{"envVars":null,"image":{"imagePath":"nginx","ownerId":""},"name":"web-service-env-var-tf","ownerId":"some-owner-id","rootDir":"","secretFiles":null,"serviceDetails":{"envSpecificDetails":{},"healthCheckPath":"","numInstances":1,"plan":"free","previews":{},"pullRequestPreviewsEnabled":"no","region":"oregon","runtime":"image"},"type":"web_service"}'
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            Content-Type:
+                - application/json
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1044
+        uncompressed: false
+        body: |
+            {"deployId":"dep-ct6vn35j0q5s700ckgb0","service":{"autoDeploy":"yes","createdAt":"2024-12-02T18:25:16.437791Z","dashboardUrl":"http://dashboard.render.localhost:3000/web/srv-ct6vn35j0q5s700ckga0","id":"srv-ct6vn35j0q5s700ckga0","imagePath":"docker.io/library/nginx:latest","name":"web-service-env-var-tf","notifyOnFail":"default","ownerId":"some-owner-id","rootDir":"","serviceDetails":{"buildPlan":"free","env":"image","envSpecificDetails":{"dockerCommand":"","dockerContext":"","dockerfilePath":""},"healthCheckPath":"","numInstances":1,"openPorts":[{"port":10000,"protocol":"TCP"}],"plan":"free","previews":{"generation":"off"},"pullRequestPreviewsEnabled":"no","region":"oregon","runtime":"image","sshAddress":"srv-email@example.com","url":"https://web-service-env-var-tf.localhost.onrender.com:9443"},"slug":"web-service-env-var-tf","suspended":"not_suspended","suspenders":[],"type":"web_service","updatedAt":"2024-12-02T18:25:16.986341Z"}}
+        headers:
+            Content-Length:
+                - "1044"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:17 GMT
+            Ratelimit-Limit:
+                - "20"
+            Ratelimit-Remaining:
+                - "9"
+            Ratelimit-Reset:
+                - "2084"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000758
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 201 Created
+        code: 201
+        duration: 1.640346416s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 2
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: '{}'
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            Content-Type:
+                - application/json
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/notification-settings/overrides/services/srv-ct6vn35j0q5s700ckga0
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 113
+        uncompressed: false
+        body: |
+            {"notificationsToSend":"default","previewNotificationsEnabled":"default","serviceId":"srv-ct6vn35j0q5s700ckga0"}
+        headers:
+            Content-Length:
+                - "113"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:17 GMT
+            Ratelimit-Limit:
+                - "100"
+            Ratelimit-Remaining:
+                - "90"
+            Ratelimit-Reset:
+                - "42"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000759
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 102.136708ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/env-vars
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:17 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "356"
+            Ratelimit-Reset:
+                - "42"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000760
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 93.56925ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/secret-files
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:17 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "355"
+            Ratelimit-Reset:
+                - "42"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000761
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 97.107333ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/custom-domains?limit=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:17 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "354"
+            Ratelimit-Reset:
+                - "42"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000762
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 94.84725ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/notification-settings/overrides/services/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 113
+        uncompressed: false
+        body: |
+            {"notificationsToSend":"default","previewNotificationsEnabled":"default","serviceId":"srv-ct6vn35j0q5s700ckga0"}
+        headers:
+            Content-Length:
+                - "113"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:17 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "353"
+            Ratelimit-Reset:
+                - "42"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000763
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 99.27875ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: srv-ct6vn35j0q5s700ckga0"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:18 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "352"
+            Ratelimit-Reset:
+                - "41"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000764
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 139.311584ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services?name=web-service-env-var-tf&ownerId=some-owner-id&type=web_service
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1052
+        uncompressed: false
+        body: |
+            [{"cursor":"LLUBv6QtETNuMzVqMHE1czcwMGNrZ2Ew","service":{"autoDeploy":"yes","createdAt":"2024-12-02T18:25:16.437791Z","dashboardUrl":"http://dashboard.render.localhost:3000/web/srv-ct6vn35j0q5s700ckga0","id":"srv-ct6vn35j0q5s700ckga0","imagePath":"docker.io/library/nginx:latest","name":"web-service-env-var-tf","notifyOnFail":"default","ownerId":"some-owner-id","rootDir":"","serviceDetails":{"buildPlan":"free","env":"image","envSpecificDetails":{"dockerCommand":"","dockerContext":"","dockerfilePath":""},"healthCheckPath":"","numInstances":1,"openPorts":[{"port":10000,"protocol":"TCP"}],"plan":"free","previews":{"generation":"off"},"pullRequestPreviewsEnabled":"no","region":"oregon","runtime":"image","sshAddress":"srv-email@example.com","url":"https://web-service-env-var-tf.localhost.onrender.com:9443"},"slug":"web-service-env-var-tf","suspended":"not_suspended","suspenders":[],"type":"web_service","updatedAt":"2024-12-02T18:25:16.986341Z"}}]
+        headers:
+            Content-Length:
+                - "1052"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:18 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "351"
+            Ratelimit-Reset:
+                - "41"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000765
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 154.850375ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/env-vars
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:18 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "350"
+            Ratelimit-Reset:
+                - "41"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000766
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 89.785958ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/secret-files
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:18 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "349"
+            Ratelimit-Reset:
+                - "41"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000767
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 94.876292ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/custom-domains?limit=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:18 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "348"
+            Ratelimit-Reset:
+                - "41"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000768
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 92.691875ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/notification-settings/overrides/services/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 113
+        uncompressed: false
+        body: |
+            {"notificationsToSend":"default","previewNotificationsEnabled":"default","serviceId":"srv-ct6vn35j0q5s700ckga0"}
+        headers:
+            Content-Length:
+                - "113"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:18 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "347"
+            Ratelimit-Reset:
+                - "41"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000769
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 96.919959ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: srv-ct6vn35j0q5s700ckga0"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:19 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "346"
+            Ratelimit-Reset:
+                - "40"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000770
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 136.2055ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 994
+        uncompressed: false
+        body: |
+            {"autoDeploy":"yes","createdAt":"2024-12-02T18:25:16.437791Z","dashboardUrl":"http://dashboard.render.localhost:3000/web/srv-ct6vn35j0q5s700ckga0","id":"srv-ct6vn35j0q5s700ckga0","imagePath":"docker.io/library/nginx:latest","name":"web-service-env-var-tf","notifyOnFail":"default","ownerId":"some-owner-id","rootDir":"","serviceDetails":{"buildPlan":"free","env":"image","envSpecificDetails":{"dockerCommand":"","dockerContext":"","dockerfilePath":""},"healthCheckPath":"","numInstances":1,"openPorts":[{"port":10000,"protocol":"TCP"}],"plan":"free","previews":{"generation":"off"},"pullRequestPreviewsEnabled":"no","region":"oregon","runtime":"image","sshAddress":"srv-email@example.com","url":"https://web-service-env-var-tf.localhost.onrender.com:9443"},"slug":"web-service-env-var-tf","suspended":"not_suspended","suspenders":[],"type":"web_service","updatedAt":"2024-12-02T18:25:16.986341Z"}
+        headers:
+            Content-Length:
+                - "994"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:19 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "345"
+            Ratelimit-Reset:
+                - "40"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000771
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 110.302875ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/env-vars
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:19 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "344"
+            Ratelimit-Reset:
+                - "40"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000772
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 94.603834ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/secret-files
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:19 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "343"
+            Ratelimit-Reset:
+                - "40"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000773
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 99.185375ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/custom-domains?limit=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:19 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "342"
+            Ratelimit-Reset:
+                - "40"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000774
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 92.503041ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/notification-settings/overrides/services/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 113
+        uncompressed: false
+        body: |
+            {"notificationsToSend":"default","previewNotificationsEnabled":"default","serviceId":"srv-ct6vn35j0q5s700ckga0"}
+        headers:
+            Content-Length:
+                - "113"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:19 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "341"
+            Ratelimit-Reset:
+                - "40"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000775
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 94.68075ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: srv-ct6vn35j0q5s700ckga0"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:20 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "340"
+            Ratelimit-Reset:
+                - "39"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000776
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 131.258542ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 994
+        uncompressed: false
+        body: |
+            {"autoDeploy":"yes","createdAt":"2024-12-02T18:25:16.437791Z","dashboardUrl":"http://dashboard.render.localhost:3000/web/srv-ct6vn35j0q5s700ckga0","id":"srv-ct6vn35j0q5s700ckga0","imagePath":"docker.io/library/nginx:latest","name":"web-service-env-var-tf","notifyOnFail":"default","ownerId":"some-owner-id","rootDir":"","serviceDetails":{"buildPlan":"free","env":"image","envSpecificDetails":{"dockerCommand":"","dockerContext":"","dockerfilePath":""},"healthCheckPath":"","numInstances":1,"openPorts":[{"port":10000,"protocol":"TCP"}],"plan":"free","previews":{"generation":"off"},"pullRequestPreviewsEnabled":"no","region":"oregon","runtime":"image","sshAddress":"srv-email@example.com","url":"https://web-service-env-var-tf.localhost.onrender.com:9443"},"slug":"web-service-env-var-tf","suspended":"not_suspended","suspenders":[],"type":"web_service","updatedAt":"2024-12-02T18:25:16.986341Z"}
+        headers:
+            Content-Length:
+                - "994"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:20 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "339"
+            Ratelimit-Reset:
+                - "39"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000777
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 101.588333ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/env-vars
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:20 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "338"
+            Ratelimit-Reset:
+                - "39"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000778
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 102.391458ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/secret-files
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:20 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "337"
+            Ratelimit-Reset:
+                - "39"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000779
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 106.626292ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/custom-domains?limit=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:20 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "336"
+            Ratelimit-Reset:
+                - "39"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000780
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 92.858459ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/notification-settings/overrides/services/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 113
+        uncompressed: false
+        body: |
+            {"notificationsToSend":"default","previewNotificationsEnabled":"default","serviceId":"srv-ct6vn35j0q5s700ckga0"}
+        headers:
+            Content-Length:
+                - "113"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:21 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "335"
+            Ratelimit-Reset:
+                - "38"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000781
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 91.149292ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: srv-ct6vn35j0q5s700ckga0"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:21 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "334"
+            Ratelimit-Reset:
+                - "38"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000782
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 131.922208ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 994
+        uncompressed: false
+        body: |
+            {"autoDeploy":"yes","createdAt":"2024-12-02T18:25:16.437791Z","dashboardUrl":"http://dashboard.render.localhost:3000/web/srv-ct6vn35j0q5s700ckga0","id":"srv-ct6vn35j0q5s700ckga0","imagePath":"docker.io/library/nginx:latest","name":"web-service-env-var-tf","notifyOnFail":"default","ownerId":"some-owner-id","rootDir":"","serviceDetails":{"buildPlan":"free","env":"image","envSpecificDetails":{"dockerCommand":"","dockerContext":"","dockerfilePath":""},"healthCheckPath":"","numInstances":1,"openPorts":[{"port":10000,"protocol":"TCP"}],"plan":"free","previews":{"generation":"off"},"pullRequestPreviewsEnabled":"no","region":"oregon","runtime":"image","sshAddress":"srv-email@example.com","url":"https://web-service-env-var-tf.localhost.onrender.com:9443"},"slug":"web-service-env-var-tf","suspended":"not_suspended","suspenders":[],"type":"web_service","updatedAt":"2024-12-02T18:25:16.986341Z"}
+        headers:
+            Content-Length:
+                - "994"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:21 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "333"
+            Ratelimit-Reset:
+                - "38"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000783
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 100.764541ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/env-vars
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:21 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "332"
+            Ratelimit-Reset:
+                - "38"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000784
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 114.45475ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/secret-files
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:21 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "331"
+            Ratelimit-Reset:
+                - "38"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000785
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 95.068083ms
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/custom-domains?limit=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:21 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "330"
+            Ratelimit-Reset:
+                - "38"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000786
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 92.265166ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/notification-settings/overrides/services/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 113
+        uncompressed: false
+        body: |
+            {"notificationsToSend":"default","previewNotificationsEnabled":"default","serviceId":"srv-ct6vn35j0q5s700ckga0"}
+        headers:
+            Content-Length:
+                - "113"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:22 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "329"
+            Ratelimit-Reset:
+                - "37"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000787
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 95.740709ms
+    - id: 30
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: srv-ct6vn35j0q5s700ckga0"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:22 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "328"
+            Ratelimit-Reset:
+                - "37"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000788
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 133.360833ms
+    - id: 31
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 994
+        uncompressed: false
+        body: |
+            {"autoDeploy":"yes","createdAt":"2024-12-02T18:25:16.437791Z","dashboardUrl":"http://dashboard.render.localhost:3000/web/srv-ct6vn35j0q5s700ckga0","id":"srv-ct6vn35j0q5s700ckga0","imagePath":"docker.io/library/nginx:latest","name":"web-service-env-var-tf","notifyOnFail":"default","ownerId":"some-owner-id","rootDir":"","serviceDetails":{"buildPlan":"free","env":"image","envSpecificDetails":{"dockerCommand":"","dockerContext":"","dockerfilePath":""},"healthCheckPath":"","numInstances":1,"openPorts":[{"port":10000,"protocol":"TCP"}],"plan":"free","previews":{"generation":"off"},"pullRequestPreviewsEnabled":"no","region":"oregon","runtime":"image","sshAddress":"srv-email@example.com","url":"https://web-service-env-var-tf.localhost.onrender.com:9443"},"slug":"web-service-env-var-tf","suspended":"not_suspended","suspenders":[],"type":"web_service","updatedAt":"2024-12-02T18:25:16.986341Z"}
+        headers:
+            Content-Length:
+                - "994"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:22 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "327"
+            Ratelimit-Reset:
+                - "37"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000789
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 98.136542ms
+    - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/env-vars
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:22 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "326"
+            Ratelimit-Reset:
+                - "37"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000790
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 99.989666ms
+    - id: 33
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/secret-files
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:22 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "325"
+            Ratelimit-Reset:
+                - "37"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000791
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 99.194459ms
+    - id: 34
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/custom-domains?limit=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:22 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "324"
+            Ratelimit-Reset:
+                - "37"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000792
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 93.55075ms
+    - id: 35
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/notification-settings/overrides/services/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 113
+        uncompressed: false
+        body: |
+            {"notificationsToSend":"default","previewNotificationsEnabled":"default","serviceId":"srv-ct6vn35j0q5s700ckga0"}
+        headers:
+            Content-Length:
+                - "113"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:23 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "323"
+            Ratelimit-Reset:
+                - "36"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000793
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 100.65075ms
+    - id: 36
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: srv-ct6vn35j0q5s700ckga0"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:23 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "322"
+            Ratelimit-Reset:
+                - "36"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000794
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 133.477167ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 994
+        uncompressed: false
+        body: |
+            {"autoDeploy":"yes","createdAt":"2024-12-02T18:25:16.437791Z","dashboardUrl":"http://dashboard.render.localhost:3000/web/srv-ct6vn35j0q5s700ckga0","id":"srv-ct6vn35j0q5s700ckga0","imagePath":"docker.io/library/nginx:latest","name":"web-service-env-var-tf","notifyOnFail":"default","ownerId":"some-owner-id","rootDir":"","serviceDetails":{"buildPlan":"free","env":"image","envSpecificDetails":{"dockerCommand":"","dockerContext":"","dockerfilePath":""},"healthCheckPath":"","numInstances":1,"openPorts":[{"port":10000,"protocol":"TCP"}],"plan":"free","previews":{"generation":"off"},"pullRequestPreviewsEnabled":"no","region":"oregon","runtime":"image","sshAddress":"srv-email@example.com","url":"https://web-service-env-var-tf.localhost.onrender.com:9443"},"slug":"web-service-env-var-tf","suspended":"not_suspended","suspenders":[],"type":"web_service","updatedAt":"2024-12-02T18:25:16.986341Z"}
+        headers:
+            Content-Length:
+                - "994"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:23 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "321"
+            Ratelimit-Reset:
+                - "36"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000795
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 108.863125ms
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/env-vars
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:23 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "320"
+            Ratelimit-Reset:
+                - "36"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000796
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 92.796166ms
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/secret-files
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:23 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "319"
+            Ratelimit-Reset:
+                - "36"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000797
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 93.792583ms
+    - id: 40
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/custom-domains?limit=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:24 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "318"
+            Ratelimit-Reset:
+                - "36"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000798
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 90.964875ms
+    - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/notification-settings/overrides/services/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 113
+        uncompressed: false
+        body: |
+            {"notificationsToSend":"default","previewNotificationsEnabled":"default","serviceId":"srv-ct6vn35j0q5s700ckga0"}
+        headers:
+            Content-Length:
+                - "113"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:24 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "317"
+            Ratelimit-Reset:
+                - "35"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000799
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 95.759375ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: srv-ct6vn35j0q5s700ckga0"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:24 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "316"
+            Ratelimit-Reset:
+                - "35"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000800
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 136.07375ms
+    - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 345
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: '{"image":{"imagePath":"nginx","ownerId":"some-owner-id"},"name":"web-service-env-var-tf","rootDir":"","serviceDetails":{"envSpecificDetails":{"dockerCommand":""},"healthCheckPath":"","plan":"free","preDeployCommand":"","previews":{},"pullRequestPreviewsEnabled":"no","runtime":"image"}}'
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            Content-Type:
+                - application/json
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 994
+        uncompressed: false
+        body: |
+            {"autoDeploy":"yes","createdAt":"2024-12-02T18:25:16.437791Z","dashboardUrl":"http://dashboard.render.localhost:3000/web/srv-ct6vn35j0q5s700ckga0","id":"srv-ct6vn35j0q5s700ckga0","imagePath":"docker.io/library/nginx:latest","name":"web-service-env-var-tf","notifyOnFail":"default","ownerId":"some-owner-id","rootDir":"","serviceDetails":{"buildPlan":"free","env":"image","envSpecificDetails":{"dockerCommand":"","dockerContext":"","dockerfilePath":""},"healthCheckPath":"","numInstances":1,"openPorts":[{"port":10000,"protocol":"TCP"}],"plan":"free","previews":{"generation":"off"},"pullRequestPreviewsEnabled":"no","region":"oregon","runtime":"image","sshAddress":"srv-email@example.com","url":"https://web-service-env-var-tf.localhost.onrender.com:9443"},"slug":"web-service-env-var-tf","suspended":"not_suspended","suspenders":[],"type":"web_service","updatedAt":"2024-12-02T18:25:16.986341Z"}
+        headers:
+            Content-Length:
+                - "994"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:25 GMT
+            Ratelimit-Limit:
+                - "10"
+            Ratelimit-Remaining:
+                - "9"
+            Ratelimit-Reset:
+                - "35"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000801
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 1.189497459s
+    - id: 44
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 29
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: '[{"key":"foo","value":"bar"}]'
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            Content-Type:
+                - application/json
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/env-vars
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 85
+        uncompressed: false
+        body: |
+            [{"envVar":{"key":"foo","value":"bar"},"cursor":"DLRR7F1e8FhuNWRqMHE1czcwMGNrZ2Rn"}]
+        headers:
+            Content-Length:
+                - "85"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:25 GMT
+            Ratelimit-Limit:
+                - "100"
+            Ratelimit-Remaining:
+                - "89"
+            Ratelimit-Reset:
+                - "34"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000802
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 158.404333ms
+    - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 34
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: '[{"content":"bar","name":"file1"}]'
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            Content-Type:
+                - application/json
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/secret-files
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 94
+        uncompressed: false
+        body: |
+            [{"secretFile":{"content":"bar","name":"file1"},"cursor":"DLRR7F1e8FhuNWxqMHE1czcwMGNrZ2Uw"}]
+        headers:
+            Content-Length:
+                - "94"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:26 GMT
+            Ratelimit-Limit:
+                - "100"
+            Ratelimit-Remaining:
+                - "88"
+            Ratelimit-Reset:
+                - "34"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000803
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 107.981375ms
+    - id: 46
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 2
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: '{}'
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            Content-Type:
+                - application/json
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/notification-settings/overrides/services/srv-ct6vn35j0q5s700ckga0
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 113
+        uncompressed: false
+        body: |
+            {"notificationsToSend":"default","previewNotificationsEnabled":"default","serviceId":"srv-ct6vn35j0q5s700ckga0"}
+        headers:
+            Content-Length:
+                - "113"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:26 GMT
+            Ratelimit-Limit:
+                - "100"
+            Ratelimit-Remaining:
+                - "87"
+            Ratelimit-Reset:
+                - "33"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000804
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 96.60125ms
+    - id: 47
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/custom-domains?limit=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:26 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "315"
+            Ratelimit-Reset:
+                - "33"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000805
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 98.143583ms
+    - id: 48
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 2
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: '{}'
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            Content-Type:
+                - application/json
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/deploys
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 325
+        uncompressed: false
+        body: |
+            {"id":"dep-ct6vn5lj0q5s700ckgf0","commit":null,"image":{"ref":"docker.io/library/nginx:latest","sha":"sha256:8987949924fc00ae83e3609611990c17cceedc876c5bb9c9f60ca917170ebde1"},"status":"update_in_progress","trigger":"api","createdAt":"2024-12-02T18:25:26.846684Z","updatedAt":"2024-12-02T18:25:27.132171Z","finishedAt":null}
+        headers:
+            Content-Length:
+                - "325"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:27 GMT
+            Ratelimit-Limit:
+                - "10"
+            Ratelimit-Remaining:
+                - "8"
+            Ratelimit-Reset:
+                - "33"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000806
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 201 Created
+        code: 201
+        duration: 764.176416ms
+    - id: 49
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 994
+        uncompressed: false
+        body: |
+            {"autoDeploy":"yes","createdAt":"2024-12-02T18:25:16.437791Z","dashboardUrl":"http://dashboard.render.localhost:3000/web/srv-ct6vn35j0q5s700ckga0","id":"srv-ct6vn35j0q5s700ckga0","imagePath":"docker.io/library/nginx:latest","name":"web-service-env-var-tf","notifyOnFail":"default","ownerId":"some-owner-id","rootDir":"","serviceDetails":{"buildPlan":"free","env":"image","envSpecificDetails":{"dockerCommand":"","dockerContext":"","dockerfilePath":""},"healthCheckPath":"","numInstances":1,"openPorts":[{"port":10000,"protocol":"TCP"}],"plan":"free","previews":{"generation":"off"},"pullRequestPreviewsEnabled":"no","region":"oregon","runtime":"image","sshAddress":"srv-email@example.com","url":"https://web-service-env-var-tf.localhost.onrender.com:9443"},"slug":"web-service-env-var-tf","suspended":"not_suspended","suspenders":[],"type":"web_service","updatedAt":"2024-12-02T18:25:26.995207Z"}
+        headers:
+            Content-Length:
+                - "994"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:27 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "314"
+            Ratelimit-Reset:
+                - "32"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000807
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 103.621084ms
+    - id: 50
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/env-vars
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 85
+        uncompressed: false
+        body: |
+            [{"envVar":{"key":"foo","value":"bar"},"cursor":"DLRR7F1e8FhuNWRqMHE1czcwMGNrZ2Rn"}]
+        headers:
+            Content-Length:
+                - "85"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:27 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "313"
+            Ratelimit-Reset:
+                - "32"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000808
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 83.684125ms
+    - id: 51
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/env-vars?cursor=DLRR7F1e8FhuNWRqMHE1czcwMGNrZ2Rn
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:27 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "312"
+            Ratelimit-Reset:
+                - "32"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000809
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 87.457083ms
+    - id: 52
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/secret-files
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 94
+        uncompressed: false
+        body: |
+            [{"secretFile":{"content":"bar","name":"file1"},"cursor":"DLRR7F1e8FhuNWxqMHE1czcwMGNrZ2Uw"}]
+        headers:
+            Content-Length:
+                - "94"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:27 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "311"
+            Ratelimit-Reset:
+                - "32"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000810
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 81.608833ms
+    - id: 53
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/secret-files?cursor=DLRR7F1e8FhuNWxqMHE1czcwMGNrZ2Uw
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:27 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "310"
+            Ratelimit-Reset:
+                - "32"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000811
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 85.384333ms
+    - id: 54
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/custom-domains?limit=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:28 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "309"
+            Ratelimit-Reset:
+                - "31"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000812
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 87.34475ms
+    - id: 55
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/notification-settings/overrides/services/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 113
+        uncompressed: false
+        body: |
+            {"notificationsToSend":"default","previewNotificationsEnabled":"default","serviceId":"srv-ct6vn35j0q5s700ckga0"}
+        headers:
+            Content-Length:
+                - "113"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:28 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "308"
+            Ratelimit-Reset:
+                - "31"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000813
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 83.910583ms
+    - id: 56
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: srv-ct6vn35j0q5s700ckga0"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:28 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "307"
+            Ratelimit-Reset:
+                - "31"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000814
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 129.413708ms
+    - id: 57
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 994
+        uncompressed: false
+        body: |
+            {"autoDeploy":"yes","createdAt":"2024-12-02T18:25:16.437791Z","dashboardUrl":"http://dashboard.render.localhost:3000/web/srv-ct6vn35j0q5s700ckga0","id":"srv-ct6vn35j0q5s700ckga0","imagePath":"docker.io/library/nginx:latest","name":"web-service-env-var-tf","notifyOnFail":"default","ownerId":"some-owner-id","rootDir":"","serviceDetails":{"buildPlan":"free","env":"image","envSpecificDetails":{"dockerCommand":"","dockerContext":"","dockerfilePath":""},"healthCheckPath":"","numInstances":1,"openPorts":[{"port":10000,"protocol":"TCP"}],"plan":"free","previews":{"generation":"off"},"pullRequestPreviewsEnabled":"no","region":"oregon","runtime":"image","sshAddress":"srv-email@example.com","url":"https://web-service-env-var-tf.localhost.onrender.com:9443"},"slug":"web-service-env-var-tf","suspended":"not_suspended","suspenders":[],"type":"web_service","updatedAt":"2024-12-02T18:25:26.995207Z"}
+        headers:
+            Content-Length:
+                - "994"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:28 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "306"
+            Ratelimit-Reset:
+                - "31"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000815
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 99.057584ms
+    - id: 58
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/env-vars
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 85
+        uncompressed: false
+        body: |
+            [{"envVar":{"key":"foo","value":"bar"},"cursor":"DLRR7F1e8FhuNWRqMHE1czcwMGNrZ2Rn"}]
+        headers:
+            Content-Length:
+                - "85"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:28 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "305"
+            Ratelimit-Reset:
+                - "31"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000816
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 76.581875ms
+    - id: 59
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/env-vars?cursor=DLRR7F1e8FhuNWRqMHE1czcwMGNrZ2Rn
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:29 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "304"
+            Ratelimit-Reset:
+                - "30"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000817
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 81.795833ms
+    - id: 60
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/secret-files
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 94
+        uncompressed: false
+        body: |
+            [{"secretFile":{"content":"bar","name":"file1"},"cursor":"DLRR7F1e8FhuNWxqMHE1czcwMGNrZ2Uw"}]
+        headers:
+            Content-Length:
+                - "94"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:29 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "303"
+            Ratelimit-Reset:
+                - "30"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000818
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 86.121042ms
+    - id: 61
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/secret-files?cursor=DLRR7F1e8FhuNWxqMHE1czcwMGNrZ2Uw
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:29 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "302"
+            Ratelimit-Reset:
+                - "30"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000819
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 90.896833ms
+    - id: 62
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/custom-domains?limit=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:29 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "301"
+            Ratelimit-Reset:
+                - "30"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000820
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 82.412125ms
+    - id: 63
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/notification-settings/overrides/services/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 113
+        uncompressed: false
+        body: |
+            {"notificationsToSend":"default","previewNotificationsEnabled":"default","serviceId":"srv-ct6vn35j0q5s700ckga0"}
+        headers:
+            Content-Length:
+                - "113"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:29 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "300"
+            Ratelimit-Reset:
+                - "30"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000821
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 85.084792ms
+    - id: 64
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: srv-ct6vn35j0q5s700ckga0"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:29 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "299"
+            Ratelimit-Reset:
+                - "30"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000822
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 118.828541ms
+    - id: 65
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 994
+        uncompressed: false
+        body: |
+            {"autoDeploy":"yes","createdAt":"2024-12-02T18:25:16.437791Z","dashboardUrl":"http://dashboard.render.localhost:3000/web/srv-ct6vn35j0q5s700ckga0","id":"srv-ct6vn35j0q5s700ckga0","imagePath":"docker.io/library/nginx:latest","name":"web-service-env-var-tf","notifyOnFail":"default","ownerId":"some-owner-id","rootDir":"","serviceDetails":{"buildPlan":"free","env":"image","envSpecificDetails":{"dockerCommand":"","dockerContext":"","dockerfilePath":""},"healthCheckPath":"","numInstances":1,"openPorts":[{"port":10000,"protocol":"TCP"}],"plan":"free","previews":{"generation":"off"},"pullRequestPreviewsEnabled":"no","region":"oregon","runtime":"image","sshAddress":"srv-email@example.com","url":"https://web-service-env-var-tf.localhost.onrender.com:9443"},"slug":"web-service-env-var-tf","suspended":"not_suspended","suspenders":[],"type":"web_service","updatedAt":"2024-12-02T18:25:26.995207Z"}
+        headers:
+            Content-Length:
+                - "994"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:30 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "298"
+            Ratelimit-Reset:
+                - "29"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000823
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 93.687125ms
+    - id: 66
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/env-vars
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 85
+        uncompressed: false
+        body: |
+            [{"envVar":{"key":"foo","value":"bar"},"cursor":"DLRR7F1e8FhuNWRqMHE1czcwMGNrZ2Rn"}]
+        headers:
+            Content-Length:
+                - "85"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:30 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "297"
+            Ratelimit-Reset:
+                - "29"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000824
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 81.579917ms
+    - id: 67
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/env-vars?cursor=DLRR7F1e8FhuNWRqMHE1czcwMGNrZ2Rn
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:30 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "296"
+            Ratelimit-Reset:
+                - "29"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000825
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 87.370167ms
+    - id: 68
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/secret-files
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 94
+        uncompressed: false
+        body: |
+            [{"secretFile":{"content":"bar","name":"file1"},"cursor":"DLRR7F1e8FhuNWxqMHE1czcwMGNrZ2Uw"}]
+        headers:
+            Content-Length:
+                - "94"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:30 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "295"
+            Ratelimit-Reset:
+                - "29"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000826
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 81.637584ms
+    - id: 69
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/secret-files?cursor=DLRR7F1e8FhuNWxqMHE1czcwMGNrZ2Uw
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:30 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "294"
+            Ratelimit-Reset:
+                - "29"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000827
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 81.499292ms
+    - id: 70
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/custom-domains?limit=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:30 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "293"
+            Ratelimit-Reset:
+                - "29"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000828
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 88.637625ms
+    - id: 71
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/notification-settings/overrides/services/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 113
+        uncompressed: false
+        body: |
+            {"notificationsToSend":"default","previewNotificationsEnabled":"default","serviceId":"srv-ct6vn35j0q5s700ckga0"}
+        headers:
+            Content-Length:
+                - "113"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:31 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "292"
+            Ratelimit-Reset:
+                - "28"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000829
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 87.387708ms
+    - id: 72
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: srv-ct6vn35j0q5s700ckga0"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:31 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "291"
+            Ratelimit-Reset:
+                - "28"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000830
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 122.627542ms
+    - id: 73
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 994
+        uncompressed: false
+        body: |
+            {"autoDeploy":"yes","createdAt":"2024-12-02T18:25:16.437791Z","dashboardUrl":"http://dashboard.render.localhost:3000/web/srv-ct6vn35j0q5s700ckga0","id":"srv-ct6vn35j0q5s700ckga0","imagePath":"docker.io/library/nginx:latest","name":"web-service-env-var-tf","notifyOnFail":"default","ownerId":"some-owner-id","rootDir":"","serviceDetails":{"buildPlan":"free","env":"image","envSpecificDetails":{"dockerCommand":"","dockerContext":"","dockerfilePath":""},"healthCheckPath":"","numInstances":1,"openPorts":[{"port":10000,"protocol":"TCP"}],"plan":"free","previews":{"generation":"off"},"pullRequestPreviewsEnabled":"no","region":"oregon","runtime":"image","sshAddress":"srv-email@example.com","url":"https://web-service-env-var-tf.localhost.onrender.com:9443"},"slug":"web-service-env-var-tf","suspended":"not_suspended","suspenders":[],"type":"web_service","updatedAt":"2024-12-02T18:25:26.995207Z"}
+        headers:
+            Content-Length:
+                - "994"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:31 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "290"
+            Ratelimit-Reset:
+                - "28"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000831
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 93.429167ms
+    - id: 74
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/env-vars
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 85
+        uncompressed: false
+        body: |
+            [{"envVar":{"key":"foo","value":"bar"},"cursor":"DLRR7F1e8FhuNWRqMHE1czcwMGNrZ2Rn"}]
+        headers:
+            Content-Length:
+                - "85"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:31 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "289"
+            Ratelimit-Reset:
+                - "28"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000832
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 87.590875ms
+    - id: 75
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/env-vars?cursor=DLRR7F1e8FhuNWRqMHE1czcwMGNrZ2Rn
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:31 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "288"
+            Ratelimit-Reset:
+                - "28"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000833
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 85.263916ms
+    - id: 76
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/secret-files
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 94
+        uncompressed: false
+        body: |
+            [{"secretFile":{"content":"bar","name":"file1"},"cursor":"DLRR7F1e8FhuNWxqMHE1czcwMGNrZ2Uw"}]
+        headers:
+            Content-Length:
+                - "94"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:31 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "287"
+            Ratelimit-Reset:
+                - "28"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000834
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 90.861541ms
+    - id: 77
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/secret-files?cursor=DLRR7F1e8FhuNWxqMHE1czcwMGNrZ2Uw
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:32 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "286"
+            Ratelimit-Reset:
+                - "27"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000835
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 82.03825ms
+    - id: 78
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/custom-domains?limit=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:32 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "285"
+            Ratelimit-Reset:
+                - "27"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000836
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 84.255542ms
+    - id: 79
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/notification-settings/overrides/services/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 113
+        uncompressed: false
+        body: |
+            {"notificationsToSend":"default","previewNotificationsEnabled":"default","serviceId":"srv-ct6vn35j0q5s700ckga0"}
+        headers:
+            Content-Length:
+                - "113"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:32 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "284"
+            Ratelimit-Reset:
+                - "27"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000837
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 83.047208ms
+    - id: 80
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: srv-ct6vn35j0q5s700ckga0"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:32 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "283"
+            Ratelimit-Reset:
+                - "27"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000838
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 113.5275ms
+    - id: 81
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 994
+        uncompressed: false
+        body: |
+            {"autoDeploy":"yes","createdAt":"2024-12-02T18:25:16.437791Z","dashboardUrl":"http://dashboard.render.localhost:3000/web/srv-ct6vn35j0q5s700ckga0","id":"srv-ct6vn35j0q5s700ckga0","imagePath":"docker.io/library/nginx:latest","name":"web-service-env-var-tf","notifyOnFail":"default","ownerId":"some-owner-id","rootDir":"","serviceDetails":{"buildPlan":"free","env":"image","envSpecificDetails":{"dockerCommand":"","dockerContext":"","dockerfilePath":""},"healthCheckPath":"","numInstances":1,"openPorts":[{"port":10000,"protocol":"TCP"}],"plan":"free","previews":{"generation":"off"},"pullRequestPreviewsEnabled":"no","region":"oregon","runtime":"image","sshAddress":"srv-email@example.com","url":"https://web-service-env-var-tf.localhost.onrender.com:9443"},"slug":"web-service-env-var-tf","suspended":"not_suspended","suspenders":[],"type":"web_service","updatedAt":"2024-12-02T18:25:26.995207Z"}
+        headers:
+            Content-Length:
+                - "994"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:32 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "282"
+            Ratelimit-Reset:
+                - "27"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000839
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 91.279042ms
+    - id: 82
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/env-vars
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 85
+        uncompressed: false
+        body: |
+            [{"envVar":{"key":"foo","value":"bar"},"cursor":"DLRR7F1e8FhuNWRqMHE1czcwMGNrZ2Rn"}]
+        headers:
+            Content-Length:
+                - "85"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:33 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "281"
+            Ratelimit-Reset:
+                - "26"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000840
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 285.20075ms
+    - id: 83
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/env-vars?cursor=DLRR7F1e8FhuNWRqMHE1czcwMGNrZ2Rn
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:33 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "280"
+            Ratelimit-Reset:
+                - "26"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000841
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 91.666375ms
+    - id: 84
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/secret-files
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 94
+        uncompressed: false
+        body: |
+            [{"secretFile":{"content":"bar","name":"file1"},"cursor":"DLRR7F1e8FhuNWxqMHE1czcwMGNrZ2Uw"}]
+        headers:
+            Content-Length:
+                - "94"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:33 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "279"
+            Ratelimit-Reset:
+                - "26"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000842
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 87.840167ms
+    - id: 85
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/secret-files?cursor=DLRR7F1e8FhuNWxqMHE1czcwMGNrZ2Uw
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:33 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "278"
+            Ratelimit-Reset:
+                - "26"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000843
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 86.167875ms
+    - id: 86
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/custom-domains?limit=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:33 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "277"
+            Ratelimit-Reset:
+                - "26"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000844
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 83.466042ms
+    - id: 87
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/notification-settings/overrides/services/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 113
+        uncompressed: false
+        body: |
+            {"notificationsToSend":"default","previewNotificationsEnabled":"default","serviceId":"srv-ct6vn35j0q5s700ckga0"}
+        headers:
+            Content-Length:
+                - "113"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:33 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "276"
+            Ratelimit-Reset:
+                - "26"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000845
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 84.4655ms
+    - id: 88
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: srv-ct6vn35j0q5s700ckga0"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:34 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "275"
+            Ratelimit-Reset:
+                - "25"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000846
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 114.714416ms
+    - id: 89
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 345
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: '{"image":{"imagePath":"nginx","ownerId":"some-owner-id"},"name":"web-service-env-var-tf","rootDir":"","serviceDetails":{"envSpecificDetails":{"dockerCommand":""},"healthCheckPath":"","plan":"free","preDeployCommand":"","previews":{},"pullRequestPreviewsEnabled":"no","runtime":"image"}}'
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            Content-Type:
+                - application/json
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 994
+        uncompressed: false
+        body: |
+            {"autoDeploy":"yes","createdAt":"2024-12-02T18:25:16.437791Z","dashboardUrl":"http://dashboard.render.localhost:3000/web/srv-ct6vn35j0q5s700ckga0","id":"srv-ct6vn35j0q5s700ckga0","imagePath":"docker.io/library/nginx:latest","name":"web-service-env-var-tf","notifyOnFail":"default","ownerId":"some-owner-id","rootDir":"","serviceDetails":{"buildPlan":"free","env":"image","envSpecificDetails":{"dockerCommand":"","dockerContext":"","dockerfilePath":""},"healthCheckPath":"","numInstances":1,"openPorts":[{"port":10000,"protocol":"TCP"}],"plan":"free","previews":{"generation":"off"},"pullRequestPreviewsEnabled":"no","region":"oregon","runtime":"image","sshAddress":"srv-email@example.com","url":"https://web-service-env-var-tf.localhost.onrender.com:9443"},"slug":"web-service-env-var-tf","suspended":"not_suspended","suspenders":[],"type":"web_service","updatedAt":"2024-12-02T18:25:26.995207Z"}
+        headers:
+            Content-Length:
+                - "994"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:35 GMT
+            Ratelimit-Limit:
+                - "10"
+            Ratelimit-Remaining:
+                - "7"
+            Ratelimit-Reset:
+                - "25"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000847
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 1.106495334s
+    - id: 90
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 57
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: '[{"key":"baz","value":"qux"},{"key":"foo","value":"bar"}]'
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            Content-Type:
+                - application/json
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/env-vars
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 168
+        uncompressed: false
+        body: |
+            [{"envVar":{"key":"baz","value":"qux"},"cursor":"DLRR7F1e8FhuN3RqMHE1czcwMGNrZ2ln"},{"envVar":{"key":"foo","value":"bar"},"cursor":"DLRR7F1e8FhuN3RqMHE1czcwMGNrZ2ow"}]
+        headers:
+            Content-Length:
+                - "168"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:35 GMT
+            Ratelimit-Limit:
+                - "100"
+            Ratelimit-Remaining:
+                - "86"
+            Ratelimit-Reset:
+                - "24"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000848
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 96.363583ms
+    - id: 91
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 67
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: '[{"content":"qux","name":"file2"},{"content":"bar","name":"file1"}]'
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            Content-Type:
+                - application/json
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/secret-files
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 186
+        uncompressed: false
+        body: |
+            [{"secretFile":{"content":"qux","name":"file2"},"cursor":"DLRR7F1e8FhuN3RqMHE1czcwMGNrZ2pn"},{"secretFile":{"content":"bar","name":"file1"},"cursor":"DLRR7F1e8FhuN3RqMHE1czcwMGNrZ2sw"}]
+        headers:
+            Content-Length:
+                - "186"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:35 GMT
+            Ratelimit-Limit:
+                - "100"
+            Ratelimit-Remaining:
+                - "85"
+            Ratelimit-Reset:
+                - "24"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000849
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 102.82675ms
+    - id: 92
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 2
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: '{}'
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            Content-Type:
+                - application/json
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/notification-settings/overrides/services/srv-ct6vn35j0q5s700ckga0
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 113
+        uncompressed: false
+        body: |
+            {"notificationsToSend":"default","previewNotificationsEnabled":"default","serviceId":"srv-ct6vn35j0q5s700ckga0"}
+        headers:
+            Content-Length:
+                - "113"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:35 GMT
+            Ratelimit-Limit:
+                - "100"
+            Ratelimit-Remaining:
+                - "84"
+            Ratelimit-Reset:
+                - "24"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000850
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 88.504167ms
+    - id: 93
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/custom-domains?limit=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:36 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "274"
+            Ratelimit-Reset:
+                - "24"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000851
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 81.108833ms
+    - id: 94
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 2
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: '{}'
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            Content-Type:
+                - application/json
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/deploys
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 325
+        uncompressed: false
+        body: |
+            {"id":"dep-ct6vn85j0q5s700ckgl0","commit":null,"image":{"ref":"docker.io/library/nginx:latest","sha":"sha256:8987949924fc00ae83e3609611990c17cceedc876c5bb9c9f60ca917170ebde1"},"status":"update_in_progress","trigger":"api","createdAt":"2024-12-02T18:25:36.514142Z","updatedAt":"2024-12-02T18:25:36.807759Z","finishedAt":null}
+        headers:
+            Content-Length:
+                - "325"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:36 GMT
+            Ratelimit-Limit:
+                - "10"
+            Ratelimit-Remaining:
+                - "6"
+            Ratelimit-Reset:
+                - "23"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000852
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 201 Created
+        code: 201
+        duration: 760.231334ms
+    - id: 95
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 994
+        uncompressed: false
+        body: |
+            {"autoDeploy":"yes","createdAt":"2024-12-02T18:25:16.437791Z","dashboardUrl":"http://dashboard.render.localhost:3000/web/srv-ct6vn35j0q5s700ckga0","id":"srv-ct6vn35j0q5s700ckga0","imagePath":"docker.io/library/nginx:latest","name":"web-service-env-var-tf","notifyOnFail":"default","ownerId":"some-owner-id","rootDir":"","serviceDetails":{"buildPlan":"free","env":"image","envSpecificDetails":{"dockerCommand":"","dockerContext":"","dockerfilePath":""},"healthCheckPath":"","numInstances":1,"openPorts":[{"port":10000,"protocol":"TCP"}],"plan":"free","previews":{"generation":"off"},"pullRequestPreviewsEnabled":"no","region":"oregon","runtime":"image","sshAddress":"srv-email@example.com","url":"https://web-service-env-var-tf.localhost.onrender.com:9443"},"slug":"web-service-env-var-tf","suspended":"not_suspended","suspenders":[],"type":"web_service","updatedAt":"2024-12-02T18:25:36.666057Z"}
+        headers:
+            Content-Length:
+                - "994"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:36 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "273"
+            Ratelimit-Reset:
+                - "23"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000853
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 95.746625ms
+    - id: 96
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/env-vars
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 168
+        uncompressed: false
+        body: |
+            [{"envVar":{"key":"foo","value":"bar"},"cursor":"DLRR7F1e8FhuN3RqMHE1czcwMGNrZ2ow"},{"envVar":{"key":"baz","value":"qux"},"cursor":"DLRR7F1e8FhuN3RqMHE1czcwMGNrZ2ln"}]
+        headers:
+            Content-Length:
+                - "168"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:37 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "272"
+            Ratelimit-Reset:
+                - "22"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000854
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 86.712583ms
+    - id: 97
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/env-vars?cursor=DLRR7F1e8FhuN3RqMHE1czcwMGNrZ2ln
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:37 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "271"
+            Ratelimit-Reset:
+                - "22"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000855
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 88.241625ms
+    - id: 98
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/secret-files
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 186
+        uncompressed: false
+        body: |
+            [{"secretFile":{"content":"bar","name":"file1"},"cursor":"DLRR7F1e8FhuN3RqMHE1czcwMGNrZ2sw"},{"secretFile":{"content":"qux","name":"file2"},"cursor":"DLRR7F1e8FhuN3RqMHE1czcwMGNrZ2pn"}]
+        headers:
+            Content-Length:
+                - "186"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:37 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "270"
+            Ratelimit-Reset:
+                - "22"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000856
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 105.021959ms
+    - id: 99
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/secret-files?cursor=DLRR7F1e8FhuN3RqMHE1czcwMGNrZ2pn
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:37 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "269"
+            Ratelimit-Reset:
+                - "22"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000857
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 83.044208ms
+    - id: 100
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/custom-domains?limit=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:37 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "268"
+            Ratelimit-Reset:
+                - "22"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000858
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 89.354667ms
+    - id: 101
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/notification-settings/overrides/services/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 113
+        uncompressed: false
+        body: |
+            {"notificationsToSend":"default","previewNotificationsEnabled":"default","serviceId":"srv-ct6vn35j0q5s700ckga0"}
+        headers:
+            Content-Length:
+                - "113"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:37 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "267"
+            Ratelimit-Reset:
+                - "22"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000859
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 82.564333ms
+    - id: 102
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: srv-ct6vn35j0q5s700ckga0"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:38 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "266"
+            Ratelimit-Reset:
+                - "21"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000860
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 117.799917ms
+    - id: 103
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 994
+        uncompressed: false
+        body: |
+            {"autoDeploy":"yes","createdAt":"2024-12-02T18:25:16.437791Z","dashboardUrl":"http://dashboard.render.localhost:3000/web/srv-ct6vn35j0q5s700ckga0","id":"srv-ct6vn35j0q5s700ckga0","imagePath":"docker.io/library/nginx:latest","name":"web-service-env-var-tf","notifyOnFail":"default","ownerId":"some-owner-id","rootDir":"","serviceDetails":{"buildPlan":"free","env":"image","envSpecificDetails":{"dockerCommand":"","dockerContext":"","dockerfilePath":""},"healthCheckPath":"","numInstances":1,"openPorts":[{"port":10000,"protocol":"TCP"}],"plan":"free","previews":{"generation":"off"},"pullRequestPreviewsEnabled":"no","region":"oregon","runtime":"image","sshAddress":"srv-email@example.com","url":"https://web-service-env-var-tf.localhost.onrender.com:9443"},"slug":"web-service-env-var-tf","suspended":"not_suspended","suspenders":[],"type":"web_service","updatedAt":"2024-12-02T18:25:36.666057Z"}
+        headers:
+            Content-Length:
+                - "994"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:38 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "265"
+            Ratelimit-Reset:
+                - "21"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000861
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 113.224208ms
+    - id: 104
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/env-vars
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 168
+        uncompressed: false
+        body: |
+            [{"envVar":{"key":"foo","value":"bar"},"cursor":"DLRR7F1e8FhuN3RqMHE1czcwMGNrZ2ow"},{"envVar":{"key":"baz","value":"qux"},"cursor":"DLRR7F1e8FhuN3RqMHE1czcwMGNrZ2ln"}]
+        headers:
+            Content-Length:
+                - "168"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:38 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "264"
+            Ratelimit-Reset:
+                - "21"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000862
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 88.797333ms
+    - id: 105
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/env-vars?cursor=DLRR7F1e8FhuN3RqMHE1czcwMGNrZ2ln
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:38 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "263"
+            Ratelimit-Reset:
+                - "21"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000863
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 87.1565ms
+    - id: 106
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/secret-files
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 186
+        uncompressed: false
+        body: |
+            [{"secretFile":{"content":"bar","name":"file1"},"cursor":"DLRR7F1e8FhuN3RqMHE1czcwMGNrZ2sw"},{"secretFile":{"content":"qux","name":"file2"},"cursor":"DLRR7F1e8FhuN3RqMHE1czcwMGNrZ2pn"}]
+        headers:
+            Content-Length:
+                - "186"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:38 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "262"
+            Ratelimit-Reset:
+                - "21"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000864
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 83.648084ms
+    - id: 107
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/secret-files?cursor=DLRR7F1e8FhuN3RqMHE1czcwMGNrZ2pn
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:39 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "261"
+            Ratelimit-Reset:
+                - "20"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000865
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 82.284666ms
+    - id: 108
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/custom-domains?limit=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:39 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "260"
+            Ratelimit-Reset:
+                - "20"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000866
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 88.047875ms
+    - id: 109
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/notification-settings/overrides/services/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 113
+        uncompressed: false
+        body: |
+            {"notificationsToSend":"default","previewNotificationsEnabled":"default","serviceId":"srv-ct6vn35j0q5s700ckga0"}
+        headers:
+            Content-Length:
+                - "113"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:39 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "259"
+            Ratelimit-Reset:
+                - "20"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000867
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 81.768042ms
+    - id: 110
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: srv-ct6vn35j0q5s700ckga0"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:39 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "258"
+            Ratelimit-Reset:
+                - "20"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000868
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 119.647917ms
+    - id: 111
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 994
+        uncompressed: false
+        body: |
+            {"autoDeploy":"yes","createdAt":"2024-12-02T18:25:16.437791Z","dashboardUrl":"http://dashboard.render.localhost:3000/web/srv-ct6vn35j0q5s700ckga0","id":"srv-ct6vn35j0q5s700ckga0","imagePath":"docker.io/library/nginx:latest","name":"web-service-env-var-tf","notifyOnFail":"default","ownerId":"some-owner-id","rootDir":"","serviceDetails":{"buildPlan":"free","env":"image","envSpecificDetails":{"dockerCommand":"","dockerContext":"","dockerfilePath":""},"healthCheckPath":"","numInstances":1,"openPorts":[{"port":10000,"protocol":"TCP"}],"plan":"free","previews":{"generation":"off"},"pullRequestPreviewsEnabled":"no","region":"oregon","runtime":"image","sshAddress":"srv-email@example.com","url":"https://web-service-env-var-tf.localhost.onrender.com:9443"},"slug":"web-service-env-var-tf","suspended":"not_suspended","suspenders":[],"type":"web_service","updatedAt":"2024-12-02T18:25:36.666057Z"}
+        headers:
+            Content-Length:
+                - "994"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:39 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "257"
+            Ratelimit-Reset:
+                - "20"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000869
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 295.045208ms
+    - id: 112
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/env-vars
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 168
+        uncompressed: false
+        body: |
+            [{"envVar":{"key":"foo","value":"bar"},"cursor":"DLRR7F1e8FhuN3RqMHE1czcwMGNrZ2ow"},{"envVar":{"key":"baz","value":"qux"},"cursor":"DLRR7F1e8FhuN3RqMHE1czcwMGNrZ2ln"}]
+        headers:
+            Content-Length:
+                - "168"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:40 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "256"
+            Ratelimit-Reset:
+                - "19"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000870
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 93.731083ms
+    - id: 113
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/env-vars?cursor=DLRR7F1e8FhuN3RqMHE1czcwMGNrZ2ln
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:40 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "255"
+            Ratelimit-Reset:
+                - "19"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000871
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 89.765042ms
+    - id: 114
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/secret-files
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 186
+        uncompressed: false
+        body: |
+            [{"secretFile":{"content":"bar","name":"file1"},"cursor":"DLRR7F1e8FhuN3RqMHE1czcwMGNrZ2sw"},{"secretFile":{"content":"qux","name":"file2"},"cursor":"DLRR7F1e8FhuN3RqMHE1czcwMGNrZ2pn"}]
+        headers:
+            Content-Length:
+                - "186"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:40 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "254"
+            Ratelimit-Reset:
+                - "19"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000872
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 77.109875ms
+    - id: 115
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/secret-files?cursor=DLRR7F1e8FhuN3RqMHE1czcwMGNrZ2pn
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:40 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "253"
+            Ratelimit-Reset:
+                - "19"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000873
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 82.094416ms
+    - id: 116
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/custom-domains?limit=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:40 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "252"
+            Ratelimit-Reset:
+                - "19"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000874
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 86.677333ms
+    - id: 117
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/notification-settings/overrides/services/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 113
+        uncompressed: false
+        body: |
+            {"notificationsToSend":"default","previewNotificationsEnabled":"default","serviceId":"srv-ct6vn35j0q5s700ckga0"}
+        headers:
+            Content-Length:
+                - "113"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:40 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "251"
+            Ratelimit-Reset:
+                - "19"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000875
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 105.928125ms
+    - id: 118
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: srv-ct6vn35j0q5s700ckga0"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:41 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "250"
+            Ratelimit-Reset:
+                - "18"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000876
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 115.563042ms
+    - id: 119
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 994
+        uncompressed: false
+        body: |
+            {"autoDeploy":"yes","createdAt":"2024-12-02T18:25:16.437791Z","dashboardUrl":"http://dashboard.render.localhost:3000/web/srv-ct6vn35j0q5s700ckga0","id":"srv-ct6vn35j0q5s700ckga0","imagePath":"docker.io/library/nginx:latest","name":"web-service-env-var-tf","notifyOnFail":"default","ownerId":"some-owner-id","rootDir":"","serviceDetails":{"buildPlan":"free","env":"image","envSpecificDetails":{"dockerCommand":"","dockerContext":"","dockerfilePath":""},"healthCheckPath":"","numInstances":1,"openPorts":[{"port":10000,"protocol":"TCP"}],"plan":"free","previews":{"generation":"off"},"pullRequestPreviewsEnabled":"no","region":"oregon","runtime":"image","sshAddress":"srv-email@example.com","url":"https://web-service-env-var-tf.localhost.onrender.com:9443"},"slug":"web-service-env-var-tf","suspended":"not_suspended","suspenders":[],"type":"web_service","updatedAt":"2024-12-02T18:25:36.666057Z"}
+        headers:
+            Content-Length:
+                - "994"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:41 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "249"
+            Ratelimit-Reset:
+                - "18"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000877
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 88.051083ms
+    - id: 120
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/env-vars
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 168
+        uncompressed: false
+        body: |
+            [{"envVar":{"key":"foo","value":"bar"},"cursor":"DLRR7F1e8FhuN3RqMHE1czcwMGNrZ2ow"},{"envVar":{"key":"baz","value":"qux"},"cursor":"DLRR7F1e8FhuN3RqMHE1czcwMGNrZ2ln"}]
+        headers:
+            Content-Length:
+                - "168"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:41 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "248"
+            Ratelimit-Reset:
+                - "18"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000878
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 83.372583ms
+    - id: 121
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/env-vars?cursor=DLRR7F1e8FhuN3RqMHE1czcwMGNrZ2ln
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:41 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "247"
+            Ratelimit-Reset:
+                - "18"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000879
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 84.507ms
+    - id: 122
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/secret-files
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 186
+        uncompressed: false
+        body: |
+            [{"secretFile":{"content":"bar","name":"file1"},"cursor":"DLRR7F1e8FhuN3RqMHE1czcwMGNrZ2sw"},{"secretFile":{"content":"qux","name":"file2"},"cursor":"DLRR7F1e8FhuN3RqMHE1czcwMGNrZ2pn"}]
+        headers:
+            Content-Length:
+                - "186"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:41 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "246"
+            Ratelimit-Reset:
+                - "18"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000880
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 88.586292ms
+    - id: 123
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/secret-files?cursor=DLRR7F1e8FhuN3RqMHE1czcwMGNrZ2pn
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:41 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "245"
+            Ratelimit-Reset:
+                - "18"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000881
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 84.335292ms
+    - id: 124
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/custom-domains?limit=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:42 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "244"
+            Ratelimit-Reset:
+                - "17"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000882
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 174.958375ms
+    - id: 125
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/notification-settings/overrides/services/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 113
+        uncompressed: false
+        body: |
+            {"notificationsToSend":"default","previewNotificationsEnabled":"default","serviceId":"srv-ct6vn35j0q5s700ckga0"}
+        headers:
+            Content-Length:
+                - "113"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:42 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "243"
+            Ratelimit-Reset:
+                - "17"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000883
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 93.123083ms
+    - id: 126
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: srv-ct6vn35j0q5s700ckga0"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:42 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "242"
+            Ratelimit-Reset:
+                - "17"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000884
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 115.629208ms
+    - id: 127
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 994
+        uncompressed: false
+        body: |
+            {"autoDeploy":"yes","createdAt":"2024-12-02T18:25:16.437791Z","dashboardUrl":"http://dashboard.render.localhost:3000/web/srv-ct6vn35j0q5s700ckga0","id":"srv-ct6vn35j0q5s700ckga0","imagePath":"docker.io/library/nginx:latest","name":"web-service-env-var-tf","notifyOnFail":"default","ownerId":"some-owner-id","rootDir":"","serviceDetails":{"buildPlan":"free","env":"image","envSpecificDetails":{"dockerCommand":"","dockerContext":"","dockerfilePath":""},"healthCheckPath":"","numInstances":1,"openPorts":[{"port":10000,"protocol":"TCP"}],"plan":"free","previews":{"generation":"off"},"pullRequestPreviewsEnabled":"no","region":"oregon","runtime":"image","sshAddress":"srv-email@example.com","url":"https://web-service-env-var-tf.localhost.onrender.com:9443"},"slug":"web-service-env-var-tf","suspended":"not_suspended","suspenders":[],"type":"web_service","updatedAt":"2024-12-02T18:25:36.666057Z"}
+        headers:
+            Content-Length:
+                - "994"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:42 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "241"
+            Ratelimit-Reset:
+                - "17"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000885
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 93.266417ms
+    - id: 128
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/env-vars
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 168
+        uncompressed: false
+        body: |
+            [{"envVar":{"key":"foo","value":"bar"},"cursor":"DLRR7F1e8FhuN3RqMHE1czcwMGNrZ2ow"},{"envVar":{"key":"baz","value":"qux"},"cursor":"DLRR7F1e8FhuN3RqMHE1czcwMGNrZ2ln"}]
+        headers:
+            Content-Length:
+                - "168"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:42 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "240"
+            Ratelimit-Reset:
+                - "17"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000886
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 84.736875ms
+    - id: 129
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/env-vars?cursor=DLRR7F1e8FhuN3RqMHE1czcwMGNrZ2ln
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:42 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "239"
+            Ratelimit-Reset:
+                - "17"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000887
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 84.650083ms
+    - id: 130
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/secret-files
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 186
+        uncompressed: false
+        body: |
+            [{"secretFile":{"content":"bar","name":"file1"},"cursor":"DLRR7F1e8FhuN3RqMHE1czcwMGNrZ2sw"},{"secretFile":{"content":"qux","name":"file2"},"cursor":"DLRR7F1e8FhuN3RqMHE1czcwMGNrZ2pn"}]
+        headers:
+            Content-Length:
+                - "186"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:43 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "238"
+            Ratelimit-Reset:
+                - "16"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000888
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 81.328292ms
+    - id: 131
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/secret-files?cursor=DLRR7F1e8FhuN3RqMHE1czcwMGNrZ2pn
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:43 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "237"
+            Ratelimit-Reset:
+                - "16"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000889
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 290.481916ms
+    - id: 132
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/custom-domains?limit=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:43 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "236"
+            Ratelimit-Reset:
+                - "16"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000890
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 85.706666ms
+    - id: 133
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/notification-settings/overrides/services/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 113
+        uncompressed: false
+        body: |
+            {"notificationsToSend":"default","previewNotificationsEnabled":"default","serviceId":"srv-ct6vn35j0q5s700ckga0"}
+        headers:
+            Content-Length:
+                - "113"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:43 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "235"
+            Ratelimit-Reset:
+                - "16"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000891
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 81.670917ms
+    - id: 134
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: srv-ct6vn35j0q5s700ckga0"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:43 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "234"
+            Ratelimit-Reset:
+                - "16"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000892
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 120.368125ms
+    - id: 135
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 345
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: '{"image":{"imagePath":"nginx","ownerId":"some-owner-id"},"name":"web-service-env-var-tf","rootDir":"","serviceDetails":{"envSpecificDetails":{"dockerCommand":""},"healthCheckPath":"","plan":"free","preDeployCommand":"","previews":{},"pullRequestPreviewsEnabled":"no","runtime":"image"}}'
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            Content-Type:
+                - application/json
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 994
+        uncompressed: false
+        body: |
+            {"autoDeploy":"yes","createdAt":"2024-12-02T18:25:16.437791Z","dashboardUrl":"http://dashboard.render.localhost:3000/web/srv-ct6vn35j0q5s700ckga0","id":"srv-ct6vn35j0q5s700ckga0","imagePath":"docker.io/library/nginx:latest","name":"web-service-env-var-tf","notifyOnFail":"default","ownerId":"some-owner-id","rootDir":"","serviceDetails":{"buildPlan":"free","env":"image","envSpecificDetails":{"dockerCommand":"","dockerContext":"","dockerfilePath":""},"healthCheckPath":"","numInstances":1,"openPorts":[{"port":10000,"protocol":"TCP"}],"plan":"free","previews":{"generation":"off"},"pullRequestPreviewsEnabled":"no","region":"oregon","runtime":"image","sshAddress":"srv-email@example.com","url":"https://web-service-env-var-tf.localhost.onrender.com:9443"},"slug":"web-service-env-var-tf","suspended":"not_suspended","suspenders":[],"type":"web_service","updatedAt":"2024-12-02T18:25:36.666057Z"}
+        headers:
+            Content-Length:
+                - "994"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:45 GMT
+            Ratelimit-Limit:
+                - "10"
+            Ratelimit-Remaining:
+                - "5"
+            Ratelimit-Reset:
+                - "15"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000893
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 1.102786958s
+    - id: 136
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 4
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: "null"
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            Content-Type:
+                - application/json
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/env-vars
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:45 GMT
+            Ratelimit-Limit:
+                - "100"
+            Ratelimit-Remaining:
+                - "83"
+            Ratelimit-Reset:
+                - "14"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000894
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 98.419334ms
+    - id: 137
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 4
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: "null"
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            Content-Type:
+                - application/json
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/secret-files
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:45 GMT
+            Ratelimit-Limit:
+                - "100"
+            Ratelimit-Remaining:
+                - "82"
+            Ratelimit-Reset:
+                - "14"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000895
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 97.376292ms
+    - id: 138
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 2
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: '{}'
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            Content-Type:
+                - application/json
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/notification-settings/overrides/services/srv-ct6vn35j0q5s700ckga0
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 113
+        uncompressed: false
+        body: |
+            {"notificationsToSend":"default","previewNotificationsEnabled":"default","serviceId":"srv-ct6vn35j0q5s700ckga0"}
+        headers:
+            Content-Length:
+                - "113"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:45 GMT
+            Ratelimit-Limit:
+                - "100"
+            Ratelimit-Remaining:
+                - "81"
+            Ratelimit-Reset:
+                - "14"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000896
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 86.6535ms
+    - id: 139
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/custom-domains?limit=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:45 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "233"
+            Ratelimit-Reset:
+                - "14"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000897
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 87.286875ms
+    - id: 140
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 2
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: '{}'
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            Content-Type:
+                - application/json
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/deploys
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 325
+        uncompressed: false
+        body: |
+            {"id":"dep-ct6vnalj0q5s700ckgq0","commit":null,"image":{"ref":"docker.io/library/nginx:latest","sha":"sha256:8987949924fc00ae83e3609611990c17cceedc876c5bb9c9f60ca917170ebde1"},"status":"update_in_progress","trigger":"api","createdAt":"2024-12-02T18:25:46.330916Z","updatedAt":"2024-12-02T18:25:46.598367Z","finishedAt":null}
+        headers:
+            Content-Length:
+                - "325"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:46 GMT
+            Ratelimit-Limit:
+                - "10"
+            Ratelimit-Remaining:
+                - "4"
+            Ratelimit-Reset:
+                - "14"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000898
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 201 Created
+        code: 201
+        duration: 735.93275ms
+    - id: 141
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 994
+        uncompressed: false
+        body: |
+            {"autoDeploy":"yes","createdAt":"2024-12-02T18:25:16.437791Z","dashboardUrl":"http://dashboard.render.localhost:3000/web/srv-ct6vn35j0q5s700ckga0","id":"srv-ct6vn35j0q5s700ckga0","imagePath":"docker.io/library/nginx:latest","name":"web-service-env-var-tf","notifyOnFail":"default","ownerId":"some-owner-id","rootDir":"","serviceDetails":{"buildPlan":"free","env":"image","envSpecificDetails":{"dockerCommand":"","dockerContext":"","dockerfilePath":""},"healthCheckPath":"","numInstances":1,"openPorts":[{"port":10000,"protocol":"TCP"}],"plan":"free","previews":{"generation":"off"},"pullRequestPreviewsEnabled":"no","region":"oregon","runtime":"image","sshAddress":"srv-email@example.com","url":"https://web-service-env-var-tf.localhost.onrender.com:9443"},"slug":"web-service-env-var-tf","suspended":"not_suspended","suspenders":[],"type":"web_service","updatedAt":"2024-12-02T18:25:46.464762Z"}
+        headers:
+            Content-Length:
+                - "994"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:46 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "232"
+            Ratelimit-Reset:
+                - "13"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000899
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 102.787042ms
+    - id: 142
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/env-vars
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:46 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "231"
+            Ratelimit-Reset:
+                - "13"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000900
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 88.884416ms
+    - id: 143
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/secret-files
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:47 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "230"
+            Ratelimit-Reset:
+                - "12"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000901
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 86.385125ms
+    - id: 144
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/custom-domains?limit=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:47 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "229"
+            Ratelimit-Reset:
+                - "12"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000902
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 93.633417ms
+    - id: 145
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/notification-settings/overrides/services/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 113
+        uncompressed: false
+        body: |
+            {"notificationsToSend":"default","previewNotificationsEnabled":"default","serviceId":"srv-ct6vn35j0q5s700ckga0"}
+        headers:
+            Content-Length:
+                - "113"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:47 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "228"
+            Ratelimit-Reset:
+                - "12"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000903
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 84.408166ms
+    - id: 146
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: srv-ct6vn35j0q5s700ckga0"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:47 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "227"
+            Ratelimit-Reset:
+                - "12"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000904
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 114.791167ms
+    - id: 147
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 994
+        uncompressed: false
+        body: |
+            {"autoDeploy":"yes","createdAt":"2024-12-02T18:25:16.437791Z","dashboardUrl":"http://dashboard.render.localhost:3000/web/srv-ct6vn35j0q5s700ckga0","id":"srv-ct6vn35j0q5s700ckga0","imagePath":"docker.io/library/nginx:latest","name":"web-service-env-var-tf","notifyOnFail":"default","ownerId":"some-owner-id","rootDir":"","serviceDetails":{"buildPlan":"free","env":"image","envSpecificDetails":{"dockerCommand":"","dockerContext":"","dockerfilePath":""},"healthCheckPath":"","numInstances":1,"openPorts":[{"port":10000,"protocol":"TCP"}],"plan":"free","previews":{"generation":"off"},"pullRequestPreviewsEnabled":"no","region":"oregon","runtime":"image","sshAddress":"srv-email@example.com","url":"https://web-service-env-var-tf.localhost.onrender.com:9443"},"slug":"web-service-env-var-tf","suspended":"not_suspended","suspenders":[],"type":"web_service","updatedAt":"2024-12-02T18:25:46.464762Z"}
+        headers:
+            Content-Length:
+                - "994"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:47 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "226"
+            Ratelimit-Reset:
+                - "12"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000905
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 91.47775ms
+    - id: 148
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/env-vars
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:48 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "225"
+            Ratelimit-Reset:
+                - "12"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000906
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 83.201125ms
+    - id: 149
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/secret-files
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:48 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "224"
+            Ratelimit-Reset:
+                - "11"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000907
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 89.7465ms
+    - id: 150
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/custom-domains?limit=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:48 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "223"
+            Ratelimit-Reset:
+                - "11"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000908
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 85.062333ms
+    - id: 151
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/notification-settings/overrides/services/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 113
+        uncompressed: false
+        body: |
+            {"notificationsToSend":"default","previewNotificationsEnabled":"default","serviceId":"srv-ct6vn35j0q5s700ckga0"}
+        headers:
+            Content-Length:
+                - "113"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:48 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "222"
+            Ratelimit-Reset:
+                - "11"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000909
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 85.464792ms
+    - id: 152
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: srv-ct6vn35j0q5s700ckga0"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:48 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "221"
+            Ratelimit-Reset:
+                - "11"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000910
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 118.542834ms
+    - id: 153
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 994
+        uncompressed: false
+        body: |
+            {"autoDeploy":"yes","createdAt":"2024-12-02T18:25:16.437791Z","dashboardUrl":"http://dashboard.render.localhost:3000/web/srv-ct6vn35j0q5s700ckga0","id":"srv-ct6vn35j0q5s700ckga0","imagePath":"docker.io/library/nginx:latest","name":"web-service-env-var-tf","notifyOnFail":"default","ownerId":"some-owner-id","rootDir":"","serviceDetails":{"buildPlan":"free","env":"image","envSpecificDetails":{"dockerCommand":"","dockerContext":"","dockerfilePath":""},"healthCheckPath":"","numInstances":1,"openPorts":[{"port":10000,"protocol":"TCP"}],"plan":"free","previews":{"generation":"off"},"pullRequestPreviewsEnabled":"no","region":"oregon","runtime":"image","sshAddress":"srv-email@example.com","url":"https://web-service-env-var-tf.localhost.onrender.com:9443"},"slug":"web-service-env-var-tf","suspended":"not_suspended","suspenders":[],"type":"web_service","updatedAt":"2024-12-02T18:25:46.464762Z"}
+        headers:
+            Content-Length:
+                - "994"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:48 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "220"
+            Ratelimit-Reset:
+                - "11"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000911
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 88.599459ms
+    - id: 154
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/env-vars
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:49 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "219"
+            Ratelimit-Reset:
+                - "10"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000912
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 83.3345ms
+    - id: 155
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/secret-files
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:49 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "218"
+            Ratelimit-Reset:
+                - "10"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000913
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 90.741625ms
+    - id: 156
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/custom-domains?limit=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:49 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "217"
+            Ratelimit-Reset:
+                - "10"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000914
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 84.997583ms
+    - id: 157
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/notification-settings/overrides/services/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 113
+        uncompressed: false
+        body: |
+            {"notificationsToSend":"default","previewNotificationsEnabled":"default","serviceId":"srv-ct6vn35j0q5s700ckga0"}
+        headers:
+            Content-Length:
+                - "113"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:49 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "216"
+            Ratelimit-Reset:
+                - "10"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000915
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 83.216ms
+    - id: 158
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: srv-ct6vn35j0q5s700ckga0"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:49 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "215"
+            Ratelimit-Reset:
+                - "10"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000916
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 117.7675ms
+    - id: 159
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 994
+        uncompressed: false
+        body: |
+            {"autoDeploy":"yes","createdAt":"2024-12-02T18:25:16.437791Z","dashboardUrl":"http://dashboard.render.localhost:3000/web/srv-ct6vn35j0q5s700ckga0","id":"srv-ct6vn35j0q5s700ckga0","imagePath":"docker.io/library/nginx:latest","name":"web-service-env-var-tf","notifyOnFail":"default","ownerId":"some-owner-id","rootDir":"","serviceDetails":{"buildPlan":"free","env":"image","envSpecificDetails":{"dockerCommand":"","dockerContext":"","dockerfilePath":""},"healthCheckPath":"","numInstances":1,"openPorts":[{"port":10000,"protocol":"TCP"}],"plan":"free","previews":{"generation":"off"},"pullRequestPreviewsEnabled":"no","region":"oregon","runtime":"image","sshAddress":"srv-email@example.com","url":"https://web-service-env-var-tf.localhost.onrender.com:9443"},"slug":"web-service-env-var-tf","suspended":"not_suspended","suspenders":[],"type":"web_service","updatedAt":"2024-12-02T18:25:46.464762Z"}
+        headers:
+            Content-Length:
+                - "994"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:49 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "214"
+            Ratelimit-Reset:
+                - "10"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000917
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 92.20475ms
+    - id: 160
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/env-vars
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:50 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "213"
+            Ratelimit-Reset:
+                - "9"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000918
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 83.5705ms
+    - id: 161
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/secret-files
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:50 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "212"
+            Ratelimit-Reset:
+                - "9"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000919
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 86.937083ms
+    - id: 162
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0/custom-domains?limit=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: |
+            []
+        headers:
+            Content-Length:
+                - "3"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:50 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "211"
+            Ratelimit-Reset:
+                - "9"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000920
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 86.595667ms
+    - id: 163
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/notification-settings/overrides/services/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 113
+        uncompressed: false
+        body: |
+            {"notificationsToSend":"default","previewNotificationsEnabled":"default","serviceId":"srv-ct6vn35j0q5s700ckga0"}
+        headers:
+            Content-Length:
+                - "113"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:50 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "210"
+            Ratelimit-Reset:
+                - "9"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000921
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 81.242459ms
+    - id: 164
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/logs/streams/resource/srv-ct6vn35j0q5s700ckga0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 50
+        uncompressed: false
+        body: |
+            {"message":"not found: srv-ct6vn35j0q5s700ckga0"}
+        headers:
+            Content-Length:
+                - "50"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 02 Dec 2024 18:25:50 GMT
+            Ratelimit-Limit:
+                - "400"
+            Ratelimit-Remaining:
+                - "209"
+            Ratelimit-Reset:
+                - "9"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000922
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 404 Not Found
+        code: 404
+        duration: 131.885ms
+    - id: 165
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: https://api.testing.render.com/v1
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - some-api-key
+            User-Agent:
+                - terraform-provider-render/test
+        url: https://api.testing.render.com/v1/services/srv-ct6vn35j0q5s700ckga0
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Date:
+                - Mon, 02 Dec 2024 18:25:51 GMT
+            Ratelimit-Limit:
+                - "100"
+            Ratelimit-Remaining:
+                - "80"
+            Ratelimit-Reset:
+                - "9"
+            Referrer-Policy:
+                - same-origin
+            Render-Request-Id:
+                - api-86f88f97dc-mq7v6/f6uEMMelME-000923
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 204 No Content
+        code: 204
+        duration: 230.513667ms

--- a/internal/provider/webservice/resource/testdata/maintenance_mode_free_enabled.tf
+++ b/internal/provider/webservice/resource/testdata/maintenance_mode_free_enabled.tf
@@ -1,0 +1,17 @@
+# Issue #80: enabling maintenance mode on a free-tier service must be rejected at plan
+# time, since the Render API only supports it on non-free tiers.
+resource "render_web_service" "service" {
+  name   = "web-service-env-var-tf"
+  plan   = "free"
+  region = "oregon"
+
+  runtime_source = {
+    image = {
+      image_url = "nginx"
+    }
+  }
+
+  maintenance_mode = {
+    enabled = true
+  }
+}

--- a/internal/provider/webservice/resource/validators.go
+++ b/internal/provider/webservice/resource/validators.go
@@ -1,0 +1,53 @@
+package resource
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"terraform-provider-render/internal/client"
+)
+
+// maintenanceModeFreeTierValidator rejects enabling maintenance mode on the free plan at
+// plan time. The Render API only supports maintenance mode on non-free tiers (issue #80);
+// without this, an explicit `maintenance_mode = { enabled = true }` on a free service is
+// silently dropped from the request and surfaces later as a confusing
+// "inconsistent result after apply" framework error instead of a clear message.
+type maintenanceModeFreeTierValidator struct{}
+
+func (v maintenanceModeFreeTierValidator) Description(_ context.Context) string {
+	return "maintenance mode can only be enabled for non-free tier services"
+}
+
+func (v maintenanceModeFreeTierValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v maintenanceModeFreeTierValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var servicePlan types.String
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("plan"), &servicePlan)...)
+	if resp.Diagnostics.HasError() || servicePlan.IsNull() || servicePlan.IsUnknown() {
+		return
+	}
+	if client.Plan(servicePlan.ValueString()) != client.PlanFree {
+		return
+	}
+
+	enabledPath := path.Root("maintenance_mode").AtName("enabled")
+	var enabled types.Bool
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, enabledPath, &enabled)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if enabled.ValueBool() {
+		resp.Diagnostics.AddAttributeError(
+			enabledPath,
+			"Maintenance mode not available on the free plan",
+			"maintenance mode can only be configured for non-free tier services; "+
+				"remove maintenance_mode or upgrade the service plan.",
+		)
+	}
+}


### PR DESCRIPTION
Free-tier web services can't be managed with Terraform. The Render API omits `maintenance_mode` for free services, but the provider stored it as null (conflicting with the schema's default object) and always sent it back on update. The result: a perpetual diff on import, and every apply failing with `maintenance mode can only be configured for non-free tier services`.

- Omit `maintenance_mode` from create/update payloads on the free plan
- On read, fall back to the schema default when the API omits it, instead of null
- Reject enabling `maintenance_mode` on the free plan at plan time, so it fails with a clear message instead of a confusing post-apply error

Tested with unit tests for the request builders and read mapper, plus cassette-based acceptance tests: `TestFreeTierMaintenanceMode` reproduces the perpetual-diff failure (fails without the read-path fix with "inconsistent result after apply"), and `TestFreeTierMaintenanceModeRejectsEnabled` covers the validator.

Fixes #80