### PR TITLE
fix(terraform): preserve OCI digest references across refresh and update

### DIFF
--- a/internal/provider/common/models.go
+++ b/internal/provider/common/models.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"fmt"
-	"strings"
 
 	"terraform-provider-render/internal/client"
 	"terraform-provider-render/internal/client/autoscaling"
@@ -255,26 +254,23 @@ func DockerRuntimeSource(service *client.Service, envDetails client.EnvSpecificD
 }
 
 func ImageRuntimeSource(service *client.Service, envDetails client.EnvSpecificDetails) (*ImageRuntimeSourceModel, error) {
-	var imageURL *string
-	var imageTag *string
-	var imageDigest *string
-
-	if service.ImagePath != nil && strings.Contains(*service.ImagePath, "@") {
-		imageParts := strings.Split(*service.ImagePath, "@")
-		imageURL = &imageParts[0]
-		imageDigest = &imageParts[1]
-	}
-
-	if service.ImagePath != nil && strings.Contains(*service.ImagePath, ":") {
-		imageParts := strings.Split(*service.ImagePath, ":")
-		imageURL = &imageParts[0]
-		imageTag = &imageParts[1]
-	}
-
 	image := &ImageRuntimeSourceModel{
-		ImageURL: commontypes.ImageURLStringValue{StringValue: types.StringPointerValue(imageURL)},
-		Tag:      types.StringPointerValue(imageTag),
-		Digest:   types.StringPointerValue(imageDigest),
+		ImageURL: commontypes.ImageURLStringValue{StringValue: types.StringNull()},
+		Tag:      types.StringNull(),
+		Digest:   types.StringNull(),
+	}
+	if service.ImagePath != nil {
+		reference, err := parseImageReference(*service.ImagePath)
+		if err != nil {
+			return nil, err
+		}
+		image.ImageURL = commontypes.ImageURLStringValue{StringValue: types.StringValue(reference.repository)}
+		if reference.tag != "" {
+			image.Tag = types.StringValue(reference.tag)
+		}
+		if reference.digest != "" {
+			image.Digest = types.StringValue(reference.digest)
+		}
 	}
 
 	if service.RegistryCredential != nil {

--- a/internal/provider/common/runtimesource.go
+++ b/internal/provider/common/runtimesource.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"terraform-provider-render/internal/client"
@@ -40,6 +41,54 @@ type RuntimeSourceModel struct {
 	Docker        *DockerRuntimeSourceModel `tfsdk:"docker"`
 	NativeRuntime *NativeRuntimeModel       `tfsdk:"native_runtime"`
 	Image         *ImageRuntimeSourceModel  `tfsdk:"image"`
+}
+
+type imageReference struct {
+	repository string
+	tag        string
+	digest     string
+}
+
+func parseImageReference(reference string) (imageReference, error) {
+	if reference == "" {
+		return imageReference{}, fmt.Errorf("image reference is empty")
+	}
+
+	if repository, digest, ok := strings.Cut(reference, "@"); ok {
+		if repository == "" || digest == "" {
+			return imageReference{}, fmt.Errorf("invalid digest image reference %q", reference)
+		}
+		return imageReference{
+			repository: repository,
+			digest:     digest,
+		}, nil
+	}
+
+	lastColon := strings.LastIndex(reference, ":")
+	lastSlash := strings.LastIndex(reference, "/")
+	if lastColon > lastSlash {
+		if lastColon == 0 || lastColon == len(reference)-1 {
+			return imageReference{}, fmt.Errorf("invalid tagged image reference %q", reference)
+		}
+		return imageReference{
+			repository: reference[:lastColon],
+			tag:        reference[lastColon+1:],
+		}, nil
+	}
+
+	return imageReference{repository: reference}, nil
+}
+
+func (r imageReference) String() string {
+	if r.digest != "" {
+		return fmt.Sprintf("%s@%s", r.repository, r.digest)
+	}
+
+	if r.tag != "" {
+		return fmt.Sprintf("%s:%s", r.repository, r.tag)
+	}
+
+	return r.repository
 }
 
 func (m *RuntimeSourceModel) Runtime() string {
@@ -173,15 +222,11 @@ func EnvSpecificDetailsForPATCH(runtimeSource *RuntimeSourceModel, startCommand 
 }
 
 func ImageURLForURLAndReference(url, tag, digest string) string {
-	if tag != "" {
-		return fmt.Sprintf("%s:%s", url, tag)
-	}
-
-	if digest != "" {
-		return fmt.Sprintf("%s@%s", url, digest)
-	}
-
-	return url
+	return imageReference{
+		repository: url,
+		tag:        tag,
+		digest:     digest,
+	}.String()
 }
 
 func applyAutoDeployForCreate(autoDeploy bool, autoDeployTrigger types.String, body *client.CreateServiceJSONRequestBody) {

--- a/internal/provider/common/runtimesource_test.go
+++ b/internal/provider/common/runtimesource_test.go
@@ -1,0 +1,208 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"terraform-provider-render/internal/client"
+)
+
+const testImageDigest = "sha256:1fe6fa21bcb65be49241d28f919392179db011fadf8a77ee3bfb2c314924dd4c"
+
+func TestParseImageReference(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		reference  string
+		repository string
+		tag        string
+		digest     string
+	}{
+		"bare repository": {
+			reference:  "nginx",
+			repository: "nginx",
+		},
+		"normal tag": {
+			reference:  "docker.io/library/nginx:latest",
+			repository: "docker.io/library/nginx",
+			tag:        "latest",
+		},
+		"digest with algorithm colon": {
+			reference:  "ghcr.io/acme/app@" + testImageDigest,
+			repository: "ghcr.io/acme/app",
+			digest:     testImageDigest,
+		},
+		"registry port with tag": {
+			reference:  "registry.example.com:5000/acme/app:release",
+			repository: "registry.example.com:5000/acme/app",
+			tag:        "release",
+		},
+		"registry port with digest": {
+			reference:  "registry.example.com:5000/acme/app@" + testImageDigest,
+			repository: "registry.example.com:5000/acme/app",
+			digest:     testImageDigest,
+		},
+		"nested repository path": {
+			reference:  "registry.example.com/acme/platform/app:release",
+			repository: "registry.example.com/acme/platform/app",
+			tag:        "release",
+		},
+		"non-sha256 digest algorithm is preserved": {
+			reference:  "registry.example.com/acme/app@sha512:abc123",
+			repository: "registry.example.com/acme/app",
+			digest:     "sha512:abc123",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parseImageReference(test.reference)
+			require.NoError(t, err)
+			assert.Equal(t, test.repository, got.repository)
+			assert.Equal(t, test.tag, got.tag)
+			assert.Equal(t, test.digest, got.digest)
+		})
+	}
+}
+
+func TestImageReferenceRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	references := []string{
+		"nginx",
+		"docker.io/library/nginx:latest",
+		"ghcr.io/acme/app@" + testImageDigest,
+		"registry.example.com:5000/acme/app:release",
+		"registry.example.com:5000/acme/app@" + testImageDigest,
+		"registry.example.com/acme/platform/app:release",
+		"registry.example.com/acme/app@sha512:abc123",
+	}
+
+	for _, reference := range references {
+		t.Run(reference, func(t *testing.T) {
+			t.Parallel()
+
+			parsed, err := parseImageReference(reference)
+			require.NoError(t, err)
+			assert.Equal(t, reference, parsed.String())
+		})
+	}
+}
+
+func TestParseImageReferenceRejectsMalformedSeparators(t *testing.T) {
+	t.Parallel()
+
+	for _, reference := range []string{"", "@sha256:abc123", "repo@", ":tag", "repo:"} {
+		t.Run(reference, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := parseImageReference(reference)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestImageURLForURLAndReference(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		repository string
+		tag        string
+		digest     string
+		want       string
+	}{
+		"bare repository": {
+			repository: "nginx",
+			want:       "nginx",
+		},
+		"tag": {
+			repository: "docker.io/library/nginx",
+			tag:        "latest",
+			want:       "docker.io/library/nginx:latest",
+		},
+		"digest": {
+			repository: "ghcr.io/acme/app",
+			digest:     testImageDigest,
+			want:       "ghcr.io/acme/app@" + testImageDigest,
+		},
+		"historical tag and digest state prefers digest": {
+			repository: "ghcr.io/acme/app",
+			tag:        "historical-bad-tag",
+			digest:     testImageDigest,
+			want:       "ghcr.io/acme/app@" + testImageDigest,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, test.want, ImageURLForURLAndReference(test.repository, test.tag, test.digest))
+		})
+	}
+}
+
+func TestImageRuntimeSource_DigestReference(t *testing.T) {
+	const (
+		repository = "ghcr.io/acme/app"
+	)
+	imagePath := repository + "@" + testImageDigest
+
+	image, err := ImageRuntimeSource(
+		&client.Service{
+			ImagePath:          &imagePath,
+			RegistryCredential: &client.RegistryCredentialSummary{Id: "rgc-123"},
+		},
+		client.EnvSpecificDetails{},
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, repository, image.ImageURL.ValueString())
+	assert.Equal(t, testImageDigest, image.Digest.ValueString())
+	assert.True(t, image.Tag.IsNull(), "a digest reference must not populate tag")
+	assert.Equal(t, "rgc-123", image.RegistryCredentialID.ValueString())
+}
+
+func TestImageRuntimeSource_TagReference(t *testing.T) {
+	imagePath := "registry.example.com:5000/acme/app:release"
+
+	image, err := ImageRuntimeSource(
+		&client.Service{ImagePath: &imagePath},
+		client.EnvSpecificDetails{},
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, "registry.example.com:5000/acme/app", image.ImageURL.ValueString())
+	assert.Equal(t, "release", image.Tag.ValueString())
+	assert.True(t, image.Digest.IsNull())
+	assert.True(t, image.RegistryCredentialID.IsNull())
+}
+
+func TestImageRuntimeSource_BareReference(t *testing.T) {
+	imagePath := "nginx"
+
+	image, err := ImageRuntimeSource(
+		&client.Service{ImagePath: &imagePath},
+		client.EnvSpecificDetails{},
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, "nginx", image.ImageURL.ValueString())
+	assert.True(t, image.Tag.IsNull())
+	assert.True(t, image.Digest.IsNull())
+	assert.True(t, image.RegistryCredentialID.IsNull())
+}
+
+func TestImageRuntimeSource_RejectsMalformedReference(t *testing.T) {
+	imagePath := "ghcr.io/acme/app@"
+
+	_, err := ImageRuntimeSource(
+		&client.Service{ImagePath: &imagePath},
+		client.EnvSpecificDetails{},
+	)
+	require.Error(t, err)
+}

--- a/internal/provider/webservice/resource/image_digest_roundtrip_test.go
+++ b/internal/provider/webservice/resource/image_digest_roundtrip_test.go
@@ -1,0 +1,417 @@
+package resource_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/stretchr/testify/require"
+
+	"terraform-provider-render/internal/client"
+	"terraform-provider-render/internal/client/notifications"
+	"terraform-provider-render/internal/provider"
+	"terraform-provider-render/internal/provider/common"
+	th "terraform-provider-render/internal/provider/testhelpers"
+)
+
+const (
+	digestPinnedServiceID            = "srv-digest-roundtrip"
+	digestPinnedServiceName          = "digest-roundtrip"
+	digestPinnedOwnerID              = "tea-digest-roundtrip"
+	digestPinnedRegistryCredentialID = "rgc-digest-roundtrip"
+	digestPinnedRepository           = "ghcr.io/acme/app"
+	digestPinnedDigest               = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	digestPinnedImageReference       = digestPinnedRepository + "@" + digestPinnedDigest
+	digestPinnedStartCommand         = "./bin/serve --port 10000"
+)
+
+const digestPinnedConfig = `
+variable "start_command" {
+  type    = string
+  default = null
+}
+
+resource "render_web_service" "digest" {
+  name           = "digest-roundtrip"
+  plan           = "starter"
+  region         = "oregon"
+  root_directory = "apps/api"
+  start_command  = var.start_command
+
+  runtime_source = {
+    image = {
+      image_url              = "ghcr.io/acme/app"
+      digest                 = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      registry_credential_id = "rgc-digest-roundtrip"
+    }
+  }
+}
+`
+
+func TestWebServiceResource_DigestPinnedImageRoundTrip(t *testing.T) {
+	fake := newDigestPinnedWebServiceAPI(t)
+	server := th.NewMockRenderAPI(map[string]http.HandlerFunc{
+		"/.*": fake.handle,
+	})
+	t.Cleanup(server.Close)
+
+	resourceName := "render_web_service.digest"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: digestPinnedProviderFactories(server),
+		Steps: []resource.TestStep{
+			{
+				ResourceName: resourceName,
+				Config:       digestPinnedConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "runtime_source.image.image_url", digestPinnedRepository),
+					resource.TestCheckResourceAttr(resourceName, "runtime_source.image.digest", digestPinnedDigest),
+					resource.TestCheckNoResourceAttr(resourceName, "runtime_source.image.tag"),
+					resource.TestCheckResourceAttr(resourceName, "runtime_source.image.registry_credential_id", digestPinnedRegistryCredentialID),
+					resource.TestCheckResourceAttr(resourceName, "root_directory", "apps/api"),
+				),
+			},
+			{
+				ResourceName: resourceName,
+				RefreshState: true,
+				RefreshPlanChecks: resource.RefreshPlanChecks{
+					PostRefresh: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "runtime_source.image.image_url", digestPinnedRepository),
+					resource.TestCheckResourceAttr(resourceName, "runtime_source.image.digest", digestPinnedDigest),
+					resource.TestCheckNoResourceAttr(resourceName, "runtime_source.image.tag"),
+					resource.TestCheckResourceAttr(resourceName, "runtime_source.image.registry_credential_id", digestPinnedRegistryCredentialID),
+					resource.TestCheckResourceAttr(resourceName, "root_directory", "apps/api"),
+				),
+			},
+			{
+				ResourceName: resourceName,
+				Config:       digestPinnedConfig,
+				ConfigVariables: config.Variables{
+					"start_command": config.StringVariable(digestPinnedStartCommand),
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "start_command", digestPinnedStartCommand),
+					resource.TestCheckResourceAttr(resourceName, "runtime_source.image.image_url", digestPinnedRepository),
+					resource.TestCheckResourceAttr(resourceName, "runtime_source.image.digest", digestPinnedDigest),
+					resource.TestCheckNoResourceAttr(resourceName, "runtime_source.image.tag"),
+					resource.TestCheckResourceAttr(resourceName, "runtime_source.image.registry_credential_id", digestPinnedRegistryCredentialID),
+					resource.TestCheckResourceAttr(resourceName, "root_directory", "apps/api"),
+					resource.TestCheckResourceAttr(resourceName, "plan", "starter"),
+					resource.TestCheckResourceAttr(resourceName, "region", "oregon"),
+				),
+			},
+		},
+	})
+
+	createCount, patchCount, patchImageReferences, patchRegistryCredentialIDs := fake.requests()
+	require.Equal(t, 1, createCount, "the service create mutation must not be retried")
+	require.Equal(t, 1, patchCount, "the unrelated update should issue one service PATCH")
+	require.Equal(t, []string{digestPinnedImageReference}, patchImageReferences)
+	require.Equal(t, []string{digestPinnedRegistryCredentialID}, patchRegistryCredentialIDs)
+}
+
+func digestPinnedProviderFactories(server *httptest.Server) map[string]func() (tfprotov6.ProviderServer, error) {
+	return map[string]func() (tfprotov6.ProviderServer, error){
+		"render": providerserver.NewProtocol6WithError(provider.New(
+			"test",
+			provider.WithHost(server.URL),
+			provider.WithAPIKey("digest-roundtrip-api-key"),
+			provider.WithOwnerID(digestPinnedOwnerID),
+			provider.WithHTTPClient(server.Client()),
+			provider.WithPoller(&common.TestPoller),
+			provider.WithWaitForDeployCompletion(false),
+		)()),
+	}
+}
+
+type digestPinnedWebServiceAPI struct {
+	t *testing.T
+
+	mu                         sync.Mutex
+	created                    bool
+	deleted                    bool
+	createCount                int
+	patchCount                 int
+	patchImageReferences       []string
+	patchRegistryCredentialIDs []string
+	name                       string
+	rootDirectory              string
+	startCommand               string
+}
+
+func newDigestPinnedWebServiceAPI(t *testing.T) *digestPinnedWebServiceAPI {
+	t.Helper()
+
+	return &digestPinnedWebServiceAPI{
+		t:             t,
+		name:          digestPinnedServiceName,
+		rootDirectory: "apps/api",
+	}
+}
+
+func (f *digestPinnedWebServiceAPI) handle(resp http.ResponseWriter, req *http.Request) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if got := req.Header.Get("Authorization"); got != "Bearer digest-roundtrip-api-key" {
+		f.failRequest(resp, req, "unexpected Authorization header: %q", got)
+		return
+	}
+
+	servicePath := "/services/" + digestPinnedServiceID
+	switch {
+	case req.Method == http.MethodPost && req.URL.Path == "/services":
+		f.createService(resp, req)
+	case req.Method == http.MethodGet && req.URL.Path == "/services":
+		f.listServices(resp, req)
+	case req.Method == http.MethodGet && req.URL.Path == servicePath:
+		f.retrieveService(resp)
+	case req.Method == http.MethodPatch && req.URL.Path == servicePath:
+		f.updateService(resp, req)
+	case req.Method == http.MethodDelete && req.URL.Path == servicePath:
+		f.deleted = true
+		resp.WriteHeader(http.StatusNoContent)
+	case req.Method == http.MethodGet && req.URL.Path == servicePath+"/env-vars":
+		writeDigestPinnedJSON(f.t, resp, http.StatusOK, []client.EnvVarWithCursor{})
+	case req.Method == http.MethodPut && req.URL.Path == servicePath+"/env-vars":
+		writeDigestPinnedJSON(f.t, resp, http.StatusOK, []client.EnvVarWithCursor{})
+	case req.Method == http.MethodGet && req.URL.Path == servicePath+"/secret-files":
+		writeDigestPinnedJSON(f.t, resp, http.StatusOK, []client.SecretFileWithCursor{})
+	case req.Method == http.MethodPut && req.URL.Path == servicePath+"/secret-files":
+		writeDigestPinnedJSON(f.t, resp, http.StatusOK, []client.SecretFileWithCursor{})
+	case req.Method == http.MethodGet && req.URL.Path == servicePath+"/custom-domains":
+		writeDigestPinnedJSON(f.t, resp, http.StatusOK, []client.CustomDomainWithCursor{})
+	case req.Method == http.MethodPost && req.URL.Path == servicePath+"/deploys":
+		writeDigestPinnedJSON(f.t, resp, http.StatusCreated, map[string]string{"id": "dep-digest-roundtrip-update"})
+	case (req.Method == http.MethodGet || req.Method == http.MethodPatch) && req.URL.Path == "/notification-settings/overrides/services/"+digestPinnedServiceID:
+		writeDigestPinnedJSON(f.t, resp, http.StatusOK, notifications.NotificationOverride{
+			NotificationsToSend:         notifications.NotifyOverrideDefault,
+			PreviewNotificationsEnabled: notifications.NotifyPreviewOverrideDefault,
+			ServiceId:                   digestPinnedServiceID,
+		})
+	case req.Method == http.MethodGet && req.URL.Path == "/logs/streams/resource/"+digestPinnedServiceID:
+		writeDigestPinnedJSON(f.t, resp, http.StatusNotFound, map[string]string{"message": "not found"})
+	default:
+		f.failRequest(resp, req, "unexpected request")
+	}
+}
+
+func (f *digestPinnedWebServiceAPI) createService(resp http.ResponseWriter, req *http.Request) {
+	var body client.CreateServiceJSONRequestBody
+	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+		f.failRequest(resp, req, "decode create body: %v", err)
+		return
+	}
+
+	f.createCount++
+	f.created = true
+	f.name = body.Name
+	if body.RootDir != nil {
+		f.rootDirectory = *body.RootDir
+	}
+
+	if body.OwnerId != digestPinnedOwnerID {
+		f.t.Errorf("create owner ID = %q, want %q", body.OwnerId, digestPinnedOwnerID)
+	}
+	if body.Image == nil {
+		f.t.Error("create request omitted image")
+	} else {
+		if body.Image.ImagePath != digestPinnedImageReference {
+			f.t.Errorf("create image path = %q, want %q", body.Image.ImagePath, digestPinnedImageReference)
+		}
+		if valueOrEmpty(body.Image.RegistryCredentialId) != digestPinnedRegistryCredentialID {
+			f.t.Errorf("create registry credential ID = %q, want %q", valueOrEmpty(body.Image.RegistryCredentialId), digestPinnedRegistryCredentialID)
+		}
+	}
+
+	writeDigestPinnedJSON(f.t, resp, http.StatusCreated, map[string]any{
+		"deployId": "dep-digest-roundtrip",
+		"service":  f.service(),
+	})
+}
+
+func (f *digestPinnedWebServiceAPI) listServices(resp http.ResponseWriter, req *http.Request) {
+	if f.deleted || !f.created {
+		writeDigestPinnedJSON(f.t, resp, http.StatusOK, []any{})
+		return
+	}
+
+	if got := req.URL.Query().Get("name"); got != digestPinnedServiceName {
+		f.t.Errorf("service list name = %q, want %q", got, digestPinnedServiceName)
+	}
+	if got := req.URL.Query().Get("ownerId"); got != digestPinnedOwnerID {
+		f.t.Errorf("service list ownerId = %q, want %q", got, digestPinnedOwnerID)
+	}
+	if got := req.URL.Query().Get("type"); got != string(client.WebService) {
+		f.t.Errorf("service list type = %q, want %q", got, client.WebService)
+	}
+
+	writeDigestPinnedJSON(f.t, resp, http.StatusOK, []map[string]any{{
+		"cursor":  "cursor-digest-roundtrip",
+		"service": f.service(),
+	}})
+}
+
+func (f *digestPinnedWebServiceAPI) retrieveService(resp http.ResponseWriter) {
+	if f.deleted || !f.created {
+		writeDigestPinnedJSON(f.t, resp, http.StatusNotFound, map[string]string{"message": "not found"})
+		return
+	}
+
+	writeDigestPinnedJSON(f.t, resp, http.StatusOK, f.service())
+}
+
+func (f *digestPinnedWebServiceAPI) updateService(resp http.ResponseWriter, req *http.Request) {
+	var body client.UpdateServiceJSONRequestBody
+	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+		f.failRequest(resp, req, "decode update body: %v", err)
+		return
+	}
+
+	f.patchCount++
+	if body.Name != nil {
+		f.name = *body.Name
+	}
+	if body.RootDir != nil {
+		f.rootDirectory = *body.RootDir
+	}
+
+	if body.Image == nil {
+		f.t.Error("update request omitted image")
+	} else {
+		f.patchImageReferences = append(f.patchImageReferences, body.Image.ImagePath)
+		f.patchRegistryCredentialIDs = append(f.patchRegistryCredentialIDs, valueOrEmpty(body.Image.RegistryCredentialId))
+		if body.Image.ImagePath != digestPinnedImageReference {
+			f.t.Errorf("update image path = %q, want %q", body.Image.ImagePath, digestPinnedImageReference)
+		}
+	}
+
+	if body.ServiceDetails == nil {
+		f.t.Error("update request omitted service details")
+	} else {
+		details, err := body.ServiceDetails.AsWebServiceDetailsPATCH()
+		if err != nil {
+			f.t.Errorf("decode web service update details: %v", err)
+		} else if details.EnvSpecificDetails == nil {
+			f.t.Error("update request omitted image runtime details")
+		} else {
+			dockerDetails, err := details.EnvSpecificDetails.AsDockerDetailsPATCH()
+			if err != nil {
+				f.t.Errorf("decode image runtime update details: %v", err)
+			} else if dockerDetails.DockerCommand == nil {
+				f.t.Error("update request omitted start command")
+			} else {
+				f.startCommand = *dockerDetails.DockerCommand
+			}
+		}
+	}
+
+	if f.startCommand != digestPinnedStartCommand {
+		f.t.Errorf("updated start command = %q, want %q", f.startCommand, digestPinnedStartCommand)
+	}
+
+	writeDigestPinnedJSON(f.t, resp, http.StatusOK, f.service())
+}
+
+func (f *digestPinnedWebServiceAPI) service() client.Service {
+	imagePath := digestPinnedImageReference
+	pullRequestPreviews := client.PullRequestPreviewsEnabledNo
+	previewsGeneration := client.PreviewsGenerationOff
+	fixedTime := time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC)
+
+	envSpecificDetails := client.EnvSpecificDetails{}
+	if err := envSpecificDetails.FromDockerDetails(client.DockerDetails{
+		DockerCommand:    f.startCommand,
+		DockerContext:    "",
+		DockerfilePath:   "",
+		PreDeployCommand: nil,
+	}); err != nil {
+		f.t.Errorf("encode image runtime response details: %v", err)
+	}
+
+	serviceDetails := client.Service_ServiceDetails{}
+	if err := serviceDetails.FromWebServiceDetails(client.WebServiceDetails{
+		BuildPlan:                  client.BuildPlanStarter,
+		Env:                        client.ServiceEnvImage,
+		EnvSpecificDetails:         envSpecificDetails,
+		HealthCheckPath:            "",
+		MaintenanceMode:            &client.MaintenanceMode{Enabled: false, Uri: ""},
+		NumInstances:               1,
+		OpenPorts:                  []client.ServerPort{},
+		Plan:                       client.PlanStarter,
+		Previews:                   &client.Previews{Generation: &previewsGeneration},
+		PullRequestPreviewsEnabled: &pullRequestPreviews,
+		Region:                     client.Oregon,
+		Runtime:                    client.ServiceRuntimeImage,
+		Url:                        "https://digest-roundtrip.example.com",
+	}); err != nil {
+		f.t.Errorf("encode web service response details: %v", err)
+	}
+
+	return client.Service{
+		AutoDeploy:     client.AutoDeployYes,
+		CreatedAt:      fixedTime,
+		DashboardUrl:   "https://dashboard.example.com/web/" + digestPinnedServiceID,
+		Id:             digestPinnedServiceID,
+		ImagePath:      &imagePath,
+		Name:           f.name,
+		NotifyOnFail:   client.Default,
+		OwnerId:        digestPinnedOwnerID,
+		RootDir:        f.rootDirectory,
+		ServiceDetails: serviceDetails,
+		Slug:           digestPinnedServiceName,
+		Suspended:      client.ServiceSuspendedNotSuspended,
+		Suspenders:     []client.SuspenderType{},
+		Type:           client.WebService,
+		UpdatedAt:      fixedTime,
+		RegistryCredential: &client.RegistryCredentialSummary{
+			Id:   digestPinnedRegistryCredentialID,
+			Name: "digest round-trip credential",
+		},
+	}
+}
+
+func (f *digestPinnedWebServiceAPI) failRequest(resp http.ResponseWriter, req *http.Request, format string, args ...any) {
+	f.t.Helper()
+	f.t.Errorf("%s %s: "+format, append([]any{req.Method, req.URL.RequestURI()}, args...)...)
+	writeDigestPinnedJSON(f.t, resp, http.StatusInternalServerError, map[string]string{"message": "unexpected request"})
+}
+
+func (f *digestPinnedWebServiceAPI) requests() (int, int, []string, []string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return f.createCount,
+		f.patchCount,
+		append([]string(nil), f.patchImageReferences...),
+		append([]string(nil), f.patchRegistryCredentialIDs...)
+}
+
+func writeDigestPinnedJSON(t *testing.T, resp http.ResponseWriter, status int, body any) {
+	t.Helper()
+	resp.Header().Set("Content-Type", "application/json")
+	resp.WriteHeader(status)
+	if err := json.NewEncoder(resp).Encode(body); err != nil {
+		t.Errorf("encode fake API response: %v", err)
+	}
+}
+
+func valueOrEmpty(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}

--- a/internal/provider/webservice/resource/internal/update_test.go
+++ b/internal/provider/webservice/resource/internal/update_test.go
@@ -1,0 +1,54 @@
+package internal
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"terraform-provider-render/internal/provider/common"
+	commontypes "terraform-provider-render/internal/provider/common/types"
+	"terraform-provider-render/internal/provider/webservice"
+)
+
+func TestUpdateServiceRequestFromModel_PreservesDigestAfterUnrelatedUpdate(t *testing.T) {
+	const (
+		repository = "ghcr.io/acme/app"
+		digestHex  = "1fe6fa21bcb65be49241d28f919392179db011fadf8a77ee3bfb2c314924dd4c"
+		digest     = "sha256:" + digestHex
+	)
+
+	plan := webservice.WebServiceModel{
+		Name: types.StringValue("unrelated-name-update"),
+		Plan: types.StringValue("starter"),
+		RuntimeSource: &common.RuntimeSourceModel{
+			Image: &common.ImageRuntimeSourceModel{
+				ImageURL:             commontypes.ImageURLStringValue{StringValue: types.StringValue(repository)},
+				Tag:                  types.StringValue(digestHex),
+				Digest:               types.StringValue(digest),
+				RegistryCredentialID: types.StringValue("rgc-123"),
+			},
+		},
+		PullRequestPreviewsEnabled: types.BoolValue(false),
+		PreDeployCommand:           types.StringNull(),
+		StartCommand:               types.StringNull(),
+		MaintenanceMode:            common.DefaultMaintenanceMode(),
+		Previews:                   common.PreviewsToPreviewsObject(nil),
+		IPAllowList:                common.IPAllowListFromClient(nil, nil),
+	}
+
+	req, err := UpdateServiceRequestFromModel(
+		context.Background(),
+		plan,
+		webservice.WebServiceModel{},
+		"owner-123",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, req.Image)
+
+	assert.Equal(t, repository+"@"+digest, req.Image.ImagePath)
+	assert.NotEqual(t, repository+":"+digestHex, req.Image.ImagePath)
+	assert.Equal(t, "rgc-123", *req.Image.RegistryCredentialId)
+}


### PR DESCRIPTION
## Summary

- Add one canonical parser and formatter for bare, tagged, and digest-pinned image references.
- Preserve complete digests and registry credentials during refresh.
- Prefer digests when historical state contains both a tag and a digest.
- Add unit, request-builder, and full provider lifecycle regressions.

## Root cause

`ImageRuntimeSource` parsed `@` and `:` independently. Because a digest such as `sha256:<hex>` also contains a colon, the second branch populated `tag` with the digest hex after the digest branch had already run.

The update formatter then preferred `tag` over `digest`, so malformed historical state was serialized as a tag reference instead of recovering to the digest-pinned reference.

## Before / after

Given this API reference:

```text
ghcr.io/acme/app@sha256:<hex>
```

Before this change, the reported refreshed Terraform state exposed:

```hcl
image_url = "ghcr.io/acme/app"
tag       = "<hex>"
digest    = "sha256:<hex>"
```

An unrelated service update could therefore send:

```text
ghcr.io/acme/app:<hex>
```

After this change, state remains mutually exclusive:

```hcl
image_url = "ghcr.io/acme/app"
tag       = null
digest    = "sha256:<hex>"
```

Create and update requests send the original reference:

```text
ghcr.io/acme/app@sha256:<hex>
```

## Tests

- Focused parser, formatter, and Terraform model tests: pass.
- Focused request-builder regression: pass.
- Focused provider-level lifecycle regression: pass. It creates a digest-pinned service against a deterministic fake API, refreshes to a clean plan, changes `start_command`, verifies the exact digest-pinned PATCH and registry credential, then verifies another clean plan.
- `go test -p=1 ./... -count=1 -timeout=20m`: pass.
- `go vet -p=2 ./...`: pass.
- `git diff --check` and `git diff --cached --check`: pass.
- `golangci-lint run --timeout 30m`: pass with the CI-pinned Go 1.26.0 and golangci-lint 2.11.4 toolchain (zero issues; 15m47s). The prescribed 10-minute local attempt exhausted this Windows host's package-loading time without producing a finding, so the same exact check was rerun from a warmed Passport-drive cache with a longer timeout.

The full `TF_ACC=1 go test ./...` replay could not run normally in this Windows session because `terraform-plugin-testing` attempts to create fixture snapshot symlinks and the session lacks symlink privileges. The new provider regression was still run end to end with its deterministic fake API by executing the compiled test outside the checkout. No credential-dependent live or paid Render service test was run.

## Compatibility

There are no schema, generated-client, or dependency changes. Existing bare and tagged references remain supported, including registry ports and nested paths. Digest algorithm prefixes are preserved exactly, and the existing schema conflict validation still prevents new configurations from setting both `tag` and `digest`.

Historical state containing both values now prefers the digest, allowing affected configurations to recover on refresh/apply.

## Risk and rollback

Risk is limited to image-reference parsing and formatting. Malformed empty tag or digest separators now produce a read error instead of silently creating invalid state. Reverting the commit restores the prior behavior, including the digest-update failure.

## Issue

Fixes #106
