### PR TITLE
fix(terraform): preserve state convergence when updating suspended services

### DIFF
--- a/internal/provider/backgroundworker/resource/suspended_update_test.go
+++ b/internal/provider/backgroundworker/resource/suspended_update_test.go
@@ -1,0 +1,396 @@
+package resource_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/stretchr/testify/require"
+
+	"terraform-provider-render/internal/client"
+	"terraform-provider-render/internal/client/notifications"
+	"terraform-provider-render/internal/provider"
+	"terraform-provider-render/internal/provider/common"
+	th "terraform-provider-render/internal/provider/testhelpers"
+)
+
+const (
+	suspendedUpdateServiceID   = "srv-suspended-update"
+	suspendedUpdateServiceName = "suspended-update"
+	suspendedUpdateOwnerID     = "tea-suspended-update"
+	suspendedUpdateEnvKey      = "SHARED_VALUE"
+)
+
+const suspendedUpdateConfig = `
+variable "env_value" {
+  type = string
+}
+
+resource "render_background_worker" "suspended" {
+  name   = "suspended-update"
+  plan   = "starter"
+  region = "oregon"
+
+  runtime_source = {
+    image = {
+      image_url = "nginx"
+      tag       = "latest"
+    }
+  }
+
+  env_vars = {
+    SHARED_VALUE = {
+      value = var.env_value
+    }
+  }
+}
+`
+
+func TestBackgroundWorkerResource_SuspendedUpdateConverges(t *testing.T) {
+	fake := newSuspendedUpdateAPI(t)
+	server := th.NewMockRenderAPI(map[string]http.HandlerFunc{
+		"/.*": fake.handle,
+	})
+	t.Cleanup(server.Close)
+
+	resourceName := "render_background_worker.suspended"
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: suspendedUpdateProviderFactories(server),
+		Steps: []resource.TestStep{
+			{
+				ResourceName: resourceName,
+				Config:       suspendedUpdateConfig,
+				ConfigVariables: config.Variables{
+					"env_value": config.StringVariable("before"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", suspendedUpdateServiceName),
+					resource.TestCheckResourceAttr(resourceName, "env_vars.SHARED_VALUE.value", "before"),
+				),
+			},
+			{
+				ResourceName: resourceName,
+				Config:       suspendedUpdateConfig,
+				ConfigVariables: config.Variables{
+					"env_value": config.StringVariable("after"),
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", suspendedUpdateServiceName),
+					resource.TestCheckResourceAttr(resourceName, "env_vars.SHARED_VALUE.value", "after"),
+				),
+			},
+			{
+				ResourceName: resourceName,
+				RefreshState: true,
+				RefreshPlanChecks: resource.RefreshPlanChecks{
+					PostRefresh: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "env_vars.SHARED_VALUE.value", "after"),
+				),
+			},
+		},
+	})
+
+	requests := fake.requests()
+	require.Equal(t, 1, requests.create, "the service create mutation must not be retried")
+	require.Equal(t, 1, requests.patch, "the service update mutation must not be retried")
+	require.Equal(t, 1, requests.envUpdate, "the env-var mutation must not be retried")
+	require.Equal(t, 1, requests.secretUpdate, "the secret-file mutation must not be retried")
+	require.Equal(t, 0, requests.deploy, "a suspended service must not be deployed")
+	require.Equal(t, 0, requests.suspendOrResume, "the provider must not change suspension state")
+	require.Equal(t, "after", requests.envValue, "the remote env var must contain the applied value")
+}
+
+func suspendedUpdateProviderFactories(server *httptest.Server) map[string]func() (tfprotov6.ProviderServer, error) {
+	return map[string]func() (tfprotov6.ProviderServer, error){
+		"render": providerserver.NewProtocol6WithError(provider.New(
+			"test",
+			provider.WithHost(server.URL),
+			provider.WithAPIKey("suspended-update-api-key"),
+			provider.WithOwnerID(suspendedUpdateOwnerID),
+			provider.WithHTTPClient(server.Client()),
+			provider.WithPoller(&common.TestPoller),
+			provider.WithWaitForDeployCompletion(false),
+		)()),
+	}
+}
+
+type suspendedUpdateRequestCounts struct {
+	create          int
+	patch           int
+	envUpdate       int
+	secretUpdate    int
+	deploy          int
+	suspendOrResume int
+	envValue        string
+}
+
+type suspendedUpdateAPI struct {
+	t *testing.T
+
+	mu             sync.Mutex
+	created        bool
+	deleted        bool
+	createCount    int
+	patchCount     int
+	envUpdateCount int
+	secretUpdate   int
+	deployCount    int
+	lifecycleCount int
+	envValue       string
+}
+
+func newSuspendedUpdateAPI(t *testing.T) *suspendedUpdateAPI {
+	t.Helper()
+	return &suspendedUpdateAPI{t: t}
+}
+
+func (f *suspendedUpdateAPI) handle(resp http.ResponseWriter, req *http.Request) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if got := req.Header.Get("Authorization"); got != "Bearer suspended-update-api-key" {
+		f.failRequest(resp, req, "unexpected Authorization header: %q", got)
+		return
+	}
+
+	servicePath := "/services/" + suspendedUpdateServiceID
+	switch {
+	case req.Method == http.MethodPost && req.URL.Path == "/services":
+		f.createService(resp, req)
+	case req.Method == http.MethodGet && req.URL.Path == "/services":
+		f.listServices(resp)
+	case req.Method == http.MethodGet && req.URL.Path == servicePath:
+		f.retrieveService(resp)
+	case req.Method == http.MethodPatch && req.URL.Path == servicePath:
+		f.updateService(resp, req)
+	case req.Method == http.MethodDelete && req.URL.Path == servicePath:
+		f.deleted = true
+		resp.WriteHeader(http.StatusNoContent)
+	case req.Method == http.MethodGet && req.URL.Path == servicePath+"/env-vars":
+		f.getEnvVars(resp, req)
+	case req.Method == http.MethodPut && req.URL.Path == servicePath+"/env-vars":
+		f.updateEnvVars(resp, req)
+	case req.Method == http.MethodGet && req.URL.Path == servicePath+"/secret-files":
+		writeSuspendedUpdateJSON(f.t, resp, http.StatusOK, []client.SecretFileWithCursor{})
+	case req.Method == http.MethodPut && req.URL.Path == servicePath+"/secret-files":
+		f.secretUpdate++
+		writeSuspendedUpdateJSON(f.t, resp, http.StatusOK, []client.SecretFileWithCursor{})
+	case req.Method == http.MethodPost && req.URL.Path == servicePath+"/deploys":
+		f.deployCount++
+		writeSuspendedUpdateJSON(f.t, resp, http.StatusBadRequest, map[string]string{"message": "cannot deploy suspended service"})
+	case req.Method == http.MethodPost && (req.URL.Path == servicePath+"/suspend" || req.URL.Path == servicePath+"/resume"):
+		f.lifecycleCount++
+		f.failRequest(resp, req, "provider changed suspension state")
+	case req.Method == http.MethodPatch && req.URL.Path == "/notification-settings/overrides/services/"+suspendedUpdateServiceID:
+		writeSuspendedUpdateJSON(f.t, resp, http.StatusOK, notifications.NotificationOverride{
+			NotificationsToSend:         notifications.NotifyOverrideDefault,
+			PreviewNotificationsEnabled: notifications.NotifyPreviewOverrideDefault,
+			ServiceId:                   suspendedUpdateServiceID,
+		})
+	case req.Method == http.MethodGet && req.URL.Path == "/notification-settings/overrides/services/"+suspendedUpdateServiceID:
+		writeSuspendedUpdateJSON(f.t, resp, http.StatusOK, notifications.NotificationOverride{
+			NotificationsToSend:         notifications.NotifyOverrideDefault,
+			PreviewNotificationsEnabled: notifications.NotifyPreviewOverrideDefault,
+			ServiceId:                   suspendedUpdateServiceID,
+		})
+	case req.Method == http.MethodGet && req.URL.Path == "/logs/streams/resource/"+suspendedUpdateServiceID:
+		writeSuspendedUpdateJSON(f.t, resp, http.StatusNotFound, map[string]string{"message": "not found"})
+	default:
+		f.failRequest(resp, req, "unexpected request")
+	}
+}
+
+func (f *suspendedUpdateAPI) createService(resp http.ResponseWriter, req *http.Request) {
+	var body client.CreateServiceJSONRequestBody
+	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+		f.failRequest(resp, req, "decode create body: %v", err)
+		return
+	}
+
+	f.createCount++
+	f.created = true
+	if body.OwnerId != suspendedUpdateOwnerID {
+		f.t.Errorf("create owner ID = %q, want %q", body.OwnerId, suspendedUpdateOwnerID)
+	}
+	if body.EnvVars == nil {
+		f.t.Error("create request omitted env vars")
+	} else if value, err := suspendedUpdateEnvValue(*body.EnvVars); err != nil {
+		f.t.Error(err)
+	} else {
+		f.envValue = value
+	}
+
+	writeSuspendedUpdateJSON(f.t, resp, http.StatusCreated, map[string]any{
+		"deployId": "dep-suspended-update-create",
+		"service":  f.service(),
+	})
+}
+
+func (f *suspendedUpdateAPI) listServices(resp http.ResponseWriter) {
+	if f.deleted || !f.created {
+		writeSuspendedUpdateJSON(f.t, resp, http.StatusOK, []any{})
+		return
+	}
+
+	writeSuspendedUpdateJSON(f.t, resp, http.StatusOK, []map[string]any{{
+		"cursor":  "cursor-suspended-update",
+		"service": f.service(),
+	}})
+}
+
+func (f *suspendedUpdateAPI) retrieveService(resp http.ResponseWriter) {
+	if f.deleted || !f.created {
+		writeSuspendedUpdateJSON(f.t, resp, http.StatusNotFound, map[string]string{"message": "not found"})
+		return
+	}
+
+	writeSuspendedUpdateJSON(f.t, resp, http.StatusOK, f.service())
+}
+
+func (f *suspendedUpdateAPI) updateService(resp http.ResponseWriter, req *http.Request) {
+	var body client.UpdateServiceJSONRequestBody
+	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+		f.failRequest(resp, req, "decode update body: %v", err)
+		return
+	}
+
+	f.patchCount++
+	writeSuspendedUpdateJSON(f.t, resp, http.StatusOK, f.service())
+}
+
+func (f *suspendedUpdateAPI) updateEnvVars(resp http.ResponseWriter, req *http.Request) {
+	var body client.EnvVarInputArray
+	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+		f.failRequest(resp, req, "decode env-var update body: %v", err)
+		return
+	}
+
+	f.envUpdateCount++
+	value, err := suspendedUpdateEnvValue(body)
+	if err != nil {
+		f.failRequest(resp, req, "%v", err)
+		return
+	}
+	f.envValue = value
+	writeSuspendedUpdateJSON(f.t, resp, http.StatusOK, f.envVars())
+}
+
+func (f *suspendedUpdateAPI) getEnvVars(resp http.ResponseWriter, req *http.Request) {
+	if _, hasCursor := req.URL.Query()["cursor"]; hasCursor {
+		writeSuspendedUpdateJSON(f.t, resp, http.StatusOK, []client.EnvVarWithCursor{})
+		return
+	}
+
+	writeSuspendedUpdateJSON(f.t, resp, http.StatusOK, f.envVars())
+}
+
+func suspendedUpdateEnvValue(envVars client.EnvVarInputArray) (string, error) {
+	if len(envVars) != 1 {
+		return "", fmt.Errorf("env-var request has %d items, want 1", len(envVars))
+	}
+
+	envVar, err := envVars[0].AsEnvVarKeyValue()
+	if err != nil {
+		return "", fmt.Errorf("decode env-var request: %w", err)
+	}
+	if envVar.Key != suspendedUpdateEnvKey {
+		return "", fmt.Errorf("env-var key = %q, want %q", envVar.Key, suspendedUpdateEnvKey)
+	}
+	return envVar.Value, nil
+}
+
+func (f *suspendedUpdateAPI) envVars() []client.EnvVarWithCursor {
+	return []client.EnvVarWithCursor{{
+		Cursor: "cursor-suspended-update-env",
+		EnvVar: client.EnvVar{Key: suspendedUpdateEnvKey, Value: f.envValue},
+	}}
+}
+
+func (f *suspendedUpdateAPI) service() client.Service {
+	imagePath := "nginx:latest"
+	pullRequestPreviews := client.PullRequestPreviewsEnabledNo
+	previewsGeneration := client.PreviewsGenerationOff
+	fixedTime := time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC)
+
+	envSpecificDetails := client.EnvSpecificDetails{}
+	if err := envSpecificDetails.FromDockerDetails(client.DockerDetails{}); err != nil {
+		f.t.Errorf("encode image runtime response details: %v", err)
+	}
+
+	serviceDetails := client.Service_ServiceDetails{}
+	if err := serviceDetails.FromBackgroundWorkerDetails(client.BackgroundWorkerDetails{
+		BuildPlan:                  client.BuildPlanStarter,
+		Env:                        client.ServiceEnvImage,
+		EnvSpecificDetails:         envSpecificDetails,
+		NumInstances:               1,
+		Plan:                       client.PlanStarter,
+		Previews:                   &client.Previews{Generation: &previewsGeneration},
+		PullRequestPreviewsEnabled: &pullRequestPreviews,
+		Region:                     client.Oregon,
+		Runtime:                    client.ServiceRuntimeImage,
+	}); err != nil {
+		f.t.Errorf("encode background worker response details: %v", err)
+	}
+
+	return client.Service{
+		AutoDeploy:     client.AutoDeployYes,
+		CreatedAt:      fixedTime,
+		DashboardUrl:   "https://dashboard.example.com/worker/" + suspendedUpdateServiceID,
+		Id:             suspendedUpdateServiceID,
+		ImagePath:      &imagePath,
+		Name:           suspendedUpdateServiceName,
+		NotifyOnFail:   client.Default,
+		OwnerId:        suspendedUpdateOwnerID,
+		RootDir:        "",
+		ServiceDetails: serviceDetails,
+		Slug:           suspendedUpdateServiceName,
+		Suspended:      client.ServiceSuspendedSuspended,
+		Suspenders:     []client.SuspenderType{client.SuspenderTypeUser},
+		Type:           client.BackgroundWorker,
+		UpdatedAt:      fixedTime,
+	}
+}
+
+func (f *suspendedUpdateAPI) failRequest(resp http.ResponseWriter, req *http.Request, format string, args ...any) {
+	f.t.Helper()
+	f.t.Errorf("%s %s: "+format, append([]any{req.Method, req.URL.RequestURI()}, args...)...)
+	writeSuspendedUpdateJSON(f.t, resp, http.StatusInternalServerError, map[string]string{"message": "unexpected request"})
+}
+
+func (f *suspendedUpdateAPI) requests() suspendedUpdateRequestCounts {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return suspendedUpdateRequestCounts{
+		create:          f.createCount,
+		patch:           f.patchCount,
+		envUpdate:       f.envUpdateCount,
+		secretUpdate:    f.secretUpdate,
+		deploy:          f.deployCount,
+		suspendOrResume: f.lifecycleCount,
+		envValue:        f.envValue,
+	}
+}
+
+func writeSuspendedUpdateJSON(t *testing.T, resp http.ResponseWriter, status int, body any) {
+	t.Helper()
+	resp.Header().Set("Content-Type", "application/json")
+	resp.WriteHeader(status)
+	if err := json.NewEncoder(resp).Encode(body); err != nil {
+		t.Errorf("encode fake API response: %v", err)
+	}
+}

--- a/internal/provider/common/client.go
+++ b/internal/provider/common/client.go
@@ -554,6 +554,10 @@ var scalableServiceTypes = []ServiceType{
 	ServiceTypeBackgroundWorker,
 }
 
+func shouldDeployAfterUpdate(explicitSkip bool, postUpdateServiceState client.ServiceSuspended) bool {
+	return !explicitSkip && postUpdateServiceState != client.ServiceSuspendedSuspended
+}
+
 func UpdateService(ctx context.Context, apiClient *client.ClientWithResponses, skipDeploy bool, req UpdateServiceReq, serviceType ServiceType) (*WrappedService, error) {
 	// must happen before updating the service so the instance count is reflected in the service response
 	if req.InstanceCount != nil && *req.InstanceCount > 0 && slices.Contains(scalableServiceTypes, serviceType) {
@@ -638,7 +642,7 @@ func UpdateService(ctx context.Context, apiClient *client.ClientWithResponses, s
 		}
 	}
 
-	if !skipDeploy {
+	if shouldDeployAfterUpdate(skipDeploy, service.Suspended) {
 		err = Create(func() (*http.Response, error) {
 			return apiClient.CreateDeploy(ctx, req.ServiceID, client.CreateDeployJSONRequestBody{})
 		}, nil)

--- a/internal/provider/common/client_internal_test.go
+++ b/internal/provider/common/client_internal_test.go
@@ -1,0 +1,50 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"terraform-provider-render/internal/client"
+)
+
+func TestShouldDeployAfterUpdate(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		explicitSkip           bool
+		postUpdateServiceState client.ServiceSuspended
+		want                   bool
+	}{
+		"explicit skip with active service": {
+			explicitSkip:           true,
+			postUpdateServiceState: client.ServiceSuspendedNotSuspended,
+			want:                   false,
+		},
+		"explicit skip with suspended service": {
+			explicitSkip:           true,
+			postUpdateServiceState: client.ServiceSuspendedSuspended,
+			want:                   false,
+		},
+		"suspended service": {
+			postUpdateServiceState: client.ServiceSuspendedSuspended,
+			want:                   false,
+		},
+		"active service": {
+			postUpdateServiceState: client.ServiceSuspendedNotSuspended,
+			want:                   true,
+		},
+		"unknown state preserves deployment": {
+			postUpdateServiceState: client.ServiceSuspended("future-state"),
+			want:                   true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, test.want, shouldDeployAfterUpdate(test.explicitSkip, test.postUpdateServiceState))
+		})
+	}
+}

--- a/internal/provider/common/client_test.go
+++ b/internal/provider/common/client_test.go
@@ -2,7 +2,9 @@ package common_test
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
+	"sync/atomic"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -102,11 +104,13 @@ func TestGetWrappedService(t *testing.T) {
 
 func TestUpdateService(t *testing.T) {
 	t.Run("it updates the service", func(t *testing.T) {
-		var deployCalled bool
+		var deployCalls atomic.Int32
 
 		mockAPI := th.NewMockRenderAPI(map[string]http.HandlerFunc{
 			"/services/some-service-id": th.StaticResponse(&client.Service{
-				Id: "some-service-id", Name: "updated-service",
+				Id:        "some-service-id",
+				Name:      "updated-service",
+				Suspended: client.ServiceSuspendedNotSuspended,
 			}),
 			"/services/some-service-id/env-vars": th.StaticResponse([]client.EnvVarWithCursor{
 				{EnvVar: client.EnvVar{Key: "updated-env-var", Value: "val"}},
@@ -118,7 +122,7 @@ func TestUpdateService(t *testing.T) {
 			),
 			"/disks/some-disk-id": th.StaticResponse(disks.DiskDetails{Name: "updated-disk"}),
 			"/services/some-service-id/deploys": func(resp http.ResponseWriter, req *http.Request) {
-				deployCalled = true
+				deployCalls.Add(1)
 				resp.WriteHeader(http.StatusCreated)
 			},
 			"/services/some-service-id/scale": func(resp http.ResponseWriter, req *http.Request) {
@@ -126,6 +130,7 @@ func TestUpdateService(t *testing.T) {
 			},
 			"/notification-settings/overrides/services/some-service-id": th.StaticResponse(struct{}{}),
 		})
+		t.Cleanup(mockAPI.Close)
 
 		c, err := client.NewClientWithResponses(mockAPI.URL)
 		require.NoError(t, err)
@@ -153,14 +158,16 @@ func TestUpdateService(t *testing.T) {
 		require.NotNil(t, details.Disk)
 		assert.Equal(t, "updated-disk", details.Disk.Name)
 
-		assert.True(t, deployCalled, "it should deploy the service")
+		assert.EqualValues(t, 1, deployCalls.Load(), "an active service should deploy exactly once")
 	})
 	t.Run("it skips deploy when skip is set", func(t *testing.T) {
-		var deployCalled bool
+		var deployCalls atomic.Int32
 
 		mockAPI := th.NewMockRenderAPI(map[string]http.HandlerFunc{
 			"/services/some-service-id": th.StaticResponse(&client.Service{
-				Id: "some-service-id", Name: "updated-service",
+				Id:        "some-service-id",
+				Name:      "updated-service",
+				Suspended: client.ServiceSuspendedNotSuspended,
 			}),
 			"/services/some-service-id/env-vars": th.StaticResponse([]client.EnvVarWithCursor{
 				{EnvVar: client.EnvVar{Key: "updated-env-var", Value: "val"}},
@@ -172,7 +179,7 @@ func TestUpdateService(t *testing.T) {
 			),
 			"/disks/some-disk-id": th.StaticResponse(disks.DiskDetails{Name: "updated-disk"}),
 			"/services/some-service-id/deploys": func(resp http.ResponseWriter, req *http.Request) {
-				deployCalled = true
+				deployCalls.Add(1)
 				resp.WriteHeader(http.StatusCreated)
 			},
 			"/services/some-service-id/scale": func(resp http.ResponseWriter, req *http.Request) {
@@ -180,6 +187,7 @@ func TestUpdateService(t *testing.T) {
 			},
 			"/notification-settings/overrides/services/some-service-id": th.StaticResponse(struct{}{}),
 		})
+		t.Cleanup(mockAPI.Close)
 
 		c, err := client.NewClientWithResponses(mockAPI.URL)
 		require.NoError(t, err)
@@ -193,6 +201,147 @@ func TestUpdateService(t *testing.T) {
 		}, common.ServiceTypeWebService)
 		require.NoError(t, err)
 
-		assert.False(t, deployCalled, "it should not deploy the service")
+		assert.Zero(t, deployCalls.Load(), "an explicit skip should remain authoritative")
 	})
+	t.Run("it returns a deploy error for an active service", func(t *testing.T) {
+		const serviceID = "active-service-id"
+
+		var serviceUpdateCalls atomic.Int32
+		var envVarUpdateCalls atomic.Int32
+		var secretFileUpdateCalls atomic.Int32
+		var deployCalls atomic.Int32
+
+		mockAPI := th.NewMockRenderAPI(map[string]http.HandlerFunc{
+			"/services/" + serviceID: func(resp http.ResponseWriter, req *http.Request) {
+				serviceUpdateCalls.Add(1)
+				th.StaticResponse(&client.Service{
+					Id:        serviceID,
+					Name:      "updated-active-service",
+					Suspended: client.ServiceSuspendedNotSuspended,
+					Type:      client.BackgroundWorker,
+				})(resp, req)
+			},
+			"/services/" + serviceID + "/env-vars": func(resp http.ResponseWriter, req *http.Request) {
+				envVarUpdateCalls.Add(1)
+				th.StaticResponse([]client.EnvVarWithCursor{})(resp, req)
+			},
+			"/services/" + serviceID + "/secret-files": func(resp http.ResponseWriter, req *http.Request) {
+				secretFileUpdateCalls.Add(1)
+				th.StaticResponse([]client.SecretFileWithCursor{})(resp, req)
+			},
+			"/services/" + serviceID + "/deploys": func(resp http.ResponseWriter, req *http.Request) {
+				deployCalls.Add(1)
+				resp.WriteHeader(http.StatusInternalServerError)
+			},
+		})
+		t.Cleanup(mockAPI.Close)
+
+		c, err := client.NewClientWithResponses(mockAPI.URL)
+		require.NoError(t, err)
+
+		_, err = common.UpdateService(context.Background(), c, false, common.UpdateServiceReq{
+			ServiceID: serviceID,
+		}, common.ServiceTypeBackgroundWorker)
+		require.EqualError(t, err, "unable to deploy service: unexpected status code: 500")
+
+		assert.EqualValues(t, 1, serviceUpdateCalls.Load(), "the service mutation must not be retried")
+		assert.EqualValues(t, 1, envVarUpdateCalls.Load(), "the env-var mutation must not be retried")
+		assert.EqualValues(t, 1, secretFileUpdateCalls.Load(), "the secret-file mutation must not be retried")
+		assert.EqualValues(t, 1, deployCalls.Load(), "an active service should attempt exactly one deploy")
+	})
+}
+
+func TestUpdateService_SuspendedServiceSkipsDeployAndReturnsUpdatedState(t *testing.T) {
+	const serviceID = "suspended-service-id"
+
+	var serviceUpdateCalls atomic.Int32
+	var envVarUpdateCalls atomic.Int32
+	var secretFileUpdateCalls atomic.Int32
+	var deployCalls atomic.Int32
+
+	updatedName := "updated-suspended-service"
+	envVar := client.EnvVarInput{}
+	require.NoError(t, envVar.FromEnvVarKeyValue(client.EnvVarKeyValue{
+		Key:   "UPDATED_ENV_VAR",
+		Value: "updated-value",
+	}))
+
+	mockAPI := th.NewMockRenderAPI(map[string]http.HandlerFunc{
+		"/services/" + serviceID: func(resp http.ResponseWriter, req *http.Request) {
+			serviceUpdateCalls.Add(1)
+			assert.Equal(t, http.MethodPatch, req.Method)
+
+			var body client.UpdateServiceJSONRequestBody
+			if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+				t.Errorf("decode service update body: %v", err)
+				http.Error(resp, "invalid service update body", http.StatusBadRequest)
+				return
+			}
+			if body.Name == nil {
+				t.Error("service update omitted name")
+				http.Error(resp, "missing service name", http.StatusBadRequest)
+				return
+			}
+			assert.Equal(t, updatedName, *body.Name)
+
+			th.StaticResponse(&client.Service{
+				Id:        serviceID,
+				Name:      updatedName,
+				Suspended: client.ServiceSuspendedSuspended,
+				Type:      client.BackgroundWorker,
+			})(resp, req)
+		},
+		"/services/" + serviceID + "/env-vars": func(resp http.ResponseWriter, req *http.Request) {
+			envVarUpdateCalls.Add(1)
+			assert.Equal(t, http.MethodPut, req.Method)
+			th.StaticResponse([]client.EnvVarWithCursor{{
+				EnvVar: client.EnvVar{Key: "UPDATED_ENV_VAR", Value: "updated-value"},
+			}})(resp, req)
+		},
+		"/services/" + serviceID + "/secret-files": func(resp http.ResponseWriter, req *http.Request) {
+			secretFileUpdateCalls.Add(1)
+			assert.Equal(t, http.MethodPut, req.Method)
+			th.StaticResponse([]client.SecretFileWithCursor{{
+				SecretFile: client.SecretFile{Name: "updated-secret", Content: "updated-content"},
+			}})(resp, req)
+		},
+		"/services/" + serviceID + "/deploys": func(resp http.ResponseWriter, req *http.Request) {
+			deployCalls.Add(1)
+			assert.Equal(t, http.MethodPost, req.Method)
+			resp.WriteHeader(http.StatusBadRequest)
+			_, _ = resp.Write([]byte(`{"message":"cannot deploy suspended service"}`))
+		},
+	})
+	t.Cleanup(mockAPI.Close)
+
+	c, err := client.NewClientWithResponses(mockAPI.URL)
+	require.NoError(t, err)
+
+	wrapped, err := common.UpdateService(context.Background(), c, false, common.UpdateServiceReq{
+		ServiceID: serviceID,
+		Service: client.UpdateServiceJSONRequestBody{
+			Name: &updatedName,
+		},
+		EnvVars: []client.EnvVarInput{envVar},
+		SecretFiles: []client.SecretFileInput{{
+			Name:    "updated-secret",
+			Content: "updated-content",
+		}},
+	}, common.ServiceTypeBackgroundWorker)
+	require.NoError(t, err)
+	require.NotNil(t, wrapped)
+
+	assert.Equal(t, updatedName, wrapped.Name)
+	assert.Equal(t, client.ServiceSuspendedSuspended, wrapped.Suspended)
+	require.NotNil(t, wrapped.EnvVars)
+	require.Len(t, *wrapped.EnvVars, 1)
+	assert.Equal(t, "UPDATED_ENV_VAR", (*wrapped.EnvVars)[0].EnvVar.Key)
+	require.NotNil(t, wrapped.SecretFiles)
+	require.Len(t, *wrapped.SecretFiles, 1)
+	assert.Equal(t, "updated-secret", (*wrapped.SecretFiles)[0].SecretFile.Name)
+
+	assert.EqualValues(t, 1, serviceUpdateCalls.Load(), "the service mutation must not be retried")
+	assert.EqualValues(t, 1, envVarUpdateCalls.Load(), "the env-var mutation must not be retried")
+	assert.EqualValues(t, 1, secretFileUpdateCalls.Load(), "the secret-file mutation must not be retried")
+	assert.Zero(t, deployCalls.Load(), "a suspended service must not be deployed")
 }


### PR DESCRIPTION
## Summary

- centralize the post-update deploy decision in `common.UpdateService`
- skip only the guaranteed-to-fail deploy when the update response reports a suspended service
- preserve explicit `skip_deploy_after_service_update` behavior, active-service deploys, and errors from active-service deploy failures
- return the fully updated wrapped service so Terraform can persist successful service, environment-variable, secret-file, disk, override, environment, and domain writes

## Invariant

Once remote configuration writes have succeeded, an impossible trailing deploy must not cause Terraform to discard the successful new state.

## Request order

The shared update path retains its existing order: scaling/autoscaling, service update, environment variables, secret files, disk, notification and log-stream overrides, environment membership, and custom domains. Only the final create-deploy request is skipped, and only when the post-update API response explicitly reports `suspended` (or the provider-level skip is enabled). Unknown and newly introduced states continue to deploy.

## Testing

- policy table: explicit skip with active/suspended services, suspended without explicit skip, active deployment, and unknown-state fallback
- request-level regressions: suspended updates return updated state without `/deploys`; active services deploy exactly once; active deploy failures remain errors; mutation requests are not retried
- provider-level background-worker fake: create suspended, update an environment variable, verify remote state and clean follow-up plans, and reject deploy/resume side effects
- `go test ./internal/provider/common -run 'Test(UpdateService|ShouldDeployAfterUpdate)' -count=1 -v -vet=off`
- standalone provider test binary with `TF_ACC=1` and Terraform 1.16.0: `TestBackgroundWorkerResource_SuspendedUpdateConverges`
- `go test ./...`
- `go vet ./...`
- `golangci-lint run --timeout 10m`
- `git diff --check`

The credential-dependent live acceptance suite was not run. The deterministic local fake exercises the provider lifecycle without creating or mutating a paid service.

Fixes #104
